### PR TITLE
Add support for server side interceptors

### DIFF
--- a/packages/connect/src/implementation.spec.ts
+++ b/packages/connect/src/implementation.spec.ts
@@ -12,12 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createHandlerContext } from "./implementation.js";
+import {
+  createHandlerContext,
+  createMethodImplSpec,
+} from "./implementation.js";
+import type {
+  BiDiStreamingImpl,
+  ClientStreamingImpl,
+  ServerStreamingImpl,
+  UnaryImpl,
+} from "./method-implementation.js";
 import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
 
 const TestService = {
   typeName: "handwritten.TestService",
   methods: {
+    biDiStreaming: {
+      name: "BiDiStreaming",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.BiDiStreaming,
+    },
+    clientStreaming: {
+      name: "ClientStreaming",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ClientStreaming,
+    },
+    serverStreaming: {
+      name: "ServerStreaming",
+      I: Int32Value,
+      O: StringValue,
+      kind: MethodKind.ServerStreaming,
+    },
     unary: {
       name: "Unary",
       I: Int32Value,
@@ -110,5 +137,187 @@ describe("createHandlerContext()", function () {
     expect(ctx.requestHeader.get("foo")).toBe("request");
     expect(ctx.responseHeader.get("foo")).toBe("response");
     expect(ctx.responseTrailer.get("foo")).toBe("trailer");
+  });
+});
+
+describe("createMethodImplSpec()", function () {
+  const context = createHandlerContext({
+    service: TestService,
+    method: TestService.methods.unary,
+    protocolName: "foo",
+    requestMethod: "GET",
+  });
+
+  it("should handle no interceptors", async function () {
+    const spec = createMethodImplSpec(
+      TestService,
+      TestService.methods.unary,
+      function (request) {
+        expect(request.value).toBe(13);
+        return new StringValue({ value: "response" });
+      },
+      [],
+    );
+    const impl = spec.impl as UnaryImpl<Int32Value, StringValue>;
+    const response = await impl(new Int32Value({ value: 13 }), context);
+    expect(response.value).toBe("response");
+  });
+
+  it("should chain in order", async function () {
+    const state: { calls: number[] } = { calls: [] };
+    const spec = createMethodImplSpec(
+      TestService,
+      TestService.methods.unary,
+      function () {
+        return new StringValue({ value: "response" });
+      },
+      [
+        {
+          unary: function (request, context, next) {
+            state.calls.push(1);
+            return next(request, context);
+          },
+        },
+        {
+          unary: function (request, context, next) {
+            state.calls.push(2);
+            return next(request, context);
+          },
+        },
+      ],
+    );
+    const impl = spec.impl as UnaryImpl<Int32Value, StringValue>;
+    await impl(new Int32Value({ value: 9 }), context);
+    expect(state.calls).toEqual([1, 2]);
+  });
+
+  it("should override response", async function () {
+    const spec = createMethodImplSpec(
+      TestService,
+      TestService.methods.unary,
+      function () {
+        return new StringValue({ value: "response" });
+      },
+      [
+        {
+          unary: async function (request, context, next) {
+            return new StringValue({
+              value: "saw " + (await next(request, context)).value,
+            });
+          },
+        },
+      ],
+    );
+    const impl = spec.impl as UnaryImpl<Int32Value, StringValue>;
+    const response = await impl(new Int32Value({ value: 9 }), context);
+    expect(response.value).toBe("saw response");
+  });
+
+  it("should support bidi streaming", async function () {
+    const state: { calls: unknown[] } = { calls: [] };
+    const spec = createMethodImplSpec(
+      TestService,
+      TestService.methods.biDiStreaming,
+      async function* (requests) {
+        for await (const request of requests) {
+          yield new StringValue({ value: `response for ${request.value}` });
+        }
+      },
+      [
+        {
+          biDiStreaming: async function* (requests, context, next) {
+            const intercept = {
+              async *[Symbol.asyncIterator]() {
+                for await (const request of requests) {
+                  state.calls.push(request.value);
+                  yield request;
+                }
+              },
+            };
+            yield* next(intercept, context);
+          },
+        },
+      ],
+    );
+    const impl = spec.impl as BiDiStreamingImpl<Int32Value, StringValue>;
+    const requests = {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *[Symbol.asyncIterator]() {
+        yield new Int32Value({ value: 1 });
+        yield new Int32Value({ value: 2 });
+      },
+    };
+    const responses = [];
+    for await (const response of impl(requests, context)) {
+      responses.push(response.value);
+    }
+    expect(responses).toEqual(["response for 1", "response for 2"]);
+  });
+
+  it("should support client streaming", async function () {
+    const state: { calls: unknown[] } = { calls: [] };
+    const spec = createMethodImplSpec(
+      TestService,
+      TestService.methods.clientStreaming,
+      async function (requests) {
+        const values = [];
+        for await (const request of requests) {
+          values.push(request.value);
+        }
+        return new StringValue({ value: values.join(", ") });
+      },
+      [
+        {
+          clientStreaming: async function (requests, context, next) {
+            const intercept = {
+              async *[Symbol.asyncIterator]() {
+                for await (const request of requests) {
+                  state.calls.push(request.value);
+                  yield request;
+                }
+              },
+            };
+            return next(intercept, context);
+          },
+        },
+      ],
+    );
+    const impl = spec.impl as ClientStreamingImpl<Int32Value, StringValue>;
+    const requests = {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *[Symbol.asyncIterator]() {
+        yield new Int32Value({ value: 1 });
+        yield new Int32Value({ value: 2 });
+      },
+    };
+    const response = await impl(requests, context);
+    expect(response.value).toBe("1, 2");
+  });
+
+  it("should support server streaming", async function () {
+    const spec = createMethodImplSpec(
+      TestService,
+      TestService.methods.serverStreaming,
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async function* (request) {
+        yield new StringValue({ value: `first ${request.value}` });
+        yield new StringValue({ value: `second ${request.value}` });
+      },
+      [
+        {
+          serverStreaming: async function* (requests, context, next) {
+            for await (const response of next(requests, context)) {
+              yield new StringValue({ value: `saw ${response.value}` });
+            }
+          },
+        },
+      ],
+    );
+    const impl = spec.impl as ServerStreamingImpl<Int32Value, StringValue>;
+    const responses = [];
+    for await (const response of impl(new Int32Value({ value: 9 }), context)) {
+      responses.push(response.value);
+    }
+    expect(responses).toEqual(["saw first 9", "saw second 9"]);
   });
 });

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -38,10 +38,11 @@ export type {
 } from "./interceptor.js";
 
 export type {
-  ServiceImpl,
   MethodImpl,
   HandlerContext,
-} from "./implementation.js";
+  TypedMethodInfo,
+} from "./method-implementation.js";
+export type { ServiceImpl } from "./implementation.js";
 export { createConnectRouter } from "./router.js";
 export type { ConnectRouter, ConnectRouterOptions } from "./router.js";
 export { createHandlerContext } from "./implementation.js";

