### PR TITLE
Switch to eslint-plugin-n

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,7 @@ module.exports = {
     "packages/*/dist/**",
     "node_modules/**",
   ],
-  plugins: ["@typescript-eslint", "node", "import"],
+  plugins: ["@typescript-eslint", "n", "import"],
   // Rules and settings that do not require a non-default parser
   extends: ["eslint:recommended"],
   rules: {
@@ -68,35 +68,23 @@ module.exports = {
     {
       files: ["**/*.{js,mjs,cjs}"],
       parserOptions: {
-        ecmaVersion: 2020,
+          ecmaVersion: 13, // ES2022 - https://eslint.org/docs/latest/use/configure/language-options#specifying-environments
       },
-      extends: ["eslint:recommended", "plugin:node/recommended"],
+      extends: ["eslint:recommended", "plugin:n/recommended"],
       rules: {
-        "node/shebang": "off", // this plugin only determines shebang necessary for files that are in a package.json "bin" field
-        "node/exports-style": ["error", "module.exports"],
-        "node/file-extension-in-import": ["error", "always"],
-        "node/prefer-global/buffer": ["error", "always"],
-        "node/prefer-global/console": ["error", "always"],
-        "node/prefer-global/process": ["error", "always"],
-        "node/prefer-global/url-search-params": ["error", "always"],
-        "node/prefer-global/url": ["error", "always"],
-        "node/prefer-promises/dns": "error",
-        "node/prefer-promises/fs": "error",
-        "no-process-exit": "off",
-        "node/no-unsupported-features/es-builtins": [
-          "error",
-          {
-            version: ">=16.0.0",
-            ignores: [],
-          },
-        ],
-        "node/no-unsupported-features/node-builtins": [
-          "error",
-          {
-            version: ">=16.0.0",
-            ignores: [],
-          },
-        ],
+          "n/shebang": "off", // this rule reports _any_ shebang outside of an npm binary as an error
+          "n/prefer-global/process": "off",
+          "n/no-process-exit": "off",
+          "n/exports-style": ["error", "module.exports"],
+          "n/file-extension-in-import": ["error", "always"],
+          "n/prefer-global/buffer": ["error", "always"],
+          "n/prefer-global/console": ["error", "always"],
+          "n/prefer-global/url-search-params": ["error", "always"],
+          "n/prefer-global/url": ["error", "always"],
+          "n/prefer-promises/dns": "error",
+          "n/prefer-promises/fs": "error",
+          "n/no-unsupported-features/node-builtins": "error",
+          "n/no-unsupported-features/es-syntax": "error",
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "connect-web",
+  "name": "connect-es",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -25,7 +25,7 @@
         "eslint": "^8.50.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.28.0",
-        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-n": "^16.3.1",
         "prettier": "^3.0.2",
         "typescript": "5.2.2"
       },
@@ -2899,6 +2899,18 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
@@ -3757,23 +3769,23 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.3.0.tgz",
+      "integrity": "sha512-W9zIs+k00I/I13+Bdkl/zG1MEO07G97XjUSQuH117w620SJ6bHtLUmoMvkGA2oYnI/gNdr+G7BONLyYnFaLLEQ==",
       "dev": true,
       "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
-        "eslint": ">=4.19.1"
+        "eslint": ">=8"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -3837,33 +3849,31 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
+      "integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.1.0",
+        "get-tsconfig": "^4.7.0",
+        "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -3880,30 +3890,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -4972,6 +4958,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-callable": {
@@ -6711,18 +6712,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^8.50.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^16.3.1",
     "prettier": "^3.0.2",
     "typescript": "5.2.2"
   }


### PR DESCRIPTION
I noticed some odd behavior in the Node.js linter. The original `eslint-plugin-node` does not seem to be maintained anymore. Let's switch to the fork [eslint-plugin-n](https://github.com/eslint-community/eslint-plugin-n).

Also see https://github.com/bufbuild/protobuf-es/pull/614