### PR TITLE
Re-use the karma configuration for local browser testing

### DIFF
--- a/packages/connect-web-test/karma.serve.conf.cjs
+++ b/packages/connect-web-test/karma.serve.conf.cjs
@@ -15,6 +15,10 @@
 module.exports = function (config) {
   require("./karma.conf.cjs")(config);
   config.set({
+    // Override the configuration settings so that we can simply serve
+    // karma, instead of running against configured browsers.
+    // This is used by the npm script "karma-serve", and the make target
+    // "test-local-browser".
     singleRun: false,
     browsers: [],
     customLaunchers: {},


### PR DESCRIPTION
This just saves us a bit of repetition in the configuration.