### PR TITLE
Stop checking diff of code size benchmark

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,4 @@ jobs:
       - name: make-test
         run: make test
       - name: make-bench-codesize
-        run: bash make/scripts/checknodiffgenerated.bash make bench-codesize
+        run: make bench-codesize

--- a/package-lock.json
+++ b/package-lock.json
@@ -6484,7 +6484,7 @@
         "@bufbuild/connect-web": "0.0.2-alpha.2",
         "@bufbuild/protobuf": "^0.0.2-alpha.2",
         "@bufbuild/protoc-gen-es": "^0.0.2-alpha.2",
-        "esbuild": "^0.14.31",
+        "esbuild": "^0.14.36",
         "google-protobuf": "^3.20.0",
         "grpc-web": "^1.3.1"
       }

--- a/packages/bench-codesize/README.md
+++ b/packages/bench-codesize/README.md
@@ -7,7 +7,7 @@ once with `protoc-gen-grpc-web`, once with `protoc-gen-connect-web`. Then we bun
 for the service `buf.alpha.registry.v1alpha1.PluginService` with [esbuild](https://esbuild.github.io/),
 minify the bundle, and compress it like a web server would usually do.
 
-| code generator | bundle size        | minified               | gzip                 |
+| code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
 | connect-web    | 271,265 b | 143,047 b | 20,746 b |
-| grpc-web       | 1,019,192 b    | 724,886 b    | 74,083 b    |
+| grpc-web       | 1,019,192 b    | 724,885 b    | 74,094 b |

--- a/packages/bench-codesize/report.mjs
+++ b/packages/bench-codesize/report.mjs
@@ -1,5 +1,5 @@
-import {deflateRawSync, gzipSync, brotliCompressSync} from "zlib";
 import {buildSync} from "esbuild";
+import {brotliCompressSync} from "zlib";
 
 
 const connectweb = gather("src/entry-connectweb.ts");
@@ -14,10 +14,10 @@ once with \`protoc-gen-grpc-web\`, once with \`protoc-gen-connect-web\`. Then we
 for the service \`buf.alpha.registry.v1alpha1.PluginService\` with [esbuild](https://esbuild.github.io/),
 minify the bundle, and compress it like a web server would usually do.
 
-| code generator | bundle size        | minified               | gzip                 |
+| code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | ${connectweb.size} | ${connectweb.minified} | ${connectweb.brotli} |
-| grpc-web       | ${grpcweb.size}    | ${grpcweb.minified}    | ${grpcweb.brotli}    |
+| connect-web    | ${connectweb.size} | ${connectweb.minified} | ${connectweb.compressed} |
+| grpc-web       | ${grpcweb.size}    | ${grpcweb.minified}    | ${grpcweb.compressed} |
 `);
 
 
@@ -29,7 +29,7 @@ function gather(entryPoint) {
         entryPoint,
         size: formatSize(bundle.byteLength),
         minified: formatSize(bundleMinified.byteLength),
-        brotli: formatSize(compressed.brotli),
+        compressed: formatSize(compressed.byteLength),
     };
 }
 
@@ -49,16 +49,7 @@ function build(entryPoint, minify, format) {
 }
 
 function compress(buf) {
-    const deflate = deflateRawSync(buf);
-    const gzip = gzipSync(buf, {
-        level: 7, // for mysterious reasons, the default (equivalent to 6) is unstable across node versions
-    });
-    const brotli = brotliCompressSync(buf);
-    return {
-        deflate: deflate.byteLength,
-        gzip: gzip.byteLength,
-        brotli: brotli.byteLength,
-    };
+    return brotliCompressSync(buf);
 }
 
 function formatSize(bytes) {


### PR DESCRIPTION
Looks like esbuild minified output is not always the same on GH runners and locally.