### PR TITLE
Add context values to clients

### DIFF
--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -127,7 +127,7 @@ export function universalRequestFromNodeRequest(
     header: nodeHeaderToWebHeader(nodeRequest.headers),
     body,
     signal: abortController.signal,
-    values: contextValues,
+    contextValues: contextValues,
   };
 }
 

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 114,440 b | 50,266 b | 13,576 b |
+| connect        | 114,538 b | 50,308 b | 13,557 b |
 | grpc-web       | 414,071 b    | 300,352 b    | 53,255 b |

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 113,658 b | 49,964 b | 13,486 b |
+| connect        | 114,440 b | 50,266 b | 13,576 b |
 | grpc-web       | 414,071 b    | 300,352 b    | 53,255 b |

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -30,8 +30,9 @@ import type {
   Transport,
   UnaryRequest,
   UnaryResponse,
+  ContextValues,
 } from "@connectrpc/connect";
-import { appendHeaders } from "@connectrpc/connect";
+import { appendHeaders, createContextValues } from "@connectrpc/connect";
 import {
   createClientMethodSerializers,
   createEnvelopeReadableStream,
@@ -142,6 +143,7 @@ export function createConnectTransport(
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
+      values?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -176,6 +178,7 @@ export function createConnectTransport(
             timeoutMs,
             header,
           ),
+          values: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -242,6 +245,7 @@ export function createConnectTransport(
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
+      values?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -320,6 +324,7 @@ export function createConnectTransport(
             timeoutMs,
             header,
           ),
+          values: values ?? createContextValues(),
           message: input,
         },
         next: async (req) => {

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -143,7 +143,7 @@ export function createConnectTransport(
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -178,7 +178,7 @@ export function createConnectTransport(
             timeoutMs,
             header,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -245,7 +245,7 @@ export function createConnectTransport(
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -324,7 +324,7 @@ export function createConnectTransport(
             timeoutMs,
             header,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message: input,
         },
         next: async (req) => {

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -178,7 +178,7 @@ export function createConnectTransport(
             timeoutMs,
             header,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -324,7 +324,7 @@ export function createConnectTransport(
             timeoutMs,
             header,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message: input,
         },
         next: async (req) => {

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -29,7 +29,9 @@ import type {
   Transport,
   UnaryRequest,
   UnaryResponse,
+  ContextValues,
 } from "@connectrpc/connect";
+import { createContextValues } from "@connectrpc/connect";
 import {
   createClientMethodSerializers,
   createEnvelopeReadableStream,
@@ -137,6 +139,7 @@ export function createGrpcWebTransport(
       timeoutMs: number | undefined,
       header: Headers,
       message: PartialMessage<I>,
+      values?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -166,6 +169,7 @@ export function createGrpcWebTransport(
             mode: "cors",
           },
           header: requestHeader(useBinaryFormat, timeoutMs, header),
+          values: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -233,6 +237,7 @@ export function createGrpcWebTransport(
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
+      values?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -323,6 +328,7 @@ export function createGrpcWebTransport(
             mode: "cors",
           },
           header: requestHeader(useBinaryFormat, timeoutMs, header),
+          values: values ?? createContextValues(),
           message: input,
         },
         next: async (req) => {

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -169,7 +169,7 @@ export function createGrpcWebTransport(
             mode: "cors",
           },
           header: requestHeader(useBinaryFormat, timeoutMs, header),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -328,7 +328,7 @@ export function createGrpcWebTransport(
             mode: "cors",
           },
           header: requestHeader(useBinaryFormat, timeoutMs, header),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message: input,
         },
         next: async (req) => {

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -139,7 +139,7 @@ export function createGrpcWebTransport(
       timeoutMs: number | undefined,
       header: Headers,
       message: PartialMessage<I>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -169,7 +169,7 @@ export function createGrpcWebTransport(
             mode: "cors",
           },
           header: requestHeader(useBinaryFormat, timeoutMs, header),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -237,7 +237,7 @@ export function createGrpcWebTransport(
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const { serialize, parse } = createClientMethodSerializers(
         method,
@@ -328,7 +328,7 @@ export function createGrpcWebTransport(
             mode: "cors",
           },
           header: requestHeader(useBinaryFormat, timeoutMs, header),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message: input,
         },
         next: async (req) => {

--- a/packages/connect/src/call-options.ts
+++ b/packages/connect/src/call-options.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { ContextValues } from "./context-values";
+import type { ContextValues } from "./context-values.js";
 
 /**
  * Options for a call. Every client should accept CallOptions as optional

--- a/packages/connect/src/call-options.ts
+++ b/packages/connect/src/call-options.ts
@@ -50,5 +50,5 @@ export interface CallOptions {
   /**
    * ContextValues to pass to the interceptors.
    */
-  values?: ContextValues;
+  contextValues?: ContextValues;
 }

--- a/packages/connect/src/call-options.ts
+++ b/packages/connect/src/call-options.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { ContextValues } from "./context-values";
+
 /**
  * Options for a call. Every client should accept CallOptions as optional
  * argument in its RPC methods.
@@ -44,4 +46,9 @@ export interface CallOptions {
    * Called when response trailers are received.
    */
   onTrailer?(trailers: Headers): void;
+
+  /**
+   * ContextValues to pass to the interceptors.
+   */
+  values?: ContextValues;
 }

--- a/packages/connect/src/callback-client.ts
+++ b/packages/connect/src/callback-client.ts
@@ -99,7 +99,7 @@ function createUnaryFn<I extends Message<I>, O extends Message<O>>(
         options.timeoutMs,
         options.headers,
         requestMessage,
-        options.values,
+        options.contextValues,
       )
       .then(
         (response) => {
@@ -147,7 +147,7 @@ function createServerStreamingFn<I extends Message<I>, O extends Message<O>>(
         options.timeoutMs,
         options.headers,
         createAsyncIterable([input]),
-        options.values,
+        options.contextValues,
       );
       options.onHeader?.(response.header);
       for await (const message of response.message) {

--- a/packages/connect/src/callback-client.ts
+++ b/packages/connect/src/callback-client.ts
@@ -99,6 +99,7 @@ function createUnaryFn<I extends Message<I>, O extends Message<O>>(
         options.timeoutMs,
         options.headers,
         requestMessage,
+        options.values,
       )
       .then(
         (response) => {
@@ -146,6 +147,7 @@ function createServerStreamingFn<I extends Message<I>, O extends Message<O>>(
         options.timeoutMs,
         options.headers,
         createAsyncIterable([input]),
+        options.values,
       );
       options.onHeader?.(response.header);
       for await (const message of response.message) {

--- a/packages/connect/src/implementation.ts
+++ b/packages/connect/src/implementation.ts
@@ -140,7 +140,7 @@ interface HandlerContextInit {
   requestHeader?: HeadersInit;
   responseHeader?: HeadersInit;
   responseTrailer?: HeadersInit;
-  values?: ContextValues;
+  contextValues?: ContextValues;
 }
 
 interface HandlerContextController extends HandlerContext {
@@ -181,7 +181,7 @@ export function createHandlerContext(
       deadline.cleanup();
       abortController.abort(reason);
     },
-    values: init.values ?? createContextValues(),
+    values: init.contextValues ?? createContextValues(),
   };
 }
 

--- a/packages/connect/src/interceptor.ts
+++ b/packages/connect/src/interceptor.ts
@@ -18,7 +18,7 @@ import type {
   MethodInfo,
   ServiceType,
 } from "@bufbuild/protobuf";
-import type { ContextValues } from "./context-values";
+import type { ContextValues } from "./context-values.js";
 
 /**
  * An interceptor can add logic to clients, similar to the decorators

--- a/packages/connect/src/interceptor.ts
+++ b/packages/connect/src/interceptor.ts
@@ -169,7 +169,7 @@ interface RequestCommon<I extends Message<I>, O extends Message<O>> {
   /**
    * The context values for the current call.
    */
-  readonly values: ContextValues;
+  readonly contextValues: ContextValues;
 }
 
 interface ResponseCommon<I extends Message<I>, O extends Message<O>> {

--- a/packages/connect/src/interceptor.ts
+++ b/packages/connect/src/interceptor.ts
@@ -18,6 +18,7 @@ import type {
   MethodInfo,
   ServiceType,
 } from "@bufbuild/protobuf";
+import type { ContextValues } from "./context-values";
 
 /**
  * An interceptor can add logic to clients, similar to the decorators
@@ -164,6 +165,11 @@ interface RequestCommon<I extends Message<I>, O extends Message<O>> {
    * Headers that will be sent along with the request.
    */
   readonly header: Headers;
+
+  /**
+   * The context values for the current call.
+   */
+  readonly values: ContextValues;
 }
 
 interface ResponseCommon<I extends Message<I>, O extends Message<O>> {

--- a/packages/connect/src/promise-client.spec.ts
+++ b/packages/connect/src/promise-client.spec.ts
@@ -82,7 +82,7 @@ describe("createUnaryFn()", function () {
             (next) => {
               return (req) => {
                 interceptorCalled = true;
-                expect(req.values.get(kString)).toBe("bar");
+                expect(req.contextValues.get(kString)).toBe("bar");
                 return next(req);
               };
             },
@@ -96,7 +96,7 @@ describe("createUnaryFn()", function () {
       TestService.methods.unaryMethod,
     );
     const res = await fn(input, {
-      values: createContextValues().set(kString, "bar"),
+      contextValues: createContextValues().set(kString, "bar"),
     });
     expect(res).toBeInstanceOf(StringValue);
     expect(res.value).toEqual(output.value);
@@ -158,7 +158,7 @@ describe("createClientStreamingFn()", function () {
             (next) => {
               return (req) => {
                 interceptorCalled = true;
-                expect(req.values.get(kString)).toBe("bar");
+                expect(req.contextValues.get(kString)).toBe("bar");
                 return next(req);
               };
             },
@@ -177,7 +177,7 @@ describe("createClientStreamingFn()", function () {
         yield input;
       })(),
       {
-        values: createContextValues().set(kString, "bar"),
+        contextValues: createContextValues().set(kString, "bar"),
       },
     );
     expect(res).toBeInstanceOf(StringValue);
@@ -309,7 +309,7 @@ describe("createServerStreamingFn()", function () {
             (next) => {
               return (req) => {
                 interceptorCalled = true;
-                expect(req.values.get(kString)).toBe("bar");
+                expect(req.contextValues.get(kString)).toBe("bar");
                 return next(req);
               };
             },
@@ -326,7 +326,7 @@ describe("createServerStreamingFn()", function () {
     const receivedMessages: StringValue[] = [];
     const input = new Int32Value({ value: 123 });
     for await (const res of fn(input, {
-      values: createContextValues().set(kString, "bar"),
+      contextValues: createContextValues().set(kString, "bar"),
     })) {
       receivedMessages.push(res);
     }
@@ -409,7 +409,7 @@ describe("createBiDiStreamingFn()", () => {
             (next) => {
               return (req) => {
                 interceptorCalled = true;
-                expect(req.values.get(kString)).toBe("bar");
+                expect(req.contextValues.get(kString)).toBe("bar");
                 return next(req);
               };
             },
@@ -425,7 +425,7 @@ describe("createBiDiStreamingFn()", () => {
 
     let index = 0;
     for await (const res of fn(input, {
-      values: createContextValues().set(kString, "bar"),
+      contextValues: createContextValues().set(kString, "bar"),
     })) {
       expect(res).toEqual(new StringValue({ value: values[index].toString() }));
       index += 1;

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -90,7 +90,7 @@ export function createUnaryFn<I extends Message<I>, O extends Message<O>>(
       options?.timeoutMs,
       options?.headers,
       input,
-      options?.values,
+      options?.contextValues,
     );
     options?.onHeader?.(response.header);
     options?.onTrailer?.(response.trailer);
@@ -124,7 +124,7 @@ export function createServerStreamingFn<
         options?.timeoutMs,
         options?.headers,
         createAsyncIterable([input]),
-        options?.values,
+        options?.contextValues,
       ),
       options,
     );
@@ -159,7 +159,7 @@ export function createClientStreamingFn<
       options?.timeoutMs,
       options?.headers,
       request,
-      options?.values,
+      options?.contextValues,
     );
     options?.onHeader?.(response.header);
     let singleMessage: O | undefined;
@@ -206,7 +206,7 @@ export function createBiDiStreamingFn<
         options?.timeoutMs,
         options?.headers,
         request,
-        options?.values,
+        options?.contextValues,
       ),
       options,
     );

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -77,7 +77,7 @@ type UnaryFn<I extends Message<I>, O extends Message<O>> = (
   options?: CallOptions,
 ) => Promise<O>;
 
-function createUnaryFn<I extends Message<I>, O extends Message<O>>(
+export function createUnaryFn<I extends Message<I>, O extends Message<O>>(
   transport: Transport,
   service: ServiceType,
   method: MethodInfo<I, O>,
@@ -90,6 +90,7 @@ function createUnaryFn<I extends Message<I>, O extends Message<O>>(
       options?.timeoutMs,
       options?.headers,
       input,
+      options?.values,
     );
     options?.onHeader?.(response.header);
     options?.onTrailer?.(response.trailer);
@@ -123,6 +124,7 @@ export function createServerStreamingFn<
         options?.timeoutMs,
         options?.headers,
         createAsyncIterable([input]),
+        options?.values,
       ),
       options,
     );
@@ -157,6 +159,7 @@ export function createClientStreamingFn<
       options?.timeoutMs,
       options?.headers,
       request,
+      options?.values,
     );
     options?.onHeader?.(response.header);
     let singleMessage: O | undefined;
@@ -203,6 +206,7 @@ export function createBiDiStreamingFn<
         options?.timeoutMs,
         options?.headers,
         request,
+        options?.values,
       ),
       options,
     );

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -195,7 +195,7 @@ function createUnaryHandler<I extends Message<I>, O extends Message<O>>(
           ? contentTypeUnaryProto
           : contentTypeUnaryJson,
       },
-      values: req.values,
+      contextValues: req.contextValues,
     });
     const compression = compressionNegotiate(
       opt.acceptCompression,
@@ -380,7 +380,7 @@ function createStreamHandler<I extends Message<I>, O extends Message<O>>(
           ? contentTypeStreamProto
           : contentTypeStreamJson,
       },
-      values: req.values,
+      contextValues: req.contextValues,
     });
     const compression = compressionNegotiate(
       opt.acceptCompression,

--- a/packages/connect/src/protocol-connect/transport.ts
+++ b/packages/connect/src/protocol-connect/transport.ts
@@ -53,6 +53,8 @@ import { createMethodUrl } from "../protocol/create-method-url.js";
 import { runUnaryCall, runStreamingCall } from "../protocol/run-call.js";
 import { createMethodSerializationLookup } from "../protocol/serialization.js";
 import type { Transport } from "../transport.js";
+import type { ContextValues } from "../context-values.js";
+import { createContextValues } from "../context-values.js";
 
 /**
  * Create a Transport for the Connect protocol.
@@ -69,6 +71,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
+      values?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -100,6 +103,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
+          values: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -188,6 +192,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
+      values?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -226,6 +231,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
+          values: values ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-connect/transport.ts
+++ b/packages/connect/src/protocol-connect/transport.ts
@@ -103,7 +103,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -231,7 +231,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-connect/transport.ts
+++ b/packages/connect/src/protocol-connect/transport.ts
@@ -71,7 +71,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -103,7 +103,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -192,7 +192,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -231,7 +231,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-grpc-web/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.ts
@@ -137,7 +137,7 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
       responseTrailer: {
         [headerGrpcStatus]: grpcStatusOk,
       },
-      values: req.values,
+      contextValues: req.contextValues,
     });
     const compression = compressionNegotiate(
       opt.acceptCompression,

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -65,7 +65,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -96,7 +96,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -196,7 +196,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -231,7 +231,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -96,7 +96,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -231,7 +231,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -47,6 +47,8 @@ import { runUnaryCall, runStreamingCall } from "../protocol/run-call.js";
 import { createMethodSerializationLookup } from "../protocol/serialization.js";
 import type { CommonTransportOptions } from "../protocol/transport-options.js";
 import type { Transport } from "../transport.js";
+import { createContextValues } from "../context-values.js";
+import type { ContextValues } from "../context-values.js";
 
 /**
  * Create a Transport for the gRPC-web protocol.
@@ -63,6 +65,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
+      values?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -93,6 +96,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
+          values: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -192,6 +196,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
+      values?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -226,6 +231,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
+          values: values ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-grpc/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.ts
@@ -128,7 +128,7 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
       responseTrailer: {
         [headerGrpcStatus]: grpcStatusOk,
       },
-      values: req.values,
+      contextValues: req.contextValues,
     });
     const compression = compressionNegotiate(
       opt.acceptCompression,

--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -64,7 +64,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -95,7 +95,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -172,7 +172,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
-      values?: ContextValues,
+      contextValues?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -203,7 +203,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          contextValues: values ?? createContextValues(),
+          contextValues: contextValues ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -95,7 +95,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -203,7 +203,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
-          values: values ?? createContextValues(),
+          contextValues: values ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -46,6 +46,8 @@ import { runUnaryCall, runStreamingCall } from "../protocol/run-call.js";
 import { createMethodSerializationLookup } from "../protocol/serialization.js";
 import type { CommonTransportOptions } from "../protocol/transport-options.js";
 import type { Transport } from "../transport.js";
+import { createContextValues } from "../context-values.js";
+import type { ContextValues } from "../context-values.js";
 
 /**
  * Create a Transport for the gRPC protocol.
@@ -62,6 +64,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       message: PartialMessage<I>,
+      values?: ContextValues,
     ): Promise<UnaryResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -92,6 +95,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
+          values: values ?? createContextValues(),
           message,
         },
         next: async (req: UnaryRequest<I, O>): Promise<UnaryResponse<I, O>> => {
@@ -168,6 +172,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
+      values?: ContextValues,
     ): Promise<StreamResponse<I, O>> {
       const serialization = createMethodSerializationLookup(
         method,
@@ -198,6 +203,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             opt.acceptCompression,
             opt.sendCompression,
           ),
+          values: values ?? createContextValues(),
           message: input,
         },
         next: async (req: StreamRequest<I, O>) => {

--- a/packages/connect/src/protocol/run-call.spec.ts
+++ b/packages/connect/src/protocol/run-call.spec.ts
@@ -52,7 +52,7 @@ describe("runUnaryCall()", function () {
       init: {},
       header: new Headers(),
       message: { value: 123 },
-      values: createContextValues(),
+      contextValues: createContextValues(),
     };
   }
 
@@ -135,7 +135,7 @@ describe("runStreamingCall()", function () {
       init: {},
       header: new Headers(),
       message: createAsyncIterable([{ value: 1 }, { value: 2 }, { value: 3 }]),
-      values: createContextValues(),
+      contextValues: createContextValues(),
     };
   }
 

--- a/packages/connect/src/protocol/run-call.spec.ts
+++ b/packages/connect/src/protocol/run-call.spec.ts
@@ -22,6 +22,7 @@ import type {
   UnaryResponse,
 } from "../interceptor.js";
 import { createAsyncIterable } from "./async-iterable.js";
+import { createContextValues } from "../context-values.js";
 
 const TestService = {
   typeName: "TestService",
@@ -51,6 +52,7 @@ describe("runUnaryCall()", function () {
       init: {},
       header: new Headers(),
       message: { value: 123 },
+      values: createContextValues(),
     };
   }
 
@@ -133,6 +135,7 @@ describe("runStreamingCall()", function () {
       init: {},
       header: new Headers(),
       message: createAsyncIterable([{ value: 1 }, { value: 2 }, { value: 3 }]),
+      values: createContextValues(),
     };
   }
 

--- a/packages/connect/src/protocol/universal.ts
+++ b/packages/connect/src/protocol/universal.ts
@@ -66,7 +66,7 @@ export interface UniversalServerRequest {
    */
   body: AsyncIterable<Uint8Array> | JsonValue;
   signal: AbortSignal;
-  values?: ContextValues;
+  contextValues?: ContextValues;
 }
 
 /**

--- a/packages/connect/src/transport.ts
+++ b/packages/connect/src/transport.ts
@@ -39,7 +39,7 @@ export interface Transport {
     timeoutMs: number | undefined,
     header: HeadersInit | undefined,
     input: PartialMessage<I>,
-    values?: ContextValues,
+    contextValues?: ContextValues,
   ): Promise<UnaryResponse<I, O>>;
 
   /**
@@ -53,6 +53,6 @@ export interface Transport {
     timeoutMs: number | undefined,
     header: HeadersInit | undefined,
     input: AsyncIterable<PartialMessage<I>>,
-    values?: ContextValues,
+    contextValues?: ContextValues,
   ): Promise<StreamResponse<I, O>>;
 }

--- a/packages/connect/src/transport.ts
+++ b/packages/connect/src/transport.ts
@@ -20,6 +20,7 @@ import type {
   ServiceType,
 } from "@bufbuild/protobuf";
 import type { StreamResponse, UnaryResponse } from "./interceptor.js";
+import type { ContextValues } from "./context-values.js";
 
 /**
  * Transport represents the underlying transport for a client.
@@ -38,6 +39,7 @@ export interface Transport {
     timeoutMs: number | undefined,
     header: HeadersInit | undefined,
     input: PartialMessage<I>,
+    values?: ContextValues,
   ): Promise<UnaryResponse<I, O>>;
 
   /**
@@ -51,5 +53,6 @@ export interface Transport {
     timeoutMs: number | undefined,
     header: HeadersInit | undefined,
     input: AsyncIterable<PartialMessage<I>>,
+    values?: ContextValues,
   ): Promise<StreamResponse<I, O>>;
 }


### PR DESCRIPTION
Add context values to clients. This adds support for `ContextValues` in clients via `CallOptions` and `Interceptors`: 

```ts
import { ElizaService } from "gen/...";
import { createPromiseClient } from "@connectrpc/connect";
import transport from "./transport.js";
import kUser from "user-context.js";

const client = createPromiseClient(ElizeService, trasport);

await client.say({ sentence: "Hi" }, { values: createContextValues().set(kUser, { ... }) });
```

Which can be accessed in an interceptor:

```ts
const tokenInterceptor = (next) => {
    return (req) => {
           req.header.set("Authorization", `Bearer ${req.values.get(kUser).token}`);
           return next(req);
    };
};
```