### PR TITLE
Fix connect-swift link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The libraries and the generated code are compatible with ES2017 and TypeScript 4
   TypeScript-first expansion pack for TanStack Query that gives you Protobuf superpowers
 * [connect-playwright-es](https://github.com/connectrpc/connect-playwright-es):
   Playwright tests for your Connect application
-* [connect-swift](https://github.com/bufbuild/connect-swift):
+* [connect-swift](https://github.com/connectrpc/connect-swift):
   Idiomatic gRPC & Connect RPCs for Swift
 * [connect-go](https://github.com/connectrpc/connect-go):
   Go implementation of gRPC, gRPC-Web, and Connect

--- a/packages/connect-web-test/src/gen/connectrpc/eliza/v1/eliza_connect.ts
+++ b/packages/connect-web-test/src/gen/connectrpc/eliza/v1/eliza_connect.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 /* eslint-disable */
 
 import { ConverseRequest, ConverseResponse, IntroduceRequest, IntroduceResponse, SayRequest, SayResponse } from "./eliza_pb.js";
-import { MethodKind } from "@bufbuild/protobuf";
+import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
 
 /**
  * ElizaService provides a way to talk to Eliza, a port of the DOCTOR script
@@ -42,6 +42,7 @@ export const ElizaService = {
       I: SayRequest,
       O: SayResponse,
       kind: MethodKind.Unary,
+      idempotency: MethodIdempotency.NoSideEffects,
     },
     /**
      * Converse is a bidirectional RPC. The caller may exchange multiple

--- a/packages/connect-web-test/src/gen/connectrpc/eliza/v1/eliza_pb.ts
+++ b/packages/connect-web-test/src/gen/connectrpc/eliza/v1/eliza_pb.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This fixes a link to the new connect-swift repo in connectrpc.