### PR TITLE
reorder error extraction to extract the http status error first

### DIFF
--- a/packages/bench-codesize/README.md
+++ b/packages/bench-codesize/README.md
@@ -9,5 +9,5 @@ minify the bundle, and compress it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 270,030 b | 142,431 b | 20,663 b |
+| connect-web    | 270,030 b | 142,431 b | 20,658 b |
 | grpc-web       | 1,019,192 b    | 724,885 b    | 74,094 b |

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -178,10 +178,10 @@ function createResponse<O extends Message<O>>(
           if (readFrame === undefined) {
             handler.onHeader?.(response.headers);
             const err =
+              extractHttpStatusError(response) ??
               extractContentTypeError(response.headers) ??
               extractDetailsError(response.headers) ??
-              extractHeadersError(response.headers) ??
-              extractHttpStatusError(response);
+              extractHeadersError(response.headers);
             if (err) {
               close(err);
               return;


### PR DESCRIPTION
In the latest `0.0.2-alpha.3` version, I am getting `[Internal] unexpected content type: text/plain; charset=utf-8` error in unimplemented service test, which return 404 not found. Instead of adding this content type to our accepted content type (which I believe we should not), it seems making sense to try to extract the http status error first.