### PR TITLE
Fix prep release and move to properly maintained github-script

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: prepare version
         id: prepare
         run: |
-          CURRENT_VERSION=$(cat package.json | jq -r '.version')
+          CURRENT_VERSION=$(cat packages/connect-web/package.json | jq -r '.version')
           NEXT_VERSION=$(npx -y semver -i ${{ github.event.inputs.releaseType }} $CURRENT_VERSION)
           echo "::set-output name=currentVersion::v$CURRENT_VERSION"
           echo "::set-output name=nextVersion::v$NEXT_VERSION"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -50,14 +50,17 @@ jobs:
           make release
       - name: create release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v6
         with:
-          tag_name: ${{ steps.publish.outputs.nextVersion }}
-          release_name: ${{ steps.publish.outputs.nextVersion }}
-          body: ${{ github.event.pull_request.body }}
-          prerelease: true
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "${{ steps.publish.outputs.nextVersion }}",
+              tag_name: "${{ steps.publish.outputs.nextVersion }}",
+              body: "${{ github.event.pull_request.body }}",
+              prerelease: false
+            })
       - name: close PR
         run: |
           gh pr close ${{ github.event.pull_request.number }} -d -c "Released!"


### PR DESCRIPTION
My generic script had made assumptions about where version was managed. Moved it to assume it lies under packages/connect-web.