### PR TITLE
Make`@connectrpc/connect` a peer dependency and pin the version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8100,32 +8100,30 @@
       "name": "@connectrpc/connect-express",
       "version": "0.13.2",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@connectrpc/connect": "0.13.2",
-        "@connectrpc/connect-node": "^0.13.2",
+      "devDependencies": {
         "@types/express": "^4.17.17"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
+        "@bufbuild/protobuf": "^1.2.1",
+        "@connectrpc/connect": "0.13.2",
+        "@connectrpc/connect-node": "0.13.2"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
       "version": "0.13.2",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@connectrpc/connect": "0.13.2",
-        "@connectrpc/connect-node": "^0.13.2",
-        "fastify": "^4.22.1"
-      },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
+        "@bufbuild/protobuf": "^1.2.1",
+        "@connectrpc/connect": "0.13.2",
+        "@connectrpc/connect-node": "0.13.2",
+        "fastify": "^4.22.1"
       }
     },
     "packages/connect-migrate": {
@@ -8151,15 +8149,13 @@
       "name": "@connectrpc/connect-next",
       "version": "0.13.2",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@connectrpc/connect": "0.13.2",
-        "@connectrpc/connect-node": "^0.13.2"
-      },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.2.1",
+        "@connectrpc/connect": "0.13.2",
+        "@connectrpc/connect-node": "0.13.2",
         "next": "^13.2.4"
       }
     },
@@ -8168,7 +8164,6 @@
       "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@connectrpc/connect": "0.13.2",
         "undici": "^5.23.0"
       },
       "devDependencies": {
@@ -8179,7 +8174,8 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
+        "@bufbuild/protobuf": "^1.2.1",
+        "@connectrpc/connect": "0.13.2"
       }
     },
     "packages/connect-node-test": {
@@ -8203,11 +8199,9 @@
       "name": "@connectrpc/connect-web",
       "version": "0.13.2",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@connectrpc/connect": "0.13.2"
-      },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
+        "@bufbuild/protobuf": "^1.2.1",
+        "@connectrpc/connect": "0.13.2"
       }
     },
     "packages/connect-web-bench": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8100,7 +8100,7 @@
       "name": "@connectrpc/connect-express",
       "version": "0.13.2",
       "license": "Apache-2.0",
-      "devDependencies": {
+      "dependencies": {
         "@types/express": "^4.17.17"
       },
       "engines": {

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -25,13 +25,13 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "dependencies": {
-    "@connectrpc/connect": "0.13.2",
-    "@connectrpc/connect-node": "^0.13.2",
+  "devDependencies": {
     "@types/express": "^4.17.17"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.2.1"
+    "@bufbuild/protobuf": "^1.2.1",
+    "@connectrpc/connect": "0.13.2",
+    "@connectrpc/connect-node": "0.13.2"
   },
   "files": [
     "dist/**"

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "devDependencies": {
+  "dependencies": {
     "@types/express": "^4.17.17"
   },
   "peerDependencies": {

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -25,13 +25,11 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "dependencies": {
-    "@connectrpc/connect": "0.13.2",
-    "@connectrpc/connect-node": "^0.13.2",
-    "fastify": "^4.22.1"
-  },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.2.1"
+    "@bufbuild/protobuf": "^1.2.1",
+    "fastify": "^4.22.1",
+    "@connectrpc/connect": "0.13.2",
+    "@connectrpc/connect-node": "0.13.2"
   },
   "files": [
     "dist/**"

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -25,13 +25,11 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "dependencies": {
-    "@connectrpc/connect": "0.13.2",
-    "@connectrpc/connect-node": "^0.13.2"
-  },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.2.1",
-    "next": "^13.2.4"
+    "next": "^13.2.4",
+    "@connectrpc/connect": "0.13.2",
+    "@connectrpc/connect-node": "0.13.2"
   },
   "files": [
     "dist/**"

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -26,11 +26,11 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@connectrpc/connect": "0.13.2",
     "undici": "^5.23.0"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.2.1"
+    "@bufbuild/protobuf": "^1.2.1",
+    "@connectrpc/connect": "0.13.2"
   },
   "devDependencies": {
     "@types/jasmine": "^4.3.5",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -22,11 +22,9 @@
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js"
   },
-  "dependencies": {
-    "@connectrpc/connect": "0.13.2"
-  },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.2.1"
+    "@bufbuild/protobuf": "^1.2.1",
+    "@connectrpc/connect": "0.13.2"
   },
   "files": [
     "dist/**"


### PR DESCRIPTION
Using both `@connectrpc/connect-node` and `@connectrpc/connect-web` can result in two different versions of `@connectrpc/connect`. To avoid this we make `@connectrpc/connect` a peer dependency and pin to an exact version. This way users will be forced to use the same version for all packages.