### PR TITLE
align the http to grpc status code mapping to the grpc doc

### DIFF
--- a/packages/bench-codesize/README.md
+++ b/packages/bench-codesize/README.md
@@ -9,5 +9,5 @@ minify the bundle, and compress it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 270,038 b | 142,439 b | 20,607 b |
+| connect-web    | 270,030 b | 142,431 b | 20,663 b |
 | grpc-web       | 1,019,192 b    | 724,885 b    | 74,094 b |

--- a/packages/connect-web/src/status-code.ts
+++ b/packages/connect-web/src/status-code.ts
@@ -116,15 +116,15 @@ export function codeFromHttpStatus(httpStatus: number): StatusCode {
     case 200:
       return StatusCode.Ok;
     case 400:
-      return StatusCode.InvalidArgument;
+      return StatusCode.Internal;
     case 401:
       return StatusCode.Unauthenticated;
     case 403:
       return StatusCode.PermissionDenied;
     case 404:
-      return StatusCode.NotFound;
+      return StatusCode.Unimplemented;
     case 429:
-      return StatusCode.ResourceExhausted;
+      return StatusCode.Unavailable;
     case 502:
       return StatusCode.Unavailable;
     case 503:


### PR DESCRIPTION
the http to grpc status code mapping is not aligned with [grpc doc in the comment](https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md), which seems to be the reason of a failed interop test of unimplemented service when connect-web client calling connect http1 server. Is there a reason behind these misalignments of status code? 