--- a/packages/connect/src/interceptor.spec.ts
+++ b/packages/connect/src/interceptor.spec.ts
@@ -15,7 +15,7 @@
 import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
 import type { Interceptor, StreamResponse } from "./interceptor.js";
 import { createRouterTransport } from "./router-transport.js";
-import type { HandlerContext } from "./implementation.js";
+import type { HandlerContext } from "./method-implementation.js";
 import { createAsyncIterable } from "./protocol/async-iterable.js";
 
 function makeLoggingInterceptor(name: string, log: string[]): Interceptor {

--- a/packages/connect/src/method-implementation.ts
+++ b/packages/connect/src/method-implementation.ts
@@ -1,0 +1,141 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  AnyMessage,
+  Message,
+  MessageType,
+  MethodIdempotency,
+  MethodInfo,
+  MethodKind,
+  PartialMessage,
+  ServiceType,
+} from "@bufbuild/protobuf";
+
+/**
+ * Context for an RPC on the server. Every RPC implementation can accept a
+ * HandlerContext as an argument to gain access to headers and service metadata.
+ */
+export interface HandlerContext {
+  /**
+   * Metadata for the method being called.
+   */
+  readonly method: MethodInfo;
+
+  /**
+   * Metadata for the service being called.
+   */
+  readonly service: ServiceType;
+
+  /**
+   * An AbortSignal that is aborted when the connection with the client is closed
+   * or when the deadline is reached.
+   *
+   * The signal can be used to automatically cancel downstream calls.
+   */
+  readonly signal: AbortSignal;
+
+  /**
+   * If the current request has a timeout, this function returns the remaining
+   * time.
+   */
+  readonly timeoutMs: () => number | undefined;
+
+  /**
+   * HTTP method of incoming request, usually "POST", but "GET" in the case of
+   * Connect Get.
+   */
+  readonly requestMethod: string;
+
+  /**
+   * Incoming request headers.
+   */
+  readonly requestHeader: Headers;
+
+  /**
+   * Outgoing response headers.
+   *
+   * For methods that return a stream, response headers must be set before
+   * yielding the first response message.
+   */
+  readonly responseHeader: Headers;
+
+  /**
+   * Outgoing response trailers.
+   */
+  readonly responseTrailer: Headers;
+
+  /**
+   * Name of the RPC protocol in use; one of "connect", "grpc" or "grpc-web".
+   */
+  readonly protocolName: string;
+}
+
+// prettier-ignore
+/**
+ * MethodImpl is the signature of the implementation of an RPC.
+ */
+export type MethodImpl<M extends TypedMethodInfo> =
+    M extends TypedMethodInfo<infer I, infer O, MethodKind.Unary>           ? UnaryImpl<I, O>
+  : M extends TypedMethodInfo<infer I, infer O, MethodKind.ServerStreaming> ? ServerStreamingImpl<I, O>
+  : M extends TypedMethodInfo<infer I, infer O, MethodKind.ClientStreaming> ? ClientStreamingImpl<I, O>
+  : M extends TypedMethodInfo<infer I, infer O, MethodKind.BiDiStreaming>   ? BiDiStreamingImpl<I, O>
+  : never;
+
+export interface TypedMethodInfo<
+  I extends Message<I> = AnyMessage,
+  O extends Message<O> = AnyMessage,
+  K extends MethodKind = MethodKind,
+> {
+  readonly kind: K;
+  readonly name: string;
+  readonly I: MessageType<I>;
+  readonly O: MessageType<O>;
+  readonly idempotency?: MethodIdempotency;
+}
+
+/**
+ * UnaryImp is the signature of the implementation of a unary RPC.
+ */
+export type UnaryImpl<I extends Message<I>, O extends Message<O>> = (
+  request: I,
+  context: HandlerContext,
+) => Promise<O | PartialMessage<O>> | O | PartialMessage<O>;
+
+/**
+ * ClientStreamingImpl is the signature of the implementation of a
+ * client-streaming RPC.
+ */
+export type ClientStreamingImpl<I extends Message<I>, O extends Message<O>> = (
+  requests: AsyncIterable<I>,
+  context: HandlerContext,
+) => Promise<O | PartialMessage<O>>;
+
+/**
+ * ServerStreamingImpl is the signature of the implementation of a
+ * server-streaming RPC.
+ */
+export type ServerStreamingImpl<I extends Message<I>, O extends Message<O>> = (
+  request: I,
+  context: HandlerContext,
+) => AsyncIterable<O | PartialMessage<O>>;
+
+/**
+ * BiDiStreamingImpl is the signature of the implementation of a bi-di
+ * streaming RPC.
+ */
+export type BiDiStreamingImpl<I extends Message<I>, O extends Message<O>> = (
+  requests: AsyncIterable<I>,
+  context: HandlerContext,
+) => AsyncIterable<O | PartialMessage<O>>;

