### PR TITLE
Update temptestserver and spec setup

### DIFF
--- a/packages/connect-web-test/src/gen/testing/v1/test_connectweb.ts
+++ b/packages/connect-web-test/src/gen/testing/v1/test_connectweb.ts
@@ -109,6 +109,16 @@ export const TestService = {
     /**
      * Returns exactly 5 responses. The value from the request is incremented
      * and given in each response.
+     * Responds with headers:
+     * single-value-head: foo
+     * separate-values-head: bar
+     * separate-values-head: baz
+     * joined-values-head: bar,baz
+     * Responds with trailers:
+     * single-value: foo
+     * separate-values: bar
+     * separate-values: baz
+     * joined-values: bar,baz
      *
      * @generated from rpc testing.v1.TestService.ServerStreamingHappy
      */

--- a/packages/connect-web-test/src/temptest/server-stream.spec.ts
+++ b/packages/connect-web-test/src/temptest/server-stream.spec.ts
@@ -1,0 +1,79 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestService } from "../gen/testing/v1/test_connectweb.js";
+import { Code, ConnectError, makePromiseClient } from "@bufbuild/connect-web";
+import { describeTransports } from "../util/describe-transports.js";
+import { temptestserverTransports } from "./temptestserver.js";
+
+describeTransports(temptestserverTransports, (transport) => {
+  const client = makePromiseClient(TestService, transport);
+  it("serverStreamingHappy", async () => {
+    const want = ["123", "124", "125", "126", "127"];
+    const got: string[] = [];
+    const request = {
+      value: 123,
+    };
+    for await (const response of await client.serverStreamingHappy(request)) {
+      got.push(response.value);
+    }
+    expect(got).toEqual(want);
+  });
+  it("serverStreamingError", async () => {
+    const request = {
+      value: 123,
+    };
+    let responseMessageCount = 0;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we need const _response for for await
+      for await (const _response of await client.serverStreamingError(
+        request
+      )) {
+        responseMessageCount++;
+      }
+    } catch (e) {
+      if (e instanceof ConnectError) {
+        expect(e.code).toBe(Code.AlreadyExists);
+        expect(e.rawMessage).toBe(
+          "\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n"
+        );
+      } else {
+        fail();
+      }
+    }
+    expect(responseMessageCount).toBe(0);
+  });
+  it("serverStreamingEmpty", async () => {
+    const request = {
+      value: 123,
+    };
+    let responseMessageCount = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we need const _response for for await
+    for await (const _response of await client.serverStreamingEmpty(request)) {
+      responseMessageCount++;
+    }
+    expect(responseMessageCount).toBe(0);
+  });
+  it("serverStreamingUnimplemented", async () => {
+    try {
+      await client.serverStreamingUnimplemented({});
+    } catch (e) {
+      if (e instanceof ConnectError) {
+        expect(e.code).toBe(Code.Unimplemented);
+      } else {
+        fail();
+      }
+    }
+  });
+});

--- a/packages/connect-web-test/src/temptest/temptestserver.ts
+++ b/packages/connect-web-test/src/temptest/temptestserver.ts
@@ -1,0 +1,49 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ClientTransport } from "@bufbuild/connect-web";
+import {
+  createConnectTransport,
+  createGrpcWebTransport,
+} from "@bufbuild/connect-web";
+import { TypeRegistry } from "@bufbuild/protobuf";
+import { UnaryErrorRequest } from "../gen/testing/v1/test_pb.js";
+
+export const temptestserverBaseUrl = "http://127.0.0.1:9000";
+
+export const temptestserverTransports: Record<
+  string,
+  (options?: Record<string, unknown>) => ClientTransport
+> = {
+  "gRPC-web transport": (options) =>
+    createGrpcWebTransport({
+      ...options,
+      baseUrl: temptestserverBaseUrl,
+      typeRegistry: TypeRegistry.from(UnaryErrorRequest), // used as error detail in tests
+    }),
+  "connect JSON transport": (options) =>
+    createConnectTransport({
+      ...options,
+      baseUrl: temptestserverBaseUrl,
+      useBinaryFormat: false,
+      typeRegistry: TypeRegistry.from(UnaryErrorRequest), // used as error detail in tests
+    }),
+  "connect binary transport": (options) =>
+    createConnectTransport({
+      ...options,
+      baseUrl: temptestserverBaseUrl,
+      useBinaryFormat: true,
+      typeRegistry: TypeRegistry.from(UnaryErrorRequest), // used as error detail in tests
+    }),
+};

