### PR TITLE
Rename timeout option to timeoutMs

### DIFF
--- a/packages/connect-web-test/src/crosstest/empty_unary_with_timeout.spec.ts
+++ b/packages/connect-web-test/src/crosstest/empty_unary_with_timeout.spec.ts
@@ -24,7 +24,7 @@ describe("empty_unary_with_timeout", function () {
     const deadlineMs = 1000; // 1 second
     it("with promise client", async function () {
       const client = makePromiseClient(TestService, transport);
-      const response = await client.emptyCall(empty, { timeout: deadlineMs });
+      const response = await client.emptyCall(empty, { timeoutMs: deadlineMs });
       expect(response).toEqual(empty);
     });
     it("with callback client", function (done) {
@@ -36,7 +36,7 @@ describe("empty_unary_with_timeout", function () {
           expect(response).toEqual(empty);
           done();
         },
-        { timeout: deadlineMs }
+        { timeoutMs: deadlineMs }
       );
     });
   });

--- a/packages/connect-web-test/src/crosstest/timeout_on_sleeping_server.spec.ts
+++ b/packages/connect-web-test/src/crosstest/timeout_on_sleeping_server.spec.ts
@@ -37,7 +37,7 @@ describe("timeout_on_sleeping_server", function () {
     ],
   });
   const options: ClientCallOptions = {
-    timeout: 1, // 1ms
+    timeoutMs: 1, // 1ms
   };
   function expectError(err: unknown) {
     expect(err).toBeInstanceOf(ConnectError);

--- a/packages/connect-web/src/client-transport.ts
+++ b/packages/connect-web/src/client-transport.ts
@@ -57,7 +57,7 @@ export interface ClientCallOptions {
   /**
    * Timeout in milliseconds.
    */
-  timeout?: number;
+  timeoutMs?: number;
 
   /**
    * Custom headers to send with the request.

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -158,7 +158,7 @@ function createRequest<I extends Message<I>>(
     abort,
     header: createConnectRequestHeaders(
       callOptions.headers,
-      callOptions.timeout,
+      callOptions.timeoutMs,
       method.kind,
       useBinaryFormat
     ),

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -264,8 +264,8 @@ function createGrpcWebRequestHeaders(callOptions: ClientCallOptions): Headers {
   new Headers(callOptions.headers).forEach((value, key) =>
     header.set(key, value)
   );
-  if (callOptions.timeout !== undefined) {
-    header.set("Grpc-Timeout", `${callOptions.timeout}m`);
+  if (callOptions.timeoutMs !== undefined) {
+    header.set("Grpc-Timeout", `${callOptions.timeoutMs}m`);
   }
   return header;
 }

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -27,6 +27,7 @@ export { ClientInterceptor } from "./client-interceptor.js";
 
 export {
   ClientTransport,
+  ClientCallOptions,
   ClientCall,
   ClientRequest,
   ClientRequestCallback,


### PR DESCRIPTION
This makes it more obvious that timeouts are given in milliseconds.
