### PR TITLE
Use demo.connect.build in codesize benchmark

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 86,661 b | 40,394 b | 11,110 b |
-| grpc-web       | 393,982 b    | 283,904 b    | 51,879 b |
+| connect-web    | 86,680 b | 40,403 b | 11,112 b |
+| grpc-web       | 394,791 b    | 283,922 b    | 51,870 b |

--- a/packages/connect-web-bench/src/entry-connectweb.ts
+++ b/packages/connect-web-bench/src/entry-connectweb.ts
@@ -21,7 +21,7 @@ import { ElizaService } from "./gen/connectweb/buf/connect/demo/eliza/v1/eliza_c
 const client = createPromiseClient(
   ElizaService,
   createConnectTransport({
-    baseUrl: "https://localhost",
+    baseUrl: "https://demo.connect.build",
   })
 );
 

--- a/packages/connect-web-bench/src/entry-grpcweb.ts
+++ b/packages/connect-web-bench/src/entry-grpcweb.ts
@@ -14,7 +14,7 @@
 
 import { ElizaServiceClient } from "./gen/grpcweb/buf/connect/demo/eliza/v1/eliza_grpc_web_pb.js";
 
-const client = new ElizaServiceClient("localhost");
+const client = new ElizaServiceClient("https://demo.connect.build");
 
 // eslint-disable-next-line no-console -- log statement makes sure the variable is in use
 console.log(client);


### PR DESCRIPTION
We have been using `https://localhost` - makes sense to swap this to `https://demo.connect.build` for consistency.