--- a/packages/connect-web-test/src/util/crosstestserver.ts
+++ b/packages/connect-web-test/src/util/crosstestserver.ts
@@ -12,21 +12,98 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createConnectTransport } from "@bufbuild/connect-web";
-import { createGrpcWebTransport } from "@bufbuild/connect-web";
+import {
+  createConnectTransport,
+  createGrpcWebTransport,
+} from "@bufbuild/connect-web";
+import type { ClientTransport } from "@bufbuild/connect-web";
 
+// The following servers are available through crosstests:
+//
+// | server        | port |
+// | ------------- | --- |
+// | connect-go h1 | 8080 |
+// | connect-go h2 | 8081 |
+// | grpc-go       | 8083 |
+//
+// Source: // https://github.com/bufbuild/connect-web/pull/87
 export const baseUrl = "https://127.0.0.1:8080";
 
-export const crosstestTransports = {
-  "gRPC-web transport": createGrpcWebTransport({
-    baseUrl,
-  }),
-  "connect JSON transport": createConnectTransport({
-    baseUrl,
-    useBinaryFormat: false,
-  }),
-  "connect binary transport": createConnectTransport({
-    baseUrl,
-    useBinaryFormat: true,
-  }),
-} as const;
+export const crosstestTransports: Record<
+  string,
+  (options?: Record<string, unknown>) => ClientTransport
+> = {
+  "gRPC-web transport": (options) =>
+    createGrpcWebTransport({
+      ...options,
+      baseUrl,
+    }),
+  "connect JSON transport": (options) =>
+    createConnectTransport({
+      ...options,
+      baseUrl,
+      useBinaryFormat: false,
+    }),
+  "connect binary transport": (options) =>
+    createConnectTransport({
+      ...options,
+      baseUrl,
+      useBinaryFormat: true,
+    }),
+};
+
+// https://github.com/bufbuild/connect-crosstest/blob/main/cert/client.crt
+export const clientCert = `-----BEGIN CERTIFICATE-----
+MIIEODCCAiCgAwIBAgIRAJTCeo42f8lts3VeDnN7CVwwDQYJKoZIhvcNAQELBQAw
+FjEUMBIGA1UEAxMLQ3Jvc3N0ZXN0Q0EwHhcNMjIwNTAzMTcxMDQwWhcNMjMxMTAz
+MTcxOTU2WjARMQ8wDQYDVQQDEwZjbGllbnQwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCoJI6BDesWPERm7zjLGA9Pp0XSR3rnpecXTKIBwamr35gr/It4
+jAZMMBUBHhdvLB0pAj1/hlWLvDQSuQBvfsr2KrqOvtVOP0c5KCzwHjvLmyhhvjOV
+5iEdtv5mUDwILcQH8mvK4XTyWqIDvslUs3KxWfuwrPHZE+qptVAE982pbYixQTTG
+ynRKi+tlFqb0a070koKu5jj+x2TV6Kgh4SFmexHdBSYWiElUGAks2MJ09CT5+Dva
+z4lePGlA6VlDIjwif/lziHASBvW+6J4ZpLyAeCc+1/DgI74Gmpy2oNGmb2LBMwrM
+OZL5KsdiMyYY9ZjPmKWcxybjgGPfinbctOldAgMBAAGjgYUwgYIwDgYDVR0PAQH/
+BAQDAgO4MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQU
+kjyFVJG7YocJyghCFYWHEDdWrv0wHwYDVR0jBBgwFoAUpg6MnxjPVlc2QEjDWcAC
+0qxir5IwEQYDVR0RBAowCIIGY2xpZW50MA0GCSqGSIb3DQEBCwUAA4ICAQAgqAI9
+/yUVAyf3UoSYaZrA22/OPUwvoHoQOSWZDkHXIy9VOiQAJNE8N97XzIIgbjB93sVC
+njwOUk+kXEfmPZuD8RdAR43m1s+WrKCMukAIyg7hobLHqolkUPCdKlsaXgUsNsX1
+T5ka1imVaIyggXWBVu3Q3Wpt8ERl82ncBr65wzRnvAdsGOFag4ujamSAU8s/Mhfy
+EXNkx9u4MqvfWqhU7e5uBULfic+e836ojDxa5If7/MZo892lCQq6t861e5SOHhRN
+AtS7toBmR/h5vYGDqmIwGGaR6YqcIMZ9JbWyPRbr2KIiMDGU7EvVYpIuIKdodbkJ
+aN9RTmaCJTJVHrwMos9sAjwUqis+5gZj7lsPozp7OKYlFwy5Ae4+3C8e8Q1sIzKv
+FaiodJ712fK6xsYr8CbUm4XbP3FBCAiYwbbaJg6odOciexpyvFnbF7152t+a6wOc
+52z4pz7cCjZun40eDxmSucRGx5Do1ohFNrXxriGih0nFF82GCSCZZ3ddkSTIy/Uj
+15MCKRXIOq/0kFDtMIJZ6X73I6jLvk0hiakfrV+GyrVBkzG1pHJEsSyiy7f1edTG
+FjL/opqnz8GV8od9hLHJfwclPBSEA0fp7yNvOzKm1lNPEX009ME1hK4dLKNCqv3x
+g+mJcflVCfjEqJzfEy4wPq5SJzOIzXva6DyBpA==
+-----END CERTIFICATE-----`;
+
+// https://github.com/bufbuild/connect-crosstest/blob/main/cert/client.key
+export const clientKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAqCSOgQ3rFjxEZu84yxgPT6dF0kd656XnF0yiAcGpq9+YK/yL
+eIwGTDAVAR4XbywdKQI9f4ZVi7w0ErkAb37K9iq6jr7VTj9HOSgs8B47y5soYb4z
+leYhHbb+ZlA8CC3EB/JryuF08lqiA77JVLNysVn7sKzx2RPqqbVQBPfNqW2IsUE0
+xsp0SovrZRam9GtO9JKCruY4/sdk1eioIeEhZnsR3QUmFohJVBgJLNjCdPQk+fg7
+2s+JXjxpQOlZQyI8In/5c4hwEgb1vuieGaS8gHgnPtfw4CO+BpqctqDRpm9iwTMK
+zDmS+SrHYjMmGPWYz5ilnMcm44Bj34p23LTpXQIDAQABAoIBAFaTpDC9SuwDEjFy
+QesJM3EPLztsBNPcL9ZmZhDDeCsAkWksu1/RsbhvFZGivexHaahg9+t+7vNpb+Ko
+EZpXTghczfyMNGb63CCJGEJ3PtDCzpMtjYBEo46aV/m0nISVlBeHcotfdYkIs917
+0kzjrU22iItbMZhV0gGaU16LfgEbiJpMS7nmVKnmLEs02g4G3H+xKXRfRhQA7RId
+OIa/iHkJsNQ+o4MiJ7s4G1hp3zqZBSnHuPM3qqj+MAUHobeJKdB7WCW5UWXI9OmA
+ryRSk+R6KDDoXxyWZc0FQ5BJ0OhwMzBsxgqs54CDWND/PLjmsvOjvdhMqpKRy2Am
+oMXk0J0CgYEA0Mkbhh/M7nEeGwKM8MxovSEE0u0j2ksbgt9Wx2aCfiP6GWxLZZuj
+o1aV7TgEn7M70qyeTs9B/fWVzk+tO0yN0S07VxlaY5RMV44LdHnQ85TeTEIxQIAa
+ZYq3kFdfim9ZVzouZHK4mCqYoKpKQyx0sEjbfm9+tdPbs/x5xzVa5EcCgYEAziqU
+zmopsZM4CnCnqvuKK8GH7WwDZXd7SrMOm2qBuvZxNQZsNNsTLR9SV23YA9yYrkmk
+dqdVRS9WX1HjFgbSrQ19b4nk7GZ3d1pjCIZ0BW+WVI6ZkINRCniCsK/2fakCRyas
+HTF+eZIre7SIjM2SKxQU7EbG1J1Mt3Vh3ilSyzsCgYEAuw1iDmERPhK0ESjQ0q+f
+qsoZQ0vYEiu2IyMq4QyzHoXm/L3sMsUk7yKUwemtItL2ZsHmNt8y1W8f3q29muH0
+MJKglmENfSeQ2eRV2O2GSaR3IMUw0QO0IoMMAFJ3M1SdKyviAnZRcWrAQTkvvUzn
+4kPz+iuzzv1W2cL564KewuMCgYEAuNDXQQtOgQ+Wh1ViGRcRUBRXw/C2QrmPXvGR
+QKWD0pSl+4Dcc62ITUTszc98fEm+3U7LDksHV9QNu7lutwo6xkN3lQuqmnlo0yfF
+65iMXWsg+oAzDaeKeLZ7geTcNN3TWvFCDZGW7WipbmXymzaVt+RytTTlfSfd5ABo
+UX396I0CgYASYF3TgzFVGkQK/lVlTOFaWAf0IZ3qwVfCWlezi4GVDHc+eZ27n8rE
+UPFHgEHm9ID0jun/4FQsUkkWQpvfl2H51R4UtFVePXSiKq7D/KNamSUYY3Kvyf0a
+5tmRR33Swjjp3fVRuFtiNVgfTA3OLa2quAqbRzxMsGYAUfeQtCb98g==
+-----END RSA PRIVATE KEY-----`;

--- a/packages/connect-web-test/src/util/describe-transports.ts
+++ b/packages/connect-web-test/src/util/describe-transports.ts
@@ -15,12 +15,12 @@
 import type { ClientTransport } from "@bufbuild/connect-web/src";
 
 export function describeTransports(
-  transports: Record<string, ClientTransport>,
+  transports: Record<string, () => ClientTransport>,
   specDefinitions: (transport: ClientTransport) => void
 ) {
-  for (const [name, transport] of Object.entries(transports)) {
+  for (const [name, transportFactory] of Object.entries(transports)) {
     describe(name, () => {
-      specDefinitions(transport);
+      specDefinitions(transportFactory());
     });
   }
 }

--- a/temptestserver/cmd/serve/main.go
+++ b/temptestserver/cmd/serve/main.go
@@ -95,6 +95,14 @@ func (TestService) UnaryExpectHeaders(ctx context.Context, req *connect.Request[
 }
 
 func (TestService) ServerStreamingHappy(ctx context.Context, req *connect.Request[testingv1.ServerStreamingHappyRequest], res *connect.ServerStream[testingv1.ServerStreamingHappyResponse]) error {
+	res.ResponseHeader().Add("single-value-head", "foo")
+	res.ResponseHeader().Add("separate-values-head", "bar")
+	res.ResponseHeader().Add("separate-values-head", "baz")
+	res.ResponseHeader().Add("joined-values-head", "bar, baz")
+	res.ResponseTrailer().Add("single-value", "foo")
+	res.ResponseTrailer().Add("separate-values", "bar")
+	res.ResponseTrailer().Add("separate-values", "baz")
+	res.ResponseTrailer().Add("joined-values", "bar, baz")
 	for i := 0; i < 5; i++ {
 		err := res.Send(&testingv1.ServerStreamingHappyResponse{
 			Value: fmt.Sprint(req.Msg.GetValue() + int32(i)),
@@ -170,6 +178,7 @@ func main() {
 			"Grpc-Status", "Grpc-Message", "Grpc-Status-Details-Bin",
 			// headers used in tests
 			"Joined-Values", "Separate-Values", "Single-Value",
+			"Joined-Values-Head", "Separate-Values-Head", "Single-Value-Head",
 			"Trailer-Joined-Values", "Trailer-Separate-Values", "Trailer-Single-Value",
 		},
 	}).Handler(mux)

--- a/temptestserver/internal/gen/connect/testing/v1/testingv1connect/test.connect.go
+++ b/temptestserver/internal/gen/connect/testing/v1/testingv1connect/test.connect.go
@@ -56,6 +56,16 @@ type TestServiceClient interface {
 	UnaryUnimplemented(context.Context, *connect_go.Request[v1.UnaryUnimplementedRequest]) (*connect_go.Response[v1.UnaryUnimplementedResponse], error)
 	// Returns exactly 5 responses. The value from the request is incremented
 	// and given in each response.
+	// Responds with headers:
+	// single-value-head: foo
+	// separate-values-head: bar
+	// separate-values-head: baz
+	// joined-values-head: bar,baz
+	// Responds with trailers:
+	// single-value: foo
+	// separate-values: bar
+	// separate-values: baz
+	// joined-values: bar,baz
 	ServerStreamingHappy(context.Context, *connect_go.Request[v1.ServerStreamingHappyRequest]) (*connect_go.ServerStreamForClient[v1.ServerStreamingHappyResponse], error)
 	// Always raises an error "already_exists", and a message with whitespace
 	// and unicode content
@@ -237,6 +247,16 @@ type TestServiceHandler interface {
 	UnaryUnimplemented(context.Context, *connect_go.Request[v1.UnaryUnimplementedRequest]) (*connect_go.Response[v1.UnaryUnimplementedResponse], error)
 	// Returns exactly 5 responses. The value from the request is incremented
 	// and given in each response.
+	// Responds with headers:
+	// single-value-head: foo
+	// separate-values-head: bar
+	// separate-values-head: baz
+	// joined-values-head: bar,baz
+	// Responds with trailers:
+	// single-value: foo
+	// separate-values: bar
+	// separate-values: baz
+	// joined-values: bar,baz
 	ServerStreamingHappy(context.Context, *connect_go.Request[v1.ServerStreamingHappyRequest], *connect_go.ServerStream[v1.ServerStreamingHappyResponse]) error
 	// Always raises an error "already_exists", and a message with whitespace
 	// and unicode content

--- a/temptestserver/proto/testing/v1/test.proto
+++ b/temptestserver/proto/testing/v1/test.proto
@@ -53,6 +53,16 @@ service TestService {
 
   // Returns exactly 5 responses. The value from the request is incremented
   // and given in each response.
+  // Responds with headers:
+  // single-value-head: foo
+  // separate-values-head: bar
+  // separate-values-head: baz
+  // joined-values-head: bar,baz
+  // Responds with trailers:
+  // single-value: foo
+  // separate-values: bar
+  // separate-values: baz
+  // joined-values: bar,baz
   rpc ServerStreamingHappy(ServerStreamingHappyRequest) returns (stream ServerStreamingHappyResponse);
 
   // Always raises an error "already_exists", and a message with whitespace


### PR DESCRIPTION
Updates the temporary test server with headers and trailers for server streams.

Updates the spec files so we can test interceptors with all available transports - but doesn't implement it yet.