### PR TITLE
Relax the tests for connect version numbers in user agent header fields

### DIFF
--- a/packages/connect/src/protocol-connect/request-header.spec.ts
+++ b/packages/connect/src/protocol-connect/request-header.spec.ts
@@ -41,7 +41,7 @@ describe("requestHeader", () => {
     ]);
     expect(headers.get("Content-Type")).toBe("application/proto");
     expect(headers.get("Connect-Protocol-Version")).toBe("1");
-    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
+    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+/);
   });
 
   it("should create request headers with timeout", () => {

--- a/packages/connect/src/protocol-grpc-web/request-header.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/request-header.spec.ts
@@ -38,8 +38,8 @@ describe("requestHeader", () => {
       "x-user-agent",
     ]);
     expect(headers.get("Content-Type")).toBe("application/grpc-web+proto");
-    expect(headers.get("X-User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
-    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
+    expect(headers.get("X-User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+/);
+    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+/);
     expect(headers.get("X-Grpc-Web")).toBe("1");
   });
 

--- a/packages/connect/src/protocol-grpc/request-header.spec.ts
+++ b/packages/connect/src/protocol-grpc/request-header.spec.ts
@@ -34,7 +34,7 @@ describe("requestHeader", () => {
       "user-agent",
     ]);
     expect(headers.get("Content-Type")).toBe("application/grpc+proto");
-    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+$/);
+    expect(headers.get("User-Agent")).toMatch(/^connect-es\/\d+\.\d+\.\d+/);
   });
 
   it("should create request headers with timeout", () => {


### PR DESCRIPTION
Clients set a user agent that includes the connect-es version number.

This relaxes the tests, so that they will not fail for valid version number we may use in the future, such as 1.0.0-rc.1