### PR TITLE
Updated client definitions to strip out calls that resolve to never

### DIFF
--- a/packages/connect-web/src/callback-client.ts
+++ b/packages/connect-web/src/callback-client.ts
@@ -27,6 +27,8 @@ import { makeAnyClient } from "./any-client.js";
 import { connectErrorFromReason } from "./connect-error.js";
 import type { CallOptions } from "./call-options.js";
 
+// This type returns the keys of an object where the right hand side
+// DOESN'T match never.
 type FilterOutNever<T> = {
   [P in keyof T]: T[P] extends never ? never : P;
 }[keyof T];

--- a/packages/connect-web/src/promise-client.ts
+++ b/packages/connect-web/src/promise-client.ts
@@ -25,6 +25,8 @@ import { makeAnyClient } from "./any-client.js";
 import type { StreamResponse } from "./interceptor.js";
 import type { CallOptions } from "./call-options.js";
 
+// This type returns the keys of an object where the right hand side
+// DOESN'T match never.
 type FilterOutNever<T> = {
   [P in keyof T]: T[P] extends never ? never : P;
 }[keyof T];


### PR DESCRIPTION
This change updates the typescript definitions of our clients to remove uncallable clients. I'm a little unfamiliar with the `as` being applied to a typed map key but it is the recommended mechanism to exclude keys from an object.

Ideally I wouldn't need two additional types to run interference but I can't think of a cleaner way.