### PR TITLE
fix: browser fetch can support streaming request bodies

### DIFF
--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -270,7 +270,7 @@ export function createConnectTransport(
       async function createRequestBody(
         input: AsyncIterable<I>,
       ): Promise<Uint8Array> {
-        if (method.kind != MethodKind.ServerStreaming) {
+        if (!TransformStream) {
           throw "The fetch API does not support streaming request bodies";
         }
         const r = await input[Symbol.asyncIterator]().next();

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -23,7 +23,7 @@ import type {
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
-import { Message, MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
+import { Message, MethodIdempotency } from "@bufbuild/protobuf";
 import type {
   Interceptor,
   StreamResponse,

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -22,7 +22,7 @@ import type {
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
-import { Message, MethodKind } from "@bufbuild/protobuf";
+import { Message } from "@bufbuild/protobuf";
 import type {
   Interceptor,
   StreamResponse,

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -279,7 +279,7 @@ export function createGrpcWebTransport(
       async function createRequestBody(
         input: AsyncIterable<I>,
       ): Promise<Uint8Array> {
-        if (method.kind != MethodKind.ServerStreaming) {
+        if (!TransformStream) {
           throw "The fetch API does not support streaming request bodies";
         }
         const r = await input[Symbol.asyncIterator]().next();


### PR DESCRIPTION
This is a bug fix related to client-streaming requests. 

Invoking a `MethodKind.ClientStreaming` method using a `connect` or `grpc-web` transport immediately throws the error "The fetch API does not support streaming request bodies."

This, however, appears to be a dated catch. Streaming as a request body is supported [by most modern browsers](https://caniuse.com/?search=TransformStream) using the default `fetch`. 

This PR does a [very light feature check](https://developer.chrome.com/articles/fetch-streaming-requests/#feature-detection) to ensure backwards compatibility instead of checking against the method's kind.