### PR TITLE
Add missing release notes config file

### DIFF
--- a/.github/release-notes-config.json
+++ b/.github/release-notes-config.json
@@ -1,0 +1,4 @@
+{
+  "template": "${{UNCATEGORIZED}}",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})"
+}

--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -31,7 +31,7 @@ jobs:
         id: diff
         with:
           # See https://github.com/mikepenz/release-changelog-builder-action#advanced-workflow-specification for configuration options
-          configuration: "release-notes-config.json"
+          configuration: "./.github/release-notes-config.json"
           fromTag: ${{ steps.prepare.outputs.currentVersion }}
           toTag: HEAD
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/release-notes-config.json
+++ b/release-notes-config.json
@@ -1,4 +1,0 @@
-{
-    "template": "${{UNCATEGORIZED}}",
-    "pr_template": "- ${{TITLE}} (#${{NUMBER}})"
-}


### PR DESCRIPTION
Forgot this config file, which allows customization of release notes but also required because the defaults on this specific action are a little annoying.