### PR TITLE
Set User-Agent in gRPC-web clients on Node.js

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 112,445 b | 49,571 b | 13,348 b |
+| connect        | 112,509 b | 49,592 b | 13,389 b |
 | grpc-web       | 414,071 b    | 300,352 b    | 53,255 b |

--- a/packages/connect/scripts/update-user-agent.mjs
+++ b/packages/connect/scripts/update-user-agent.mjs
@@ -1,21 +1,31 @@
-import {readFileSync, writeFileSync} from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import assert from "node:assert";
 
-const placeholder = "CONNECT_ES_USER_AGENT";
-
 const paths = [
+  "dist/esm/protocol-connect/request-header.js",
   "dist/esm/protocol-grpc/request-header.js",
   "dist/esm/protocol-grpc-web/request-header.js",
+  "dist/cjs/protocol-connect/request-header.js",
   "dist/cjs/protocol-grpc/request-header.js",
   "dist/cjs/protocol-grpc-web/request-header.js",
 ];
 
-const {version} = JSON.parse(readFileSync(new URL("../package.json", import.meta.url).pathname, "utf-8"));
+const { version } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url).pathname, "utf-8"),
+);
 assert(typeof version == "string");
 assert(version.length >= 5);
 
+let replacements = 0;
 for (const path of paths) {
   const oldContent = readFileSync(path, "utf-8");
-  const newContent = oldContent.replace(placeholder, `connect-es/${version}`);
-  writeFileSync(path, newContent);
+  const newContent = oldContent.replace(
+    /CONNECT_ES_USER_AGENT/g,
+    `connect-es/${version}`,
+  );
+  if (oldContent !== newContent) {
+    writeFileSync(path, newContent);
+    replacements++;
+  }
 }
+assert(replacements > 0);

