### PR TITLE
Add makeAnyClient()

### DIFF
--- a/packages/bench-codesize/README.md
+++ b/packages/bench-codesize/README.md
@@ -9,5 +9,5 @@ minify the bundle, and compress it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 240,323 b | 123,600 b | 19,088 b |
+| connect-web    | 240,160 b | 123,468 b | 19,038 b |
 | grpc-web       | 1,019,192 b    | 724,885 b    | 74,094 b |

--- a/packages/connect-web-test/src/any-client.spec.ts
+++ b/packages/connect-web-test/src/any-client.spec.ts
@@ -1,0 +1,30 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { makeAnyClient } from "@bufbuild/connect-web";
+import { TestService } from "./gen/grpc/testing/test_connectweb.js";
+
+describe("makeAnyClient()", () => {
+  it("works as expected", () => {
+    const client = makeAnyClient(TestService, (method) => {
+      return function (): string {
+        return `This is method ${method.name} of service ${method.service.typeName}. It takes a ${method.I.typeName} as input and returns a ${method.O.typeName}.`;
+      };
+    });
+    const result = client.unaryCall(); // eslint-disable-line
+    expect(result).toBe(
+      "This is method UnaryCall of service grpc.testing.TestService. It takes a grpc.testing.SimpleRequest as input and returns a grpc.testing.SimpleResponse."
+    );
+  });
+});

--- a/packages/connect-web/src/any-client.ts
+++ b/packages/connect-web/src/any-client.ts
@@ -1,0 +1,55 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ServiceType } from "@bufbuild/protobuf";
+import type { MethodInfo } from "@bufbuild/protobuf";
+
+/**
+ * AnyClient is an arbitrary service client with any method signature.
+ *
+ * It usually has methods for all methods defined for a service, but may
+ * omit some, for example because it's transport does not support streaming.
+ */
+export type AnyClient = Record<string, AnyClientMethod>;
+
+type AnyClientMethod = (...args: any[]) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+type CreateAnyClientMethod = (
+  method: MethodInfo & { localName: string; service: ServiceType }
+) => AnyClientMethod | null;
+
+/**
+ * Create any client for the given service.
+ *
+ * The given createMethod function is called for each method definition
+ * of the service. The function it returns is added to the client object
+ * as a method.
+ */
+export function makeAnyClient(
+  service: ServiceType,
+  createMethod: CreateAnyClientMethod
+): AnyClient {
+  const client: AnyClient = {};
+  for (const [localName, methodInfo] of Object.entries(service.methods)) {
+    const method = createMethod({
+      ...methodInfo,
+      localName,
+      service,
+    });
+    if (method != null) {
+      client[localName] = method;
+    }
+  }
+  return client;
+}

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -14,18 +14,17 @@
 
 export { makeCallbackClient, CallbackClient } from "./callback-client.js";
 export { makePromiseClient, PromiseClient } from "./promise-client.js";
+export { makeAnyClient, AnyClient } from "./any-client.js";
 
 export { ClientInterceptor } from "./client-interceptor.js";
 
 export {
   ClientTransport,
   ClientCallOptions,
-  ClientCall,
   ClientRequest,
   ClientRequestCallback,
   ClientResponse,
   ClientResponseHandler,
-  createClientTransportCalls,
   wrapTransportCall,
 } from "./client-transport.js";
 


### PR DESCRIPTION
This replaces ClientCall and createClientTransportCalls() with makeAnyClient().

This seems to be a much better fit, because it aligns with the existing makePromiseClient() and makeCallbackClient(), and it doesn't mix the concerns of client and transport like ClientCall did.