### PR TITLE
Skip .d.ts files in the migration CLI

### DIFF
--- a/packages/connect-migrate/README.md
+++ b/packages/connect-migrate/README.md
@@ -2,6 +2,9 @@
 
 This tool updates your Connect project to use the new `@connectrpc` packages.
 
+
+## Usage
+
 To migrate, run the following command in your project root directory:
 
 ```shell
@@ -23,6 +26,16 @@ This package is made up of a few migration steps
 
 We ignore all files within `node_modules` but will update any other files that 
 end with the following extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.cjs`, `.mjs`.
+
+
+## Prerequisites
+
+- Make sure that you have updated to the latest version of `@bufbuild/connect` and
+  related packages before you migrate.
+- Commit any unstaged changes to your project, so that you can revert in case the migration failed.
+- After migration, run your generate scripts to re-generate code with the latest
+  plugin versions.
+
 
 ## Alternative running methods
 

--- a/packages/connect-migrate/README.md
+++ b/packages/connect-migrate/README.md
@@ -13,21 +13,25 @@ npx @connectrpc/connect-migrate --help
 This package is made up of a few migration steps
 
 1. Updates `package.json` files to point to the new `@connectrpc` organization
-1. Updates references to these packages in any javascript/typescript files
-1. Runs the appropriate install command for your package manager
+1. Updates references to these packages in JavaScript and TypeScript files
+1. Runs the appropriate `install` command for your package manager
 
 ## What files are changed
 
-We ignore all files within node_modules but will update any other files that end with the following extensions: .ts, .tsx, .js, .jsx, .cjs, mjs.
+We ignore all files within `node_modules` but will update any other files that 
+end with the following extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.cjs`, `.mjs`.
 
 ## Alternative running methods
 
-This tool leverages jscodeshift in order to find all references to packages and update them. As a result, we've assumed a parser to parser your javascript/typescript files. If you see errors due to parsing,
-you may be using a custom babel config or another custom parser. You can work around this while leveraging
-our transforms by calling jscodeshift directly.
+This tool leverages jscodeshift in order to find all references to packages and 
+update them. As a result, we've assumed a parser to parse your JavaScript/TypeScript 
+files. If you see errors due to parsing, you may be using a custom babel config 
+or another custom parser. You can work around this while leveraging our 
+transforms by calling `jscodeshift` directly.
 
 ```shell
 npx jscodeshift -t ./node_modules/@connectrpc/connect-migrate/dist/cjs/transforms/modify-imports.js .
 ```
 
-And add any additional params you feel are necessary. You can find more information about jscodeshift [here](https://github.com/facebook/jscodeshift/blob/main/README.md#usage-cli)
+And add any additional params you feel are necessary. You can find more 
+information about `jscodeshift` [here](https://github.com/facebook/jscodeshift/blob/main/README.md#usage-cli).

--- a/packages/connect-migrate/README.md
+++ b/packages/connect-migrate/README.md
@@ -2,11 +2,14 @@
 
 This tool updates your Connect project to use the new `@connectrpc` packages.
 
-Usage:
+To migrate, run the following command in your project root directory:
 
 ```shell
-npx @connectrpc/connect-migrate --help
+npx @connectrpc/connect-migrate
 ```
+
+Add the `--help` flag to the command to learn more about the available flags.
+
 
 ## What it does
 

--- a/packages/connect-migrate/src/cli.ts
+++ b/packages/connect-migrate/src/cli.ts
@@ -29,9 +29,10 @@ const usage = `USAGE: connect-migrate
 Updates references to connect-es packages in your project to use @connectrpc.
 
 Options:
-  --version                   Print the version of connect-migrate.
   --ignore-pattern <pattern>  Glob pattern to ignore source and package files. Defaults to **/dist/**. Supports multiples.
   --no-install                Skip dependency installation after updating package.json files.
+  --version                   Print the version of connect-migrate.
+  --help                      Print this help.
 `;
 
 const logger = new Logger();

--- a/packages/connect-migrate/src/cli.ts
+++ b/packages/connect-migrate/src/cli.ts
@@ -25,10 +25,10 @@ import {
 import { Logger } from "./log";
 import modifyImports from "./transforms/modify-imports";
 
-const usage = `USAGE: connect-migrate
+const usage = `USAGE: connect-migrate [flags]
 Updates references to connect-es packages in your project to use @connectrpc.
 
-Options:
+Flags:
   --ignore-pattern <pattern>  Glob pattern to ignore source and package files. Defaults to **/dist/**. Supports multiples.
   --no-install                Skip dependency installation after updating package.json files.
   --version                   Print the version of connect-migrate.

--- a/packages/connect-migrate/src/scan.ts
+++ b/packages/connect-migrate/src/scan.ts
@@ -34,6 +34,7 @@ export function scan(ignorePatterns: string[], cwd: string, logger: Logger) {
       ...lockFilename.map((f) => `**/${f}`),
       // source files
       "**/*.ts",
+      "!**/*.d.ts",
       "**/*.js",
       "**/*.jsx",
       "**/*.cjs",


### PR DESCRIPTION
None of the jscodeshift parsers appear to support .d.ts files, so we skip them.

This also adds a "Prerequisites" section to the readme, and lightly updates the formatting.