### PR TITLE
Add mergeHeaders, simplify typings, update comments

### DIFF
--- a/packages/connect-web/src/callback-client.ts
+++ b/packages/connect-web/src/callback-client.ts
@@ -79,7 +79,7 @@ export function makeCallbackClient<T extends ServiceType>(
 }
 
 type UnaryFn<I extends Message<I>, O extends Message<O>> = (
-  request: I | PartialMessage<I>,
+  request: PartialMessage<I>,
   callback: (error: ConnectError | undefined, response: O) => void,
   options?: ClientCallOptions
 ) => CancelFn;
@@ -120,7 +120,7 @@ function createUnaryFn<I extends Message<I>, O extends Message<O>>(
 }
 
 type ServerStreamingFn<I extends Message, O extends Message> = (
-  request: I | PartialMessage<I>,
+  request: PartialMessage<I>,
   onResponse: (response: O) => void,
   onClose: (error: ConnectError | undefined) => void,
   options?: ClientCallOptions

--- a/packages/connect-web/src/connect-error.ts
+++ b/packages/connect-web/src/connect-error.ts
@@ -50,7 +50,7 @@ export class ConnectError extends Error {
   readonly details: AnyMessage[];
 
   /**
-   * Response headers or trailers associated with this error.
+   * A union of response headers and trailers associated with this error.
    */
   readonly metadata: Headers;
 

--- a/packages/connect-web/src/http-headers.ts
+++ b/packages/connect-web/src/http-headers.ts
@@ -75,3 +75,17 @@ export function decodeBinaryHeader<T extends Message<T>>(
     );
   }
 }
+
+/**
+ * Create a union of several Headers objects, by appending all fields from all
+ * inputs to a single Headers object.
+ */
+export function mergeHeaders(...headers: Headers[]): Headers {
+  const h = new Headers();
+  for (const e of headers) {
+    e.forEach((value, key) => {
+      h.append(key, value);
+    });
+  }
+  return h;
+}

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -36,7 +36,11 @@ export { createConnectTransport } from "./connect-transport.js";
 
 export { createGrpcWebTransport } from "./grpc-web-transport.js";
 
-export { decodeBinaryHeader, encodeBinaryHeader } from "./http-headers.js";
+export {
+  decodeBinaryHeader,
+  encodeBinaryHeader,
+  mergeHeaders,
+} from "./http-headers.js";
 
 export {
   createEnvelopeReader,

--- a/packages/connect-web/src/promise-client.ts
+++ b/packages/connect-web/src/promise-client.ts
@@ -65,7 +65,7 @@ export function makePromiseClient<T extends ServiceType>(
 }
 
 type UnaryFn<I extends Message<I>, O extends Message<O>> = (
-  request: I | PartialMessage<I>,
+  request: PartialMessage<I>,
   options?: ClientCallOptions
 ) => Promise<O>;
 
@@ -104,7 +104,7 @@ function createUnaryFn<I extends Message<I>, O extends Message<O>>(
 }
 
 type ServerStreamingFn<I extends Message<I>, O extends Message<O>> = (
-  request: I | PartialMessage<I>,
+  request: PartialMessage<I>,
   options?: ClientCallOptions
 ) => Promise<AsyncIterable<O>>;
 


### PR DESCRIPTION
A few very minor improvements that came up during the cleanup of the Connect implementation. Pulling them in separately to keep the diff for the cleanup smaller.