### PR TITLE
Clarify usage with the Next.js App Router

### DIFF
--- a/packages/connect-next/README.md
+++ b/packages/connect-next/README.md
@@ -21,7 +21,11 @@ add two files to your project:
         └── [[...connect]].ts
 ```
 
-`connect.ts` is where you register your RPCs:
+> Note: Next.js 13 introduced the new App Router. Your Connect API routes need 
+> to be placed in `pages/`, but you can use the `app/` directory for the App 
+> Router at the same time.
+
+The new file `connect.ts` is where you register your RPCs:
 
 ```ts
 // connect.ts

--- a/packages/connect-next/README.md
+++ b/packages/connect-next/README.md
@@ -21,9 +21,9 @@ add two files to your project:
         └── [[...connect]].ts
 ```
 
-> Note: Next.js 13 introduced the new App Router. Your Connect API routes need 
-> to be placed in `pages/`, but you can use the `app/` directory for the App 
-> Router at the same time.
+> **Note:** Next.js 13 introduced the new App Router. Your Connect API routes 
+> need to be placed in `pages/`, but you can use the `app/` directory for the 
+> App Router at the same time.
 
 The new file `connect.ts` is where you register your RPCs:
 


### PR DESCRIPTION
Add the following note to the README for [@connectrpc/connect-next](https://www.npmjs.com/package/@connectrpc/connect-next):

> Note: Next.js 13 introduced the new App Router. Your Connect API routes need 
> to be placed in `pages/`, but you can use the `app/` directory for the App 
> Router at the same time.
