### PR TITLE
Export fetch to/from universal req/res functions

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 114,538 b | 50,308 b | 13,557 b |
+| connect        | 114,538 b | 50,308 b | 13,578 b |
 | grpc-web       | 414,071 b    | 300,352 b    | 53,255 b |

--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -24,7 +24,14 @@ export type {
 export type { Compression } from "./compression.js";
 export type { UniversalHandler } from "./universal-handler.js";
 export { createUniversalHandlerClient } from "./universal-handler-client.js";
-export { createFetchClient, createFetchHandler } from "./universal-fetch.js";
+export {
+  createFetchClient,
+  createFetchHandler,
+  universalClientRequestToFetch,
+  universalClientResponseFromFetch,
+  universalServerRequestFromFetch,
+  universalServerResponseToFetch,
+} from "./universal-fetch.js";
 export { runUnaryCall, runStreamingCall } from "./run-call.js";
 
 // All exports below are private — internal code that does not follow semantic

--- a/packages/connect/src/protocol/universal-fetch.ts
+++ b/packages/connect/src/protocol/universal-fetch.ts
@@ -60,7 +60,12 @@ export function createFetchHandler(
   return Object.assign(handleFetch, uHandler);
 }
 
-function universalClientRequestToFetch(req: UniversalClientRequest): Request {
+/**
+ * Convert a universal client request to a fetch request.
+ */
+export function universalClientRequestToFetch(
+  req: UniversalClientRequest,
+): Request {
   const body =
     req.body === undefined ? null : iterableToReadableStream(req.body);
   return new Request(req.url, {
@@ -71,7 +76,10 @@ function universalClientRequestToFetch(req: UniversalClientRequest): Request {
   });
 }
 
-function universalClientResponseFromFetch(
+/**
+ * Convert a fetch response to a universal client response.
+ */
+export function universalClientResponseFromFetch(
   res: Response,
 ): UniversalClientResponse {
   return {
@@ -82,7 +90,10 @@ function universalClientResponseFromFetch(
   };
 }
 
-function universalServerRequestFromFetch(
+/**
+ * Convert a fetch request to a universal server request.
+ */
+export function universalServerRequestFromFetch(
   req: Request,
   options: FetchHandlerOptions,
 ): UniversalServerRequest {
@@ -96,7 +107,10 @@ function universalServerRequestFromFetch(
   };
 }
 
-function universalServerResponseToFetch(
+/**
+ * Convert a universal server response to a fetch response.
+ */
+export function universalServerResponseToFetch(
   res: UniversalServerResponse,
 ): Response {
   let body: ReadableStream<Uint8Array> | null = null;


### PR DESCRIPTION
Export fetch to/from universal req/res functions. This gives greater flexibility when implementing fetch based handlers and clients.