### PR TITLE
Drop clients with exact requests

### DIFF
--- a/packages/connect-web/src/callback-client.ts
+++ b/packages/connect-web/src/callback-client.ts
@@ -56,26 +56,7 @@ export type CallbackClient<T extends ServiceType> = {
   : never;
 };
 
-// prettier-ignore
-export type CallbackClientWithExactRequest<T extends ServiceType> = {
-  [P in keyof T["methods"]]:
-    T["methods"][P] extends MethodInfoUnary<infer I, infer O>           ? (request: I, callback: (error: ConnectError | undefined, response: O) => void, options?: ClientCallOptions) => CancelFn
-  : T["methods"][P] extends MethodInfoServerStreaming<infer I, infer O> ? (request: I, messageCallback: (response: O) => void, closeCallback: (error: ConnectError | undefined) => void, options?: ClientCallOptions) => CancelFn
-  : never;
-};
-
 type CancelFn = () => void;
-
-export function makeCallbackClient<T extends ServiceType>(
-  service: T,
-  transport: ClientTransport,
-  options?: { exactRequest?: false }
-): CallbackClient<T>;
-export function makeCallbackClient<T extends ServiceType>(
-  service: T,
-  transport: ClientTransport,
-  options: { exactRequest: true }
-): CallbackClientWithExactRequest<T>;
 
 /**
  * Create a CallbackClient for the given service, invoking RPCs through the
@@ -99,7 +80,7 @@ export function makeCallbackClient<T extends ServiceType>(
         break;
     }
   }
-  return client as CallbackClient<T> | CallbackClientWithExactRequest<T>;
+  return client as CallbackClient<T>;
 }
 
 type UnaryFn<I extends Message<I>, O extends Message<O>> = (

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -12,16 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {
-  makeCallbackClient,
-  CallbackClient,
-  CallbackClientWithExactRequest,
-} from "./callback-client.js";
-export {
-  makePromiseClient,
-  PromiseClient,
-  PromiseClientWithExactRequest,
-} from "./promise-client.js";
+export { makeCallbackClient, CallbackClient } from "./callback-client.js";
+export { makePromiseClient, PromiseClient } from "./promise-client.js";
 
 export { ClientInterceptor } from "./client-interceptor.js";
 

--- a/packages/connect-web/src/promise-client.ts
+++ b/packages/connect-web/src/promise-client.ts
@@ -44,25 +44,6 @@ export type PromiseClient<T extends ServiceType> = {
     : never;
 };
 
-// prettier-ignore
-export type PromiseClientWithExactRequest<T extends ServiceType> = {
-    [P in keyof T["methods"]]:
-      T["methods"][P] extends MethodInfoUnary<infer I, infer O>           ? (request: I, options?: ClientCallOptions) => Promise<O>
-    : T["methods"][P] extends MethodInfoServerStreaming<infer I, infer O> ? (request: I, options?: ClientCallOptions) => Promise<AsyncIterable<O>>
-    : never;
-};
-
-export function makePromiseClient<T extends ServiceType>(
-  service: T,
-  transport: ClientTransport,
-  options?: { exactRequest?: false }
-): PromiseClient<T>;
-export function makePromiseClient<T extends ServiceType>(
-  service: T,
-  transport: ClientTransport,
-  options: { exactRequest: true }
-): PromiseClientWithExactRequest<T>;
-
 /**
  * Create a PromiseClient for the given service, invoking RPCs through the
  * given transport.
@@ -85,7 +66,7 @@ export function makePromiseClient<T extends ServiceType>(
         break;
     }
   }
-  return client as PromiseClient<T> | PromiseClientWithExactRequest<T>;
+  return client as PromiseClient<T>;
 }
 
 type UnaryFn<I extends Message<I>, O extends Message<O>> = (


### PR DESCRIPTION
We already provide two client shapes and give the user the option to add more. Exact requests do not seem important enough to warrant complicating the two primary clients.