--- a/packages/connect/src/interceptor.spec.ts
+++ b/packages/connect/src/interceptor.spec.ts
@@ -62,6 +62,7 @@ function makeLoggingInterceptor(name: string, log: string[]): Interceptor {
       "connect-protocol-version",
       "content-type",
       "content-length",
+      "user-agent",
     ];
     const keys: string[] = [];
     header.forEach((_, key) => {

--- a/packages/connect/src/protocol-connect/get-request.ts
+++ b/packages/connect/src/protocol-connect/get-request.ts
@@ -73,12 +73,13 @@ export function transformConnectPostToGetRequest<
 
   // Omit headers that are not used for unary GET requests.
   const header = new Headers(request.header);
-  header.delete(headerProtocolVersion);
-  header.delete(headerContentType);
-  header.delete(headerUnaryContentLength);
-  header.delete(headerUnaryEncoding);
-  header.delete(headerUnaryAcceptEncoding);
-
+  [
+    headerProtocolVersion,
+    headerContentType,
+    headerUnaryContentLength,
+    headerUnaryEncoding,
+    headerUnaryAcceptEncoding,
+  ].forEach((h) => header.delete(h));
   return {
     ...request,
     init: {

--- a/packages/connect/src/protocol-connect/headers.ts
+++ b/packages/connect/src/protocol-connect/headers.ts
@@ -23,3 +23,4 @@ export const headerUnaryAcceptEncoding = "Accept-Encoding";
 export const headerStreamAcceptEncoding = "Connect-Accept-Encoding";
 export const headerTimeout = "Connect-Timeout-Ms";
 export const headerProtocolVersion = "Connect-Protocol-Version";
+export const headerUserAgent = "User-Agent";

--- a/packages/connect/src/protocol-connect/request-header.spec.ts
+++ b/packages/connect/src/protocol-connect/request-header.spec.ts
@@ -28,7 +28,7 @@ import {
 function listHeaderKeys(header: Headers): string[] {
   const keys: string[] = [];
   header.forEach((_, key) => keys.push(key));
-  return keys;
+  return keys.sort();
 }
 
 describe("requestHeader", () => {
@@ -37,9 +37,11 @@ describe("requestHeader", () => {
     expect(listHeaderKeys(headers)).toEqual([
       "connect-protocol-version",
       "content-type",
+      "user-agent",
     ]);
     expect(headers.get("Content-Type")).toBe("application/proto");
     expect(headers.get("Connect-Protocol-Version")).toBe("1");
+    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
   });
 
   it("should create request headers with timeout", () => {
@@ -48,6 +50,7 @@ describe("requestHeader", () => {
       "connect-protocol-version",
       "connect-timeout-ms",
       "content-type",
+      "user-agent",
     ]);
     expect(headers.get("Connect-Timeout-Ms")).toBe("10");
   });
@@ -75,6 +78,7 @@ describe("requestHeaderWithCompression", () => {
       "connect-protocol-version",
       "content-encoding",
       "content-type",
+      "user-agent",
     ]);
     expect(headers.get(headerUnaryEncoding)).toBe(compressionMock.name);
     expect(headers.get(headerUnaryAcceptEncoding)).toBe(compressionMock.name);
@@ -94,6 +98,7 @@ describe("requestHeaderWithCompression", () => {
       "connect-content-encoding",
       "connect-protocol-version",
       "content-type",
+      "user-agent",
     ]);
     expect(headers.get(headerStreamEncoding)).toBe(compressionMock.name);
     expect(headers.get(headerStreamAcceptEncoding)).toBe(compressionMock.name);

--- a/packages/connect/src/protocol-connect/request-header.ts
+++ b/packages/connect/src/protocol-connect/request-header.ts
@@ -21,6 +21,7 @@ import {
   headerUnaryEncoding,
   headerTimeout,
   headerProtocolVersion,
+  headerUserAgent,
 } from "./headers.js";
 import { protocolVersion } from "./version.js";
 import {
@@ -57,6 +58,7 @@ export function requestHeader(
       : contentTypeStreamJson,
   );
   result.set(headerProtocolVersion, protocolVersion);
+  result.set(headerUserAgent, "CONNECT_ES_USER_AGENT");
   return result;
 }
 

--- a/packages/connect/src/protocol-connect/transport.spec.ts
+++ b/packages/connect/src/protocol-connect/transport.spec.ts
@@ -36,8 +36,8 @@ import { createEndStreamSerialization, endStreamFlag } from "./end-stream.js";
 import { Code } from "../code.js";
 import {
   contentTypeStreamProto,
-  contentTypeUnaryProto,
   contentTypeUnaryJson,
+  contentTypeUnaryProto,
 } from "./content-type.js";
 import { errorToJsonBytes } from "./error-json.js";
 import { createHandlerFactory } from "./handler-factory.js";
@@ -235,7 +235,7 @@ describe("Connect transport", function () {
       // no headers
       const headerFields: string[] = [];
       request.header.forEach((_, key) => headerFields.push(key));
-      expect(headerFields).toEqual([]);
+      expect(headerFields).toEqual(["user-agent"]);
       // no body
       expect(request.body).toBeUndefined();
       return httpClientResponse;

--- a/packages/connect/src/protocol-grpc-web/headers.ts
+++ b/packages/connect/src/protocol-grpc-web/headers.ts
@@ -23,6 +23,7 @@ export {
   headerGrpcStatus,
   headerGrpcMessage,
   headerStatusDetailsBin,
+  headerUserAgent,
 } from "../protocol-grpc/headers.js";
 
 /**

--- a/packages/connect/src/protocol-grpc-web/request-header.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.spec.ts
@@ -25,7 +25,7 @@ import {
 function listHeaderKeys(header: Headers): string[] {
   const keys: string[] = [];
   header.forEach((_, key) => keys.push(key));
-  return keys;
+  return keys.sort();
 }
 
 describe("requestHeader", () => {
@@ -33,11 +33,13 @@ describe("requestHeader", () => {
     const headers = requestHeader(true, undefined, undefined);
     expect(listHeaderKeys(headers)).toEqual([
       "content-type",
+      "user-agent",
       "x-grpc-web",
       "x-user-agent",
     ]);
     expect(headers.get("Content-Type")).toBe("application/grpc-web+proto");
     expect(headers.get("X-User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
+    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
     expect(headers.get("X-Grpc-Web")).toBe("1");
   });
 
@@ -46,6 +48,7 @@ describe("requestHeader", () => {
     expect(listHeaderKeys(headers)).toEqual([
       "content-type",
       "grpc-timeout",
+      "user-agent",
       "x-grpc-web",
       "x-user-agent",
     ]);
@@ -70,6 +73,7 @@ describe("requestHeader", () => {
       "content-type",
       "grpc-accept-encoding",
       "grpc-encoding",
+      "user-agent",
       "x-grpc-web",
       "x-user-agent",
     ]);

--- a/packages/connect/src/protocol-grpc-web/request-header.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.ts
@@ -18,6 +18,7 @@ import {
   headerEncoding,
   headerTimeout,
   headerXGrpcWeb,
+  headerUserAgent,
   headerXUserAgent,
 } from "./headers.js";
 import { contentTypeJson, contentTypeProto } from "./content-type.js";
@@ -45,6 +46,7 @@ export function requestHeader(
   // We use "connect-es/1.2.3" where gRPC would use "grpc-es/1.2.3".
   // See https://github.com/grpc/grpc/blob/c462bb8d485fc1434ecfae438823ca8d14cf3154/doc/PROTOCOL-HTTP2.md#user-agents
   result.set(headerXUserAgent, "CONNECT_ES_USER_AGENT");
+  result.set(headerUserAgent, "CONNECT_ES_USER_AGENT");
   if (timeoutMs !== undefined) {
     result.set(headerTimeout, `${timeoutMs}m`);
   }

--- a/packages/connect/src/protocol-grpc/headers.ts
+++ b/packages/connect/src/protocol-grpc/headers.ts
@@ -22,5 +22,5 @@ export const headerTimeout = "Grpc-Timeout";
 export const headerGrpcStatus = "Grpc-Status";
 export const headerGrpcMessage = "Grpc-Message";
 export const headerStatusDetailsBin = "Grpc-Status-Details-Bin";
-export const headerUserAgent = "User-Agent";
 export const headerMessageType = "Grpc-Message-Type";
+export const headerUserAgent = "User-Agent";

--- a/packages/connect/src/protocol-grpc/request-header.spec.ts
+++ b/packages/connect/src/protocol-grpc/request-header.spec.ts
@@ -22,7 +22,7 @@ import { headerEncoding, headerAcceptEncoding } from "./headers.js";
 function listHeaderKeys(header: Headers): string[] {
   const keys: string[] = [];
   header.forEach((_, key) => keys.push(key));
-  return keys;
+  return keys.sort();
 }
 
 describe("requestHeader", () => {


### PR DESCRIPTION
gRPC-web clients already set the `X-User-Agent` request header. Browsers set their own `User-Agent` header, but that is not the case on Node.js. This PR makes sure to set the `User-Agent` header as well when possible.