### PR TITLE
Fix references to moved repos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,15 +20,15 @@ you to accept the CLA when you open your pull request.
 ```
 git clone git@github.com:your_github_username/connect-es.git
 cd connect-es
-git remote add upstream https://github.com/bufbuild/connect-es.git
+git remote add upstream https://github.com/connectrpc/connect-es.git
 git fetch upstream
 ```
 
-Make sure that the tests and the linters pass (you'll need `node`, 
+Make sure that the tests and the linters pass (you'll need `node`,
 `buf`, `bash`, Docker, and the latest stable Go release installed):
 
 ```
-make 
+make
 ```
 
 ## Making Changes
@@ -42,7 +42,7 @@ git rebase upstream/main
 git checkout -b cool_new_feature
 ```
 
-Make your changes, then ensure that `make` still passes. 
+Make your changes, then ensure that `make` still passes.
 When you're satisfied with your changes, push them to your fork.
 
 ```
@@ -63,7 +63,7 @@ We're much more likely to approve your changes if you:
 * Write a [good commit message][commit-message].
 * Maintain backward compatibility.
 
-[fork]: https://github.com/bufbuild/connect-es/fork
-[open-issue]: https://github.com/bufbuild/connect-es/issues/new
-[cla]: https://cla-assistant.io/bufbuild/connect-es
+[fork]: https://github.com/connectrpc/connect-es/fork
+[open-issue]: https://github.com/connectrpc/connect-es/issues/new
+[cla]: https://cla-assistant.io/connectrpc/connect-es
 [commit-message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Connect for ECMAScript
 
-[![License](https://img.shields.io/github/license/bufbuild/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/connect/latest?color=green&label=%40bufbuild%2Fconnect)](https://www.npmjs.com/package/@bufbuild/connect) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/protoc-gen-connect-es/latest?color=green&label=%40bufbuild%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-es)
+[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/connect/latest?color=green&label=%40bufbuild%2Fconnect)](https://www.npmjs.com/package/@bufbuild/connect) [![NPM Version](https://img.shields.io/npm/v/@bufbuild/protoc-gen-connect-es/latest?color=green&label=%40bufbuild%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-es)
 
 Connect is a family of libraries for building type-safe APIs with different languages and platforms.
 [@bufbuild/connect](https://www.npmjs.com/package/@bufbuild/connect) brings them to TypeScript,
@@ -51,7 +51,7 @@ we use [Vite](https://vitejs.dev/) and [React](https://reactjs.org/) to create a
 web interface for ELIZA.
 
 **React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/connectrpc/examples-es)),
-and we have an expansion pack for [TanStack Query](https://github.com/bufbuild/connect-query).
+and we have an expansion pack for [TanStack Query](https://github.com/connectrpc/connect-query-es).
 We support all modern web browsers that implement the widely available
 [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API).
@@ -73,7 +73,7 @@ the builtin `http` and `http2` modules.
 Would you like to use Connect on other platforms like Bun, Deno, Vercel’s Edge Runtime,
 or Cloudflare Workers? We’d love to learn about your use cases and what you’d like to do
 with Connect. You can reach us either through the [Buf Slack](https://buf.build/links/slack/)
-or by filing a [GitHub issue](https://github.com/bufbuild/connect-web/issues) and we’d
+or by filing a [GitHub issue](https://github.com/connectrpc/connect-es/issues) and we’d
 be more than happy to chat!
 
 
@@ -101,14 +101,14 @@ The libraries and the generated code are compatible with ES2017 and TypeScript 4
 
 * [examples-es](https://github.com/connectrpc/examples-es):
   Examples for using Connect with various TypeScript web frameworks and tooling
-* [connect-query](https://github.com/bufbuild/connect-query):
+* [connect-query-es](https://github.com/connectrpc/connect-query-es):
   TypeScript-first expansion pack for TanStack Query that gives you Protobuf superpowers
 * [connect-swift](https://github.com/bufbuild/connect-swift):
   Idiomatic gRPC & Connect RPCs for Swift.
-* [connect-go](https://github.com/bufbuild/connect-go):
+* [connect-go](https://github.com/connectrpc/connect-go):
   Go implementation of gRPC, gRPC-Web, and Connect
-* [connect-demo](https://github.com/bufbuild/connect-demo):
-  demonstration service powering demo.connectrpc.com
+* [examples-go](https://github.com/connectrpc/examples-go):
+  Example RPC service powering https://demo.connectrpc.com and built with connect-go
 * [connect-crosstest](https://github.com/bufbuild/connect-crosstest):
   gRPC-Web and Connect interoperability tests
 * [Buf Studio](https://buf.build/studio): web UI for ad-hoc RPCs
@@ -119,7 +119,7 @@ The libraries and the generated code are compatible with ES2017 and TypeScript 4
 
 This project is a beta: we rely on it in production, but we may make a few
 changes as we gather feedback from early adopters. Join us on [Slack](https://buf.build/links/slack)
-or see the [roadmap discussion](https://github.com/bufbuild/connect-web/discussions/315) for details.
+or see the [roadmap discussion](https://github.com/connectrpc/connect-es/discussions/315) for details.
 
 
 ## Legal

--- a/packages/connect-express/README.md
+++ b/packages/connect-express/README.md
@@ -78,4 +78,4 @@ and Express does not support the Node.js `http2` module.
 ## Getting started
 
 To get started with Connect, head over to the [docs](https://connectrpc.com/docs/node/getting-started)
-for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-es/tree/main/packages/example).
+for a tutorial, or take a look at [our example](https://github.com/connectrpc/connect-es/tree/main/packages/example).

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bufbuild/connect-es.git",
+    "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/connect-express"
   },
   "sideEffects": false,

--- a/packages/connect-fastify/README.md
+++ b/packages/connect-fastify/README.md
@@ -89,4 +89,4 @@ instead.
 ## Getting started
 
 To get started with Connect, head over to the [docs](https://connectrpc.com/docs/node/getting-started)
-for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-es/tree/main/packages/example).
+for a tutorial, or take a look at [our example](https://github.com/connectrpc/connect-es/tree/main/packages/example).

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bufbuild/connect-es.git",
+    "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/connect-fastify"
   },
   "sideEffects": false,

--- a/packages/connect-next/README.md
+++ b/packages/connect-next/README.md
@@ -94,4 +94,4 @@ to Vercel.
 ## Getting started
 
 To get started with Connect, head over to the [docs](https://connectrpc.com/docs/node/getting-started)
-for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-es/tree/main/packages/example).
+for a tutorial, or take a look at [our example](https://github.com/connectrpc/connect-es/tree/main/packages/example).

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bufbuild/connect-es.git",
+    "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/connect-next"
   },
   "sideEffects": false,

--- a/packages/connect-node-test/src/helpers/testserver.ts
+++ b/packages/connect-node-test/src/helpers/testserver.ts
@@ -64,7 +64,7 @@ export function createTestServers() {
   // | connect-go h2 | 8081 |
   // | grpc-go       | 8083 |
   //
-  // Source: https://github.com/bufbuild/connect-es/pull/87
+  // Source: https://github.com/connectrpc/connect-es/pull/87
   const servers = {
     // connect-go
     "connect-go (h1)": {

--- a/packages/connect-node/README.md
+++ b/packages/connect-node/README.md
@@ -141,4 +141,4 @@ instead.
 ## Getting started
 
 To get started with Connect, head over to the [docs](https://connectrpc.com/docs/node/getting-started)
-for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-es/tree/main/packages/example).
+for a tutorial, or take a look at [our example](https://github.com/connectrpc/connect-es/tree/main/packages/example).

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bufbuild/connect-es.git",
+    "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/connect-node"
   },
   "scripts": {

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -549,7 +549,7 @@ function ready(
   options: Required<Http2SessionOptions>,
 ): StateReady {
   // Users have reported an error "The session has been destroyed" raised
-  // from H2SessionManager.request(), see https://github.com/bufbuild/connect-es/issues/683
+  // from H2SessionManager.request(), see https://github.com/connectrpc/connect-es/issues/683
   // This assertion will show whether the session already died in the
   // "connecting" state.
   assertSessionOpen(conn);

--- a/packages/connect-web-test/src/helpers/crosstestserver.ts
+++ b/packages/connect-web-test/src/helpers/crosstestserver.ts
@@ -28,7 +28,7 @@ import { testRoutes } from "./test-routes.js";
 // | connect-go h2 | 8081 |
 // | grpc-go       | 8083 |
 //
-// Source: // https://github.com/bufbuild/connect-es/pull/87
+// Source: // https://github.com/connectrpc/connect-es/pull/87
 const crossTestConnectGoH1BaseUrl = "https://127.0.0.1:8080";
 
 // see connect-node-h1-server.mjs

--- a/packages/connect-web/README.md
+++ b/packages/connect-web/README.md
@@ -50,7 +50,7 @@ console.log(sentence) // you said: I feel happy.
 ## Getting started
 
 To get started with Connect, head over to the [docs](https://connectrpc.com/docs/node/getting-started)
-for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-es/tree/main/packages/example).
+for a tutorial, or take a look at [our example](https://github.com/connectrpc/connect-es/tree/main/packages/example).
 
 Connect plays nice with Vue, Svelte, Remix, Next.js, Angular and many others. Take a look at
 [our examples](https://github.com/connectrpc/examples-es) for various frameworks.

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bufbuild/connect-es.git",
+    "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/connect-web"
   },
   "sideEffects": false,

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -48,7 +48,7 @@ we use [Vite](https://vitejs.dev/) and [React](https://reactjs.org/) to create a
 web interface for ELIZA.
 
 **React**, **Svelte**, **Vue**, **Next.js** and **Angular** are supported (see [examples](https://github.com/connectrpc/examples-es)),
-and we have an expansion pack for [TanStack Query](https://github.com/bufbuild/connect-query).
+and we have an expansion pack for [TanStack Query](https://github.com/connectrpc/connect-query-es).
 We support all modern web browsers that implement the widely available
 [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API).

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bufbuild/connect-es.git",
+    "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/connect"
   },
   "sideEffects": false,

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -14,7 +14,7 @@ You will need [Node](https://nodejs.org/en/download/) in version 16 or later ins
 the example project and install its dependencies:
 
 ```shell
-curl -L https://github.com/bufbuild/connect-es/archive/refs/heads/main.zip > connect-web-main.zip
+curl -L https://github.com/connectrpc/connect-es/archive/refs/heads/main.zip > connect-es-main.zip
 unzip connect-es-main.zip 'connect-es-main/packages/example/*'
 
 cd connect-es-main/packages/example

--- a/packages/protoc-gen-connect-es/README.md
+++ b/packages/protoc-gen-connect-es/README.md
@@ -4,7 +4,7 @@ The code generator for Connect, a simple library to work with servers and client
 in ECMAScript with the type-safety of TypeScript.  It generates code that is compatible with
 browsers and Node.js.
 
-Learn more about Connect at [github.com/bufbuild/connect-es](https://github.com/bufbuild/connect-es).
+Learn more about Connect at [github.com/connectrpc/connect-es](https://github.com/connectrpc/connect-es).
 
 ## Installation
 

--- a/packages/protoc-gen-connect-es/package.json
+++ b/packages/protoc-gen-connect-es/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bufbuild/connect-es.git",
+    "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/protoc-gen-connect-es"
   },
   "bin": {


### PR DESCRIPTION
This fixes the references to repos that were moved to the `connectrpc` organization (including this one).