### PR TITLE
Add defensive check for http2 sessions

### DIFF
--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -224,9 +224,8 @@ export class Http2SessionManager {
         return stream;
       } catch (e) {
         // Check to see if the connection is closed or destroyed
-        // and if so, move to closed state and try again.
+        // and if so, we try again.
         if (ready.conn.closed || ready.conn.destroyed) {
-          this.setState(closed());
           continue;
         }
         throw e;
@@ -265,7 +264,11 @@ export class Http2SessionManager {
 
   private async gotoReady() {
     if (this.s.t == "ready") {
-      if (this.s.isShuttingDown()) {
+      if (
+        this.s.isShuttingDown() ||
+        this.s.conn.closed ||
+        this.s.conn.destroyed
+      ) {
         this.setState(connect(this.authority, this.http2SessionOptions));
       } else if (this.s.requiresVerify()) {
         this.setState(


### PR DESCRIPTION
Add defensive check for http2 sessions. This should fix #683. The solution is similar to the one by @mustard-mh in #712 it checks if the session is destroyed/closed and moves to closed state and retries the request with a new connection.