### PR TITLE
Fix early event loop exit on nodejs when H2 sessions are in the verify state

### DIFF
--- a/packages/connect-node/.npmignore
+++ b/packages/connect-node/.npmignore
@@ -2,3 +2,4 @@
 /*.json
 /dist/*/**/*.spec.js
 /dist/*/**/*.spec.d.ts
+/dist/*/testdata/

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -647,8 +647,12 @@ function ready(
       resetPingInterval();
     },
     ping() {
+      conn.ref();
       return new Promise<boolean>((resolve) => {
-        commonPing(() => resolve(true));
+        commonPing(() => {
+          if (streamCount == 0) conn.unref();
+          resolve(true);
+        });
         conn.once("error", () => resolve(false));
       });
     },

--- a/packages/connect-node/src/testdata/http2-session-manager-verify-ping.ts
+++ b/packages/connect-node/src/testdata/http2-session-manager-verify-ping.ts
@@ -1,0 +1,34 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-floating-promises */
+
+import { Http2SessionManager } from "../http2-session-manager.js";
+import * as http2 from "http2";
+import { parentPort, workerData } from "worker_threads";
+
+const sm = new Http2SessionManager(workerData, {
+  pingIntervalMs: 5, // intentionally short for faster tests
+});
+sm.request("POST", "/", {}, {}).then((req) => {
+  req.close(http2.constants.NGHTTP2_NO_ERROR, () =>
+    setTimeout(() => {
+      sm.request("POST", "/", {}, {}).then((req) => {
+        req.close(http2.constants.NGHTTP2_NO_ERROR, () => {
+          parentPort!.postMessage("done");
+        });
+      });
+    }, 10),
+  );
+});

--- a/packages/connect-node/tsconfig.json
+++ b/packages/connect-node/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "files": ["src/index.ts"],
-  "include": ["src/**/*.spec.ts"],
+  "include": ["src/**/*.spec.ts", "src/testdata/*.ts"],
   "extends": "../../tsconfig.base.json"
 }


### PR DESCRIPTION
Fix early event loop exit on nodejs when H2 sessions are in the verify state. We `unref` the connections to avoid idle connections stopping the process from exiting. This results in a case where process exits when verification is required (last pinged time elapsed ping interval). We always `ref` before a manual `ping` and `unref` if it succeeds with empty streams. 

Used a worker to test the behavior. Not super happy about it but seemed better than a child process.

Fixes #860. 
