### PR TITLE
Add retries to node curl commands

### DIFF
--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -9,23 +9,20 @@ on:
 permissions:
   contents: read
 jobs:
-  ci:
+  browserstack:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1.26.1
-        with:
-          github_token: ${{ github.token }}
       - name: cache
         uses: actions/cache@v3
         with:
           path: |
             ~/.tmp
             .tmp
-          key: ${{ runner.os }}-connect-web-ci-${{ hashFiles('Makefile') }}
+          key: ${{ runner.os }}-connect-web-browserstack-${{ hashFiles('Makefile') }}
           restore-keys: |
-            ${{ runner.os }}-connect-web-ci-
+            ${{ runner.os }}-connect-web-browserstack-
       - name: browserstack
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: browserstack
 on:
   push:
     branches: [main]
@@ -26,5 +26,9 @@ jobs:
           key: ${{ runner.os }}-connect-web-ci-${{ hashFiles('Makefile') }}
           restore-keys: |
             ${{ runner.os }}-connect-web-ci-
-      - name: make
-        run: make format build lint test bench checkdiff
+      - name: browserstack
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        run: make testwebbrowserstack
+

--- a/Makefile
+++ b/Makefile
@@ -31,30 +31,38 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/node20: Makefile
 	@mkdir -p $(@D)
-	curl -sSL https://nodejs.org/dist/$(NODE20_VERSION)/node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz | tar xJ -C $(TMP) node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
-	mv $(TMP)/node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
-	rm -r $(TMP)/node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	curl --retry 5 --retry-all-errors -sSL -o $(TMP)/$(NODE20_VERSION).tar.xz https://nodejs.org/dist/$(NODE20_VERSION)/node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz
+	tar xJf $(TMP)/$(NODE20_VERSION).tar.xz -C $(TMP) node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
+	@mv $(TMP)/node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
+	@rm -r $(TMP)/node-$(NODE20_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	@rm -r $(TMP)/$(NODE20_VERSION).tar.xz
 	@touch $(@)
 
 $(BIN)/node19: Makefile
 	@mkdir -p $(@D)
-	curl -sSL https://nodejs.org/dist/$(NODE19_VERSION)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz | tar xJ -C $(TMP) node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
-	mv $(TMP)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
-	rm -r $(TMP)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	curl --retry 5 --retry-all-errors -sSL -o $(TMP)/$(NODE19_VERSION).tar.xz https://nodejs.org/dist/$(NODE19_VERSION)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz
+	tar xJf $(TMP)/$(NODE19_VERSION).tar.xz -C $(TMP) node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
+	@mv $(TMP)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
+	@rm -r $(TMP)/node-$(NODE19_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	@rm -r $(TMP)/$(NODE19_VERSION).tar.xz
 	@touch $(@)
 
 $(BIN)/node18: Makefile
 	@mkdir -p $(@D)
-	curl -sSL https://nodejs.org/dist/$(NODE18_VERSION)/node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz | tar xJ -C $(TMP) node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
-	mv $(TMP)/node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
-	rm -r $(TMP)/node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	curl --retry 5 --retry-all-errors -sSL -o $(TMP)/$(NODE18_VERSION).tar.xz https://nodejs.org/dist/$(NODE18_VERSION)/node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz
+	tar xJf $(TMP)/$(NODE18_VERSION).tar.xz -C $(TMP) node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
+	@mv $(TMP)/node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
+	@rm -r $(TMP)/node-$(NODE18_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	@rm -r $(TMP)/$(NODE18_VERSION).tar.xz
 	@touch $(@)
 
 $(BIN)/node16: Makefile
 	@mkdir -p $(@D)
-	curl -sSL https://nodejs.org/dist/$(NODE16_VERSION)/node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz | tar xJ -C $(TMP) node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
-	mv $(TMP)/node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
-	rm -r $(TMP)/node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	curl --retry 5 --retry-all-errors -sSL -o $(TMP)/$(NODE16_VERSION).tar.xz https://nodejs.org/dist/$(NODE16_VERSION)/node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.xz
+	tar xJf $(TMP)/$(NODE16_VERSION).tar.xz -C $(TMP) node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node
+	@mv $(TMP)/node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH)/bin/node $(@)
+	@rm -r $(TMP)/node-$(NODE16_VERSION)-$(NODE_OS)-$(NODE_ARCH)
+	@rm -r $(TMP)/$(NODE16_VERSION).tar.xz
 	@touch $(@)
 
 $(BUILD)/protoc-gen-connect-es: node_modules tsconfig.base.json packages/protoc-gen-connect-es/tsconfig.json $(shell find packages/protoc-gen-connect-es/src -name '*.ts')

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Connect for ECMAScript
 
-[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es) [![Build](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml)
+[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![Build](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es)
 
 Connect is a family of libraries for building type-safe APIs with different languages and platforms.
 [@connectrpc/connect](https://www.npmjs.com/package/@connectrpc/connect) brings them to TypeScript,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Connect for ECMAScript
 
-[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es)
+[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![Build](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es)
 
 Connect is a family of libraries for building type-safe APIs with different languages and platforms.
 [@connectrpc/connect](https://www.npmjs.com/package/@connectrpc/connect) brings them to TypeScript,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Connect for ECMAScript
 
-[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es)
+[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es) [![Build](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml)
 
 Connect is a family of libraries for building type-safe APIs with different languages and platforms.
 [@connectrpc/connect](https://www.npmjs.com/package/@connectrpc/connect) brings them to TypeScript,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Connect for ECMAScript
 
-[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![Build](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es)
+[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es)
 
 Connect is a family of libraries for building type-safe APIs with different languages and platforms.
 [@connectrpc/connect](https://www.npmjs.com/package/@connectrpc/connect) brings them to TypeScript,


### PR DESCRIPTION
This adds retries to the `curl` commands used to pull the Node binaries. It also moves the Browserstack tests to their own workflow. Since these tests always fail for contributor PRs due to credentials, it will be easier to isolate any failures that occur.