### PR TITLE
Update gRPC and gRPC-web user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ $(BUILD)/protoc-gen-connect-es: node_modules tsconfig.base.json packages/protoc-
 	@mkdir -p $(@D)
 	@touch $(@)
 
-$(BUILD)/connect: $(GEN)/connect node_modules tsconfig.base.json packages/connect/tsconfig.json $(shell find packages/connect/src -name '*.ts') packages/connect/*.js
+$(BUILD)/connect: $(GEN)/connect node_modules packages/connect/package.json packages/connect/scripts/* tsconfig.base.json packages/connect/tsconfig.json $(shell find packages/connect/src -name '*.ts') packages/connect/*.js
 	npm run -w packages/connect clean
 	npm run -w packages/connect build
 	@mkdir -p $(@D)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "clean": "rm -rf ./dist/cjs/* ./dist/esm/* ./dist/types/*",
     "generate": "buf generate src/protocol-grpc/proto",
-    "build": "npm run build:cjs && npm run build:esm+types",
+    "build": "npm run build:cjs && npm run build:esm+types && node scripts/update-user-agent.mjs",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm+types": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/types && echo >./dist/esm/package.json '{\"type\":\"module\", \"sideEffects\":false}'",
     "jasmine": "jasmine --config=jasmine.json"

--- a/packages/connect/scripts/update-user-agent.mjs
+++ b/packages/connect/scripts/update-user-agent.mjs
@@ -1,0 +1,22 @@
+import {readFileSync, writeFileSync} from "node:fs";
+import assert from "node:assert";
+
+const placeholder = "CONNECT_ES_USER_AGENT";
+
+const paths = [
+  "dist/esm/protocol-grpc/request-header.js",
+  "dist/esm/protocol-grpc-web/request-header.js",
+  "dist/cjs/protocol-grpc/request-header.js",
+  "dist/cjs/protocol-grpc-web/request-header.js",
+];
+
+const {version} = JSON.parse(readFileSync(new URL("../package.json", import.meta.url).pathname, "utf-8"));
+console.log(version)
+assert(typeof version == "string");
+assert(version.length >= 5);
+
+for (const path of paths) {
+  const oldContent = readFileSync(path, "utf-8");
+  const newContent = oldContent.replace(placeholder, `connect-es/${version}`);
+  writeFileSync(path, newContent);
+}

--- a/packages/connect/scripts/update-user-agent.mjs
+++ b/packages/connect/scripts/update-user-agent.mjs
@@ -11,7 +11,6 @@ const paths = [
 ];
 
 const {version} = JSON.parse(readFileSync(new URL("../package.json", import.meta.url).pathname, "utf-8"));
-console.log(version)
 assert(typeof version == "string");
 assert(version.length >= 5);
 

--- a/packages/connect/src/protocol-grpc-web/request-header.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.spec.ts
@@ -37,7 +37,7 @@ describe("requestHeader", () => {
       "x-user-agent",
     ]);
     expect(headers.get("Content-Type")).toBe("application/grpc-web+proto");
-    expect(headers.get("X-User-Agent")).toBe("@bufbuild/connect-web");
+    expect(headers.get("X-User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
     expect(headers.get("X-Grpc-Web")).toBe("1");
   });
 

--- a/packages/connect/src/protocol-grpc-web/request-header.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.ts
@@ -18,7 +18,7 @@ import {
   headerEncoding,
   headerTimeout,
   headerXGrpcWeb,
-  headerXUserAgent
+  headerXUserAgent,
 } from "./headers.js";
 import { contentTypeJson, contentTypeProto } from "./content-type.js";
 import type { Compression } from "../protocol/compression.js";

--- a/packages/connect/src/protocol-grpc-web/request-header.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.ts
@@ -17,8 +17,8 @@ import {
   headerContentType,
   headerEncoding,
   headerTimeout,
-  headerXUserAgent,
   headerXGrpcWeb,
+  headerXUserAgent
 } from "./headers.js";
 import { contentTypeJson, contentTypeProto } from "./content-type.js";
 import type { Compression } from "../protocol/compression.js";
@@ -41,10 +41,10 @@ export function requestHeader(
     useBinaryFormat ? contentTypeProto : contentTypeJson,
   );
   result.set(headerXGrpcWeb, "1");
-  // Note that we do not comply with recommended structure for the
-  // user-agent string.
-  // https://github.com/grpc/grpc/blob/c462bb8d485fc1434ecfae438823ca8d14cf3154/doc/PROTOCOL-HTTP2.md#user-agents
-  result.set(headerXUserAgent, "@bufbuild/connect-web");
+  // Note that we do not strictly comply with gRPC user agents.
+  // We use "connect-es/1.2.3" where gRPC would use "grpc-es/1.2.3".
+  // See https://github.com/grpc/grpc/blob/c462bb8d485fc1434ecfae438823ca8d14cf3154/doc/PROTOCOL-HTTP2.md#user-agents
+  result.set(headerXUserAgent, "CONNECT_ES_USER_AGENT");
   if (timeoutMs !== undefined) {
     result.set(headerTimeout, `${timeoutMs}m`);
   }

--- a/packages/connect/src/protocol-grpc/request-header.spec.ts
+++ b/packages/connect/src/protocol-grpc/request-header.spec.ts
@@ -34,7 +34,7 @@ describe("requestHeader", () => {
       "user-agent",
     ]);
     expect(headers.get("Content-Type")).toBe("application/grpc+proto");
-    expect(headers.get("User-Agent")).toBe("@bufbuild/connect-web");
+    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
   });
 
   it("should create request headers with timeout", () => {

--- a/packages/connect/src/protocol-grpc/request-header.ts
+++ b/packages/connect/src/protocol-grpc/request-header.ts
@@ -37,10 +37,10 @@ export function requestHeader(
     headerContentType,
     useBinaryFormat ? contentTypeProto : contentTypeJson,
   );
-  // Note that we do not comply with recommended structure for the
-  // user-agent string.
-  // https://github.com/grpc/grpc/blob/c462bb8d485fc1434ecfae438823ca8d14cf3154/doc/PROTOCOL-HTTP2.md#user-agents
-  result.set(headerUserAgent, "@bufbuild/connect-web");
+  // Note that we do not strictly comply with gRPC user agents.
+  // We use "connect-es/1.2.3" where gRPC would use "grpc-es/1.2.3".
+  // See https://github.com/grpc/grpc/blob/c462bb8d485fc1434ecfae438823ca8d14cf3154/doc/PROTOCOL-HTTP2.md#user-agents
+  result.set(headerUserAgent, "CONNECT_ES_USER_AGENT");
   if (timeoutMs !== undefined) {
     result.set(headerTimeout, `${timeoutMs}m`);
   }


### PR DESCRIPTION
Our user-agent for gRPC and gRPC-web has always been `@bufbuild/connect-web`. 

This updates the user-agent to include the version number with the pattern `connect-es/1.2.3`.