### PR TITLE
Add main prop for older webpack support

### DIFF
--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -21,6 +21,7 @@
     "require": "./dist/cjs/index.js",
     "default": "./dist/esm/index.js"
   },
+  "main": "./dist/esm/index.js",
   "peerDependencies": {
     "@bufbuild/protobuf": "^0.0.7"
   },


### PR DESCRIPTION
The `package.json` of `connect-web` uses [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) to handle conditions for CommonJS and ES module imports.

Webpack added support for the `exports` keyword in [version 5](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#resolving).  However, older versions (< 5.x) do not support `exports`.  As a result, using an older version of Webpack with `connect-web` will cause `ModuleNotFoundErrors`.

This specifies a `main` entrypoint for backwards-compatibility.

Fixes 227