### PR TITLE
Update codesize benchmark README.md for ELIZA

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -2,10 +2,11 @@
 
 This is a simple code size comparison between Connect-Web and gRPC-web.
 
-We are generating code for the module [buf.build/bufbuild/buf](https://buf.build/bufbuild/buf)
-once with `protoc-gen-grpc-web`, once with `protoc-gen-connect-web`. Then we bundle Then we bundle [a client](./src) 
-for the service `buf.alpha.registry.v1alpha1.PluginService` with [esbuild](https://esbuild.github.io/),
-minify the bundle, and compress it like a web server would usually do.
+We are generating code for the module [buf.build/bufbuild/eliza](https://buf.build/bufbuild/eliza)
+once with `protoc-gen-grpc-web`, once with `protoc-gen-connect-web`. 
+Then we bundle a client for the service `buf.connect.demo.eliza.v1.ElizaService` 
+with [esbuild](https://esbuild.github.io/), minify the bundle, and compress 
+it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|

--- a/packages/connect-web-bench/report.mjs
+++ b/packages/connect-web-bench/report.mjs
@@ -9,10 +9,11 @@ process.stdout.write(`# Code size comparison
 
 This is a simple code size comparison between Connect-Web and gRPC-web.
 
-We are generating code for the module [buf.build/bufbuild/buf](https://buf.build/bufbuild/buf)
-once with \`protoc-gen-grpc-web\`, once with \`protoc-gen-connect-web\`. Then we bundle Then we bundle [a client](./src) 
-for the service \`buf.alpha.registry.v1alpha1.PluginService\` with [esbuild](https://esbuild.github.io/),
-minify the bundle, and compress it like a web server would usually do.
+We are generating code for the module [buf.build/bufbuild/eliza](https://buf.build/bufbuild/eliza)
+once with \`protoc-gen-grpc-web\`, once with \`protoc-gen-connect-web\`. 
+Then we bundle a client for the service \`buf.connect.demo.eliza.v1.ElizaService\` 
+with [esbuild](https://esbuild.github.io/), minify the bundle, and compress 
+it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|


### PR DESCRIPTION
Follow-up to https://github.com/bufbuild/connect-web/pull/179 - completely forgot to update the BSR links in the README.