### PR TITLE
Add ConnectError.from()

### DIFF
--- a/packages/connect-web-test/src/connect-error.spec.ts
+++ b/packages/connect-web-test/src/connect-error.spec.ts
@@ -61,6 +61,41 @@ describe("ConnectError", function () {
       });
     });
   });
+  describe("from", () => {
+    it("does not touch ConnectError", () => {
+      const connectError = new ConnectError(
+        "Not permitted",
+        Code.PermissionDenied
+      );
+      const fromError = ConnectError.from(connectError);
+      expect(fromError).toBe(connectError);
+    });
+    it("wraps other Error", () => {
+      const e = ConnectError.from(new Error("foo"));
+      expect(e.message).toBe("[unknown] foo");
+      expect(e.rawMessage).toBe("foo");
+    });
+    it("wraps string", () => {
+      const e = ConnectError.from("foo");
+      expect(e.message).toBe("[unknown] foo");
+      expect(e.rawMessage).toBe("foo");
+    });
+    it("works as documented", () => {
+      const connectError = new ConnectError(
+        "Not permitted",
+        Code.PermissionDenied
+      );
+      try {
+        throw connectError;
+      } catch (throwable) {
+        const e = ConnectError.from(throwable);
+        expect(e).toBe(connectError);
+        expect(e.message).toBe("[permission_denied] Not permitted");
+        expect(e.rawMessage).toBe("Not permitted");
+        expect(e.code).toBe(Code.PermissionDenied);
+      }
+    });
+  });
   describe("fromJsonString", () => {
     it("with syntax error throws", () => {
       expect(() => ConnectError.fromJsonString("invalid json")).toThrowError(

--- a/packages/connect-web/src/connect-error.ts
+++ b/packages/connect-web/src/connect-error.ts
@@ -200,6 +200,42 @@ export class ConnectError extends Error {
     }
     return error;
   }
+
+  /**
+   * Converts the argument into a ConnectError, if it is not already one.
+   *
+   * This method is convenient for error handling in TypeScript. Connect only
+   * raises ConnectErrors, the type system is not aware of that, forcing you
+   * to check the type of the raised error:
+   *
+   * ```typescript
+   * catch(throwable) {
+   *   if (throwable instanceof ConnectError) {
+   *     e.details;
+   *   } else {
+   *     // ?
+   *   }
+   * }
+   * ```
+   *
+   * Example usage:
+   *
+   * ```typescript
+   * catch(throwable) {
+   *   const e = ConnectError.from(throwable);
+   *   e.details;
+   * }
+   * ```
+   */
+  static from(throwable: unknown): ConnectError {
+    if (throwable instanceof ConnectError) {
+      return throwable;
+    }
+    if (throwable instanceof Error) {
+      return new ConnectError(throwable.message);
+    }
+    return new ConnectError(String(throwable));
+  }
 }
 
 /**

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -27,6 +27,7 @@ export { ClientInterceptor } from "./client-interceptor.js";
 
 export {
   ClientTransport,
+  ClientCallOptions,
   ClientCall,
   ClientRequest,
   ClientRequestCallback,


### PR DESCRIPTION
Converts the argument into a ConnectError, if it is not already one.

This method is convenient for error handling in TypeScript. Connect only
raises ConnectErrors, the type system is not aware of that, forcing you
to check the type of the raised error:

```typescript
catch(throwable) {
  if (throwable instanceof ConnectError) {
    e.details; // the type system knows it's a ConnectError now - we can access e.details
  } else {
    // ?
  }
}
```

Example usage:

```typescript
catch(throwable) {
  const e = ConnectError.from(throwable);
  e.details; // the type system knows it's a ConnectError now - we can access e.details
}
```