### PR TITLE
Add buf CLI required by prep

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -62,6 +62,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
+      - uses: bufbuild/buf-setup-action@v1.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare version
         id: prepare
         run: |


### PR DESCRIPTION
One more PR to fix prep. The setversion command apparently depends on buf cli.