### PR TITLE
Remove npm auth token

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=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


### PR DESCRIPTION
It was only used to access @bufbuild/protobuf while that was private.