### PR TITLE
listen and wait for the port on startup of the crosstest server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ __temptestserver-gorun:
 TESTSERVER_RUNNING = $(CACHE_DIR)/service/testserver
 $(TESTSERVER_RUNNING): docker-compose.yaml
 	node make/scripts/service-stop.js $(TESTSERVER_RUNNING) dockercomposeup
-	node make/scripts/service-start.js $(TESTSERVER_RUNNING) dockercomposeup 'localhost:8083'
+	node make/scripts/service-start.js $(TESTSERVER_RUNNING) dockercomposeup 'localhost:8080,localhost:8081,localhost:8083'
 
 
 # The private NPM package "@bufbuild/connect-web-test" provides test coverage:

--- a/make/scripts/service-start.js
+++ b/make/scripts/service-start.js
@@ -8,20 +8,20 @@ import * as net from "net";
 if (process.argv.length !== 5) {
   process.stderr.write(
     [
-      `USAGE: ${process.argv[1]} <lock-file-path> <make-target> <target-address>`,
+      `USAGE: ${process.argv[1]} <lock-file-path> <make-target> <target-addresses>`,
       "",
       "(Re-)start a service in the background. ",
       "",
-      "lock-file-path:  path to use for the lock file",
-      "make-target:     make target to run as the service",
-      "target-address:  target address to check if the service is running",
+      "lock-file-path:      path to use for the lock file",
+      "make-target:         make target to run as the service",
+      "target-addresses:    target addresses to check if the services are running, 'host:port' array separated by ',' separator",
       "",
     ].join("\n")
   );
   process.exit(1);
 }
 
-const [, , lockFilePath, makeTarget, targetAddress] = process.argv;
+const [, , lockFilePath, makeTarget, targetAddressesString] = process.argv;
 
 if (!existsSync(dirname(lockFilePath))) {
   mkdirSync(dirname(lockFilePath), {
@@ -39,24 +39,31 @@ child.on("exit", (code, signal) => {
   childExitSignal = signal;
 });
 
-const [host, port] = targetAddress.split(":");
-const socket = new net.Socket();
-socket.connect(parseInt(port, 10), host);
-socket.on("error", () => {
-  if (childExitCode !== undefined || childExitSignal !== undefined) {
-    process.stderr.write(`failed to start ${makeTarget}\n`);
-    process.exit(childExitCode ?? 1);
-    return;
-  }
-  setTimeout(() => {
-    socket.connect(Number(port), host);
-  }, 1000);
-});
-socket.on("ready", () => {
-  writeFileSync(lockFilePath, child.pid.toString(10), {
-    encoding: "utf-8",
+const targetAddresses = targetAddressesString.split(",");
+let successCount = 0;
+targetAddresses.forEach((address) => {
+  const [host, port] = address.split(":");
+  const socket = new net.Socket();
+  socket.connect(parseInt(port, 10), host);
+  socket.on("error", () => {
+    if (childExitCode !== undefined || childExitSignal !== undefined) {
+      process.stderr.write(`failed to start ${makeTarget}\n`);
+      process.exit(childExitCode ?? 1);
+      return;
+    }
+    setTimeout(() => {
+      socket.connect(Number(port), host);
+    }, 1000);
   });
-  child.unref();
-  process.stdout.write(`${makeTarget} runnning\n`);
-  process.exit(0);
+  socket.on("ready", () => {
+    successCount++;
+    if (successCount === targetAddresses.length) {
+      writeFileSync(lockFilePath, child.pid.toString(10), {
+        encoding: "utf-8",
+      });
+      child.unref();
+      process.stdout.write(`${makeTarget} running\n`);
+      process.exit(0);
+    }
+  });
 });


### PR DESCRIPTION
fixes TCN-159

this will print `all testing servers are started and listening` when all servers in the docker-compose have started