### PR TITLE
Always capture header in `ConnecError`

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 115,395 b | 50,680 b | 13,669 b |
+| connect        | 115,578 b | 50,754 b | 13,683 b |
 | grpc-web       | 414,071 b    | 300,352 b    | 53,255 b |

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -213,7 +213,7 @@ export function createGrpcWebTransport(
           if (trailer === undefined) {
             throw "missing trailer";
           }
-          validateTrailer(trailer);
+          validateTrailer(trailer, response.headers);
           if (message === undefined) {
             throw "missing message";
           }
@@ -279,7 +279,7 @@ export function createGrpcWebTransport(
             }
             trailerReceived = true;
             const trailer = trailerParse(data);
-            validateTrailer(trailer);
+            validateTrailer(trailer, undefined);
             trailer.forEach((value, key) => trailerTarget.set(key, value));
             continue;
           }

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -250,6 +250,7 @@ export function createGrpcWebTransport(
         body: ReadableStream<Uint8Array>,
         foundStatus: boolean,
         trailerTarget: Headers,
+        header: Headers,
       ) {
         const reader = createEnvelopeReadableStream(body).getReader();
         if (foundStatus) {
@@ -279,7 +280,7 @@ export function createGrpcWebTransport(
             }
             trailerReceived = true;
             const trailer = trailerParse(data);
-            validateTrailer(trailer, undefined);
+            validateTrailer(trailer, header);
             trailer.forEach((value, key) => trailerTarget.set(key, value));
             continue;
           }
@@ -348,7 +349,7 @@ export function createGrpcWebTransport(
             ...req,
             header: fRes.headers,
             trailer,
-            message: parseResponseBody(fRes.body, foundStatus, trailer),
+            message: parseResponseBody(fRes.body, foundStatus, trailer, fRes.headers),
           };
           return res;
         },

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -349,7 +349,12 @@ export function createGrpcWebTransport(
             ...req,
             header: fRes.headers,
             trailer,
-            message: parseResponseBody(fRes.body, foundStatus, trailer, fRes.headers),
+            message: parseResponseBody(
+              fRes.body,
+              foundStatus,
+              trailer,
+              fRes.headers,
+            ),
           };
           return res;
         },

--- a/packages/connect/src/protocol-connect/transport.ts
+++ b/packages/connect/src/protocol-connect/transport.ts
@@ -289,7 +289,11 @@ export function createTransport(opt: CommonTransportOptions): Transport {
                     }
                     endStreamReceived = true;
                     if (chunk.value.error) {
-                      throw chunk.value.error;
+                      const error = chunk.value.error;
+                      uRes.header.forEach((value, key) => {
+                        error.metadata.append(key, value);
+                      });
+                      throw error;
                     }
                     chunk.value.metadata.forEach((value, key) =>
                       res.trailer.set(key, value),

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -305,7 +305,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
                       );
                     }
                     trailerReceived = true;
-                    validateTrailer(chunk.value, undefined);
+                    validateTrailer(chunk.value, uRes.header);
                     chunk.value.forEach((value, key) =>
                       res.trailer.set(key, value),
                     );

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -169,7 +169,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
               Code.InvalidArgument,
             );
           }
-          validateTrailer(trailer);
+          validateTrailer(trailer, uRes.header);
           if (message === undefined) {
             throw new ConnectError(
               "protocol error: missing output message for unary method",
@@ -305,7 +305,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
                       );
                     }
                     trailerReceived = true;
-                    validateTrailer(chunk.value);
+                    validateTrailer(chunk.value, undefined);
                     chunk.value.forEach((value, key) =>
                       res.trailer.set(key, value),
                     );

--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -245,7 +245,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
               async function* (iterable) {
                 yield* iterable;
                 if (!foundStatus) {
-                  validateTrailer(uRes.trailer, undefined);
+                  validateTrailer(uRes.trailer, uRes.header);
                 }
               },
               { propagateDownStreamError: true },

--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -144,7 +144,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
             },
             { propagateDownStreamError: false },
           );
-          validateTrailer(uRes.trailer);
+          validateTrailer(uRes.trailer, uRes.header);
           if (message === undefined) {
             throw new ConnectError(
               "protocol error: missing output message for unary method",
@@ -245,7 +245,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
               async function* (iterable) {
                 yield* iterable;
                 if (!foundStatus) {
-                  validateTrailer(uRes.trailer);
+                  validateTrailer(uRes.trailer, undefined);
                 }
               },
               { propagateDownStreamError: true },

--- a/packages/connect/src/protocol-grpc/validate-trailer.ts
+++ b/packages/connect/src/protocol-grpc/validate-trailer.ts
@@ -20,9 +20,15 @@ import { findTrailerError } from "./trailer-status.js";
  *
  * @private Internal code, does not follow semantic versioning.
  */
-export function validateTrailer(trailer: Headers): void {
+export function validateTrailer(
+  trailer: Headers,
+  header: Headers | undefined,
+): void {
   const err = findTrailerError(trailer);
   if (err) {
+    header?.forEach((value, key) => {
+      err.metadata.append(key, value);
+    });
     throw err;
   }
 }

--- a/packages/connect/src/protocol-grpc/validate-trailer.ts
+++ b/packages/connect/src/protocol-grpc/validate-trailer.ts
@@ -20,13 +20,10 @@ import { findTrailerError } from "./trailer-status.js";
  *
  * @private Internal code, does not follow semantic versioning.
  */
-export function validateTrailer(
-  trailer: Headers,
-  header: Headers | undefined,
-): void {
+export function validateTrailer(trailer: Headers, header: Headers): void {
   const err = findTrailerError(trailer);
   if (err) {
-    header?.forEach((value, key) => {
+    header.forEach((value, key) => {
       err.metadata.append(key, value);
     });
     throw err;


### PR DESCRIPTION
In server streaming for all protocols and unary for gRPC/gRPC-Web if an error occurs after the headers are received `ConnectError.metadata` doesn't include them. Instead they are only part of the `onHeader` callback. 

We change the behavior to always capture header in `ConnecError`. 

This was caught by the new conformance tests for client in #890.