### PR TITLE
Surface response metadata in errors

### DIFF
--- a/packages/bench-codesize/README.md
+++ b/packages/bench-codesize/README.md
@@ -9,5 +9,5 @@ minify the bundle, and compress it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 240,848 b | 123,582 b | 19,104 b |
+| connect-web    | 240,962 b | 123,677 b | 19,112 b |
 | grpc-web       | 1,019,192 b    | 724,885 b    | 74,094 b |

--- a/packages/connect-web/src/private/grpc-status.ts
+++ b/packages/connect-web/src/private/grpc-status.ts
@@ -1,0 +1,15 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const grpcStatusDetailsBinName = "grpc-status-details-bin";

--- a/temptestserver/cmd/serve/main.go
+++ b/temptestserver/cmd/serve/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bufbuild/connect-web/testserver/internal/gen/connect/testing/v1/testingv1connect"
 	"github.com/bufbuild/connect-web/testserver/internal/gen/go/testing/v1"
 	"github.com/rs/cors"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type TestService struct {
@@ -40,7 +41,14 @@ func (TestService) UnaryHappy(ctx context.Context, req *connect.Request[testingv
 }
 
 func (TestService) UnaryError(context.Context, *connect.Request[testingv1.UnaryErrorRequest]) (*connect.Response[testingv1.UnaryErrorResponse], error) {
-	return nil, connect.NewError(connect.CodeAlreadyExists, errors.New("\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n"))
+	e := connect.NewError(connect.CodeAlreadyExists, errors.New("\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n"))
+	d, err := anypb.New(&testingv1.UnaryErrorRequest{Value: 123})
+	if err != nil {
+		return nil, err
+	}
+	e.AddDetail(d)
+	e.Meta().Add("single-value", "foo")
+	return nil, e
 }
 
 func (TestService) UnaryHeaders(ctx context.Context, req *connect.Request[testingv1.UnaryHeadersRequest]) (*connect.Response[testingv1.UnaryHeadersResponse], error) {


### PR DESCRIPTION
Error handling usually takes a different code path - it will be convenient to have response headers (or trailers in the case of streams) available on the error object.

Fixes and error where gRPC-web didn't unpack error details.

Adds test coverage using the temporary test server.