### PR TITLE
Fix multiple read attempts in fetch client

### DIFF
--- a/packages/connect/src/protocol/universal-fetch.ts
+++ b/packages/connect/src/protocol/universal-fetch.ts
@@ -152,9 +152,9 @@ function iterableToReadableStream(
 function iterableFromReadableStream(
   body: ReadableStream<Uint8Array> | null,
 ): AsyncIterable<Uint8Array> {
+  const reader = body?.getReader();
   return {
     [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-      const reader = body?.getReader();
       return {
         async next() {
           if (reader !== undefined) {


### PR DESCRIPTION
Fix multiple read attempts in fetch client. I caught this while working on https://github.com/connectrpc/examples-es/pull/1075. The fix similar to how we read the iterable: https://github.com/connectrpc/connect-es/blob/51470ebc229130150d5ba4147fe32b9c142cb83f/packages/connect/src/protocol/universal-fetch.ts#L129-L130