--- a/packages/connect/src/promise-client.spec.ts
+++ b/packages/connect/src/promise-client.spec.ts
@@ -20,7 +20,7 @@ import {
 } from "./promise-client.js";
 import { createAsyncIterable } from "./protocol/async-iterable.js";
 import { createRouterTransport } from "./router-transport.js";
-import type { HandlerContext } from "./implementation";
+import type { HandlerContext } from "./method-implementation";
 import { ConnectError } from "./connect-error.js";
 import { Code } from "./code.js";
 

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -22,7 +22,7 @@ import {
   StringValue,
 } from "@bufbuild/protobuf";
 import { createHandlerFactory } from "./handler-factory.js";
-import type { MethodImpl } from "../implementation.js";
+import type { MethodImpl } from "../method-implementation.js";
 import { createMethodImplSpec } from "../implementation.js";
 import type {
   UniversalHandlerOptions,
@@ -77,7 +77,7 @@ describe("createHandlerFactory()", function () {
     impl: MethodImpl<M>,
   ) {
     const h = createHandlerFactory(opt)(
-      createMethodImplSpec(testService, method, impl),
+      createMethodImplSpec(testService, method, impl, []),
     );
     const t = createTransport({
       httpClient: createUniversalHandlerClient([h]),
@@ -593,9 +593,14 @@ describe("createHandlerFactory()", function () {
 
     function setupTestHandler(opt: Partial<UniversalHandlerOptions>) {
       const h = createHandlerFactory(opt)(
-        createMethodImplSpec(NewService, OldService.methods.unary, () => {
-          return new StringValue({ value: "server ok" });
-        }),
+        createMethodImplSpec(
+          NewService,
+          OldService.methods.unary,
+          () => {
+            return new StringValue({ value: "server ok" });
+          },
+          [],
+        ),
       );
       const t = createTransport({
         httpClient: createUniversalHandlerClient([h]),

--- a/packages/connect/src/protocol-connect/transport.spec.ts
+++ b/packages/connect/src/protocol-connect/transport.spec.ts
@@ -339,6 +339,7 @@ describe("Connect transport", function () {
             b: "B",
           });
         },
+        [],
       ),
     );
     const httpClient = createUniversalHandlerClient([h]);

--- a/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
@@ -14,7 +14,7 @@
 
 import type { MethodInfo, ServiceType } from "@bufbuild/protobuf";
 import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
-import type { MethodImpl } from "../implementation.js";
+import type { MethodImpl } from "../method-implementation.js";
 import { createMethodImplSpec } from "../implementation.js";
 import { Code, ConnectError } from "../index.js";
 import type { UniversalHandlerOptions } from "../protocol/index.js";
@@ -55,7 +55,7 @@ describe("createHandlerFactory()", function () {
     impl: MethodImpl<M>,
   ) {
     const h = createHandlerFactory(opt)(
-      createMethodImplSpec(testService, method, impl),
+      createMethodImplSpec(testService, method, impl, []),
     );
     const t = createTransport({
       httpClient: createUniversalHandlerClient([h]),

--- a/packages/connect/src/protocol-grpc/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.spec.ts
@@ -14,7 +14,7 @@
 
 import type { MethodInfo, ServiceType } from "@bufbuild/protobuf";
 import { Int32Value, MethodKind, StringValue } from "@bufbuild/protobuf";
-import type { MethodImpl } from "../implementation.js";
+import type { MethodImpl } from "../method-implementation.js";
 import { createMethodImplSpec } from "../implementation.js";
 import type { UniversalHandlerOptions } from "../protocol/index.js";
 import {
@@ -55,7 +55,7 @@ describe("createHandlerFactory()", function () {
     impl: MethodImpl<M>,
   ) {
     const h = createHandlerFactory(opt)(
-      createMethodImplSpec(testService, method, impl),
+      createMethodImplSpec(testService, method, impl, []),
     );
     const t = createTransport({
       httpClient: createUniversalHandlerClient([h]),

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -99,6 +99,10 @@ export {
   uResponseMethodNotAllowed,
   uResponseVersionNotSupported,
 } from "./universal.js";
+export type {
+  InterceptorImpl,
+  UniversalInterceptor,
+} from "./universal-interceptor.js";
 export {
   validateUniversalHandlerOptions,
   createUniversalServiceHandlers,

--- a/packages/connect/src/protocol/invoke-implementation.ts
+++ b/packages/connect/src/protocol/invoke-implementation.ts
@@ -15,7 +15,8 @@
 import { Message, MethodKind } from "@bufbuild/protobuf";
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";
-import type { HandlerContext, MethodImplSpec } from "../implementation.js";
+import type { HandlerContext } from "../method-implementation.js";
+import type { MethodImplSpec } from "../implementation.js";
 import type { AsyncIterableTransform } from "./async-iterable.js";
 import { normalize, normalizeIterable } from "./normalize.js";
 

--- a/packages/connect/src/protocol/universal-interceptor.ts
+++ b/packages/connect/src/protocol/universal-interceptor.ts
@@ -1,0 +1,55 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { AnyMessage } from "@bufbuild/protobuf";
+import { MethodKind } from "@bufbuild/protobuf";
+import type { MethodImpl, TypedMethodInfo } from "../method-implementation";
+
+export type InterceptorImpl<M extends TypedMethodInfo> = (
+  ...args: [...Parameters<MethodImpl<M>>, MethodImpl<M>]
+) => ReturnType<MethodImpl<M>>;
+
+/**
+ * Intercepts requests and responses for all RPCs in a router and allows
+ * modifying behavior.
+ */
+export interface UniversalInterceptor {
+  /**
+   * The handler for streaming client and streaming server calls.
+   */
+  biDiStreaming?: InterceptorImpl<
+    TypedMethodInfo<AnyMessage, AnyMessage, MethodKind.BiDiStreaming>
+  >;
+
+  /**
+   * The handler for streaming client and streaming server calls.
+   */
+  clientStreaming?: InterceptorImpl<
+    TypedMethodInfo<AnyMessage, AnyMessage, MethodKind.ClientStreaming>
+  >;
+
+  /**
+   * The handler for unary client and streaming server calls.
+   */
+  serverStreaming?: InterceptorImpl<
+    TypedMethodInfo<AnyMessage, AnyMessage, MethodKind.ServerStreaming>
+  >;
+
+  /**
+   * The handler for unary client and unary server calls.
+   */
+  unary?: InterceptorImpl<
+    TypedMethodInfo<AnyMessage, AnyMessage, MethodKind.Unary>
+  >;
+}


### PR DESCRIPTION
(Hopefully) fixes https://github.com/connectrpc/connect-es/issues/527

* I spent a bunch of time trying to minimize the couple of casts, I think ultimately since MethodImpl is polymorphic it's inevitable to need this type of casting.
* I don't love that interceptors are a property of the `ConnectRouterOptions`, originally I was going to put them on the `ConnectRouter`. However they cannot be on `ConnectRouter` because it immediately sets up registered methods and interceptors have to be bound inside `createMethodImplSpec` (to be explicit, if you register a method and then add an interceptor afterwards the method wouldn't be intercepted.) It would be a larger and relatively pointless refactor to make it all lazy. Putting it on `ConnectRouterOptions` just means that all interceptors will be set prior to any methods being registered.

Thank you for open sourcing this fantastic set of libraries!