### PR TITLE
Switch @bufbuild/protobuf to peer dependency of @bufbuild/connect-web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5408,11 +5408,11 @@
       "name": "@bufbuild/connect-web",
       "version": "0.0.5",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@bufbuild/protobuf": "^0.0.4"
-      },
       "devDependencies": {
         "typescript": "^4.6.4"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^0.0.4"
       }
     },
     "packages/connect-web-test": {
@@ -6110,7 +6110,6 @@
     "@bufbuild/connect-web": {
       "version": "file:packages/connect-web",
       "requires": {
-        "@bufbuild/protobuf": "^0.0.4",
         "typescript": "^4.6.4"
       }
     },

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -21,7 +21,7 @@
     "require": "./dist/cjs/index.js",
     "default": "./dist/esm/index.js"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@bufbuild/protobuf": "^0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This should avoid duplicate installations with different versions, which are difficult for users to debug.