### PR TITLE
Update reference to eliza

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ $(GEN)/connect: node_modules/.bin/protoc-gen-es packages/connect/buf.gen.yaml $(
 $(GEN)/connect-web-test: node_modules/.bin/protoc-gen-es $(BUILD)/protoc-gen-connect-es packages/connect-web-test/buf.gen.yaml Makefile
 	rm -rf packages/connect-web-test/src/gen/*
 	npm run -w packages/connect-web-test generate https://github.com/connectrpc/conformance.git#ref=$(CONFORMANCE_VERSION),subdir=proto
-	npm run -w packages/connect-web-test generate buf.build/connectrpc/eliza
+	npm run -w packages/connect-web-test generate buf.build/connectrpc/eliza:8bde2b90ec0a7f23df3de5824bed0b6ea2043305
 	@mkdir -p $(@D)
 	@touch $(@)
 
@@ -143,7 +143,7 @@ $(GEN)/connect-node-test: node_modules/.bin/protoc-gen-es $(BUILD)/protoc-gen-co
 
 $(GEN)/connect-web-bench: node_modules/.bin/protoc-gen-es $(BUILD)/protoc-gen-connect-es packages/connect-web-bench/buf.gen.yaml Makefile
 	rm -rf packages/connect-web-bench/src/gen/*
-	npm run -w packages/connect-web-bench generate buf.build/connectrpc/eliza:d8fbf2620c604277a0ece1ff3a26f2ff
+	npm run -w packages/connect-web-bench generate buf.build/connectrpc/eliza:8bde2b90ec0a7f23df3de5824bed0b6ea2043305
 	@mkdir -p $(@D)
 	@touch $(@)
 

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 113,400 b | 49,846 b | 13,473 b |
+| connect        | 113,452 b | 49,876 b | 13,449 b |
 | grpc-web       | 414,071 b    | 300,352 b    | 53,255 b |

--- a/packages/connect-web-bench/src/gen/connectweb/connectrpc/eliza/v1/eliza_connect.ts
+++ b/packages/connect-web-bench/src/gen/connectweb/connectrpc/eliza/v1/eliza_connect.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 /* eslint-disable */
 
 import { ConverseRequest, ConverseResponse, IntroduceRequest, IntroduceResponse, SayRequest, SayResponse } from "./eliza_pb.js";
-import { MethodKind } from "@bufbuild/protobuf";
+import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
 
 /**
  * ElizaService provides a way to talk to Eliza, a port of the DOCTOR script
@@ -42,6 +42,7 @@ export const ElizaService = {
       I: SayRequest,
       O: SayResponse,
       kind: MethodKind.Unary,
+      idempotency: MethodIdempotency.NoSideEffects,
     },
     /**
      * Converse is a bidirectional RPC. The caller may exchange multiple

--- a/packages/connect-web-bench/src/gen/connectweb/connectrpc/eliza/v1/eliza_pb.ts
+++ b/packages/connect-web-bench/src/gen/connectweb/connectrpc/eliza/v1/eliza_pb.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This updates the version of the Eliza demo schema (sources [here](https://github.com/connectrpc/examples-go/tree/main/proto)) to the most recent commit.