### PR TITLE
add docker compose to host test server locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ UNAME_ARCH := $(shell uname -m)
 export PATH := $(abspath $(CACHE_DIR)/bin):$(abspath node_modules/.bin):$(PATH)
 
 
+# The crosstest git hash to be used by docker-compose and code generation
+CROSSTEST_VERSION := ae95e9554255a7ce55a9b7a5d80eb130a763a38e
+
+
 # The code generator protoc-gen-es generates message and enum types.
 # It is installed via the NPM package @bufbuild/protoc-gen-es.
 PROTOC_GEN_ES_BIN := node_modules/.bin/protoc-gen-es
@@ -207,4 +211,4 @@ docker-compose-clean:
 	# clean up errors are ignored
 
 docker-compose-up: docker-compose-clean
-	docker-compose up
+	CROSSTEST_VERSION=${CROSSTEST_VERSION} docker-compose up

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,13 @@
 version: "3.9"
 services:
   server-connect:
-    image: bufbuild/connect-crosstest:latest
+    image: "bufbuild/connect-crosstest:${CROSSTEST_VERSION}"
     entrypoint: /usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --cert "cert/localhost.crt" --key "cert/localhost.key"
     ports:
       - "8080:8080"
       - "8081:8081"
   server-grpc:
-    image: bufbuild/connect-crosstest:latest
+    image: "bufbuild/connect-crosstest:${CROSSTEST_VERSION}"
     entrypoint: /usr/local/bin/servergrpc --port "8083" --cert "cert/localhost.crt" --key "cert/localhost.key"
     ports:
       - "8083:8083"


### PR DESCRIPTION
with the docker-compose in this PR, we can run `make docker-compose-up`, and below servers will be run:

| server | port |
| --- | --- |
| connect-go h1 | 8080 |
| connect-go h2 | 8081 |
| grpc-go | 8083 |
