### PR TITLE
Move version bump to the prep stage

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -13,7 +13,6 @@ on:
           - patch
         default: patch
 
-
 jobs:
   gather-change-logs:
     permissions:
@@ -56,14 +55,21 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.15.0
+      - name: setup-go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
       - name: prepare version
         id: prepare
         run: |
           CURRENT_VERSION=$(cat packages/connect-web/package.json | jq -r '.version')
           NEXT_VERSION=$(npx -y semver -i ${{ github.event.inputs.releaseType }} $CURRENT_VERSION)
+          make set-version SET_VERSION=$NEXT_VERSION
           echo "::set-output name=currentVersion::v$CURRENT_VERSION"
           echo "::set-output name=nextVersion::v$NEXT_VERSION"
-          echo "v$NEXT_VERSION" > version
       - name: commit changes
         run: |
           git config user.name github-actions
@@ -100,5 +106,3 @@ jobs:
               issue_number: newPr.number,
               labels: ["release"]
             })
-
-          

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -26,19 +26,20 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      # The follow step is custom per repo
-      - name: publish
-        id: publish
-        run: |
-          NEXT_VERSION=$(echo "${{ github.event.pull_request.title }}" | awk '{print $NF}')
-          make set-version SET_VERSION=$NEXT_VERSION
-          echo "::set-output name=nextVersion::$NEXT_VERSION"
-      - name: commit changes
+      - name: merge pr
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.pull_request.number }},
+              merge_method: "squash"
+            })
+      - name: create tag
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add .
-          git commit -m "Release ${{ steps.publish.outputs.nextVersion }}"
           git tag -a "${{ steps.publish.outputs.nextVersion }}" -m "Release ${{ steps.publish.outputs.nextVersion }}"
           git push
           git push --tags
@@ -59,7 +60,7 @@ jobs:
               name: "${{ steps.publish.outputs.nextVersion }}",
               tag_name: "${{ steps.publish.outputs.nextVersion }}",
               body: "${{ github.event.pull_request.body }}",
-              prerelease: false
+              prerelease: true
             })
       - name: close PR
         run: |


### PR DESCRIPTION
Moved the `set version` stage of the release into the prep stage so we can get a better idea of the extent of the changes within the prep release PR.