### PR TITLE
Fix Jasmine config

### DIFF
--- a/packages/connect-web-test/jasmine.json
+++ b/packages/connect-web-test/jasmine.json
@@ -1,6 +1,7 @@
 {
   "spec_dir": "dist/esm",
   "spec_files": ["**/*.spec.js"],
+  "helpers": ["helpers/**/*.js"],
   "env": {
     "stopSpecOnExpectationFailure": false,
     "random": true


### PR DESCRIPTION
We recently simplified the Jasmine config, but went a bit too far. Turns out we have to keep explicitly referencing helpers.

This didn't break anything because the helpers we have right now are only required for older node versions, but we still have to fix it.