### PR TITLE
Export `*TransportOptions` types for `connect-node`

### DIFF
--- a/packages/connect-node/src/connect-node-adapter.ts
+++ b/packages/connect-node/src/connect-node-adapter.ts
@@ -31,7 +31,7 @@ import type {
 } from "./node-universal-handler.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 
-interface ConnectNodeAdapterOptions extends ConnectRouterOptions {
+export interface ConnectNodeAdapterOptions extends ConnectRouterOptions {
   /**
    * Route definitions. We recommend the following pattern:
    *

--- a/packages/connect-node/src/connect-transport.ts
+++ b/packages/connect-node/src/connect-transport.ts
@@ -29,7 +29,7 @@ import { validateNodeTransportOptions } from "./node-transport-options.js";
  *
  * See createConnectTransport().
  */
-type ConnectTransportOptions = NodeTransportOptions & {
+export type ConnectTransportOptions = NodeTransportOptions & {
   /**
    * Base URI for all HTTP requests.
    *

--- a/packages/connect-node/src/grpc-transport.ts
+++ b/packages/connect-node/src/grpc-transport.ts
@@ -29,7 +29,7 @@ import { validateNodeTransportOptions } from "./node-transport-options.js";
  *
  * See createGrpcTransport().
  */
-type GrpcTransportOptions = NodeTransportOptions & {
+export type GrpcTransportOptions = NodeTransportOptions & {
   /**
    * Base URI for all HTTP requests.
    *

--- a/packages/connect-node/src/grpc-web-transport.ts
+++ b/packages/connect-node/src/grpc-web-transport.ts
@@ -29,7 +29,7 @@ import { validateNodeTransportOptions } from "./node-transport-options.js";
  *
  * See createGrpcWebTransport().
  */
-type GrpcWebTransportOptions = NodeTransportOptions & {
+export type GrpcWebTransportOptions = NodeTransportOptions & {
   /**
    * Base URI for all HTTP requests.
    *

--- a/packages/connect-node/src/index.ts
+++ b/packages/connect-node/src/index.ts
@@ -16,10 +16,14 @@
 import "./node-headers-polyfill.js";
 
 export { createGrpcWebTransport } from "./grpc-web-transport.js";
+export type { GrpcWebTransportOptions } from "./grpc-web-transport.js";
 export { createGrpcTransport } from "./grpc-transport.js";
+export type { GrpcTransportOptions } from "./grpc-transport.js";
 export { createConnectTransport } from "./connect-transport.js";
+export type { ConnectTransportOptions } from "./connect-transport.js";
 export { compressionBrotli, compressionGzip } from "./compression.js";
 export { connectNodeAdapter } from "./connect-node-adapter.js";
+export type { ConnectNodeAdapterOptions } from "./connect-node-adapter.js";
 
 export {
   universalRequestFromNodeRequest,
@@ -27,4 +31,6 @@ export {
 } from "./node-universal-handler.js";
 
 export { createNodeHttpClient } from "./node-universal-client.js";
+export type { NodeHttpClientOptions } from "./node-universal-client.js";
 export { Http2SessionManager } from "./http2-session-manager.js";
+export type { Http2SessionOptions } from "./http2-session-manager.js";

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -40,7 +40,7 @@ import { Http2SessionManager } from "./http2-session-manager.js";
  * Options for creating an UniversalClientFn using the Node.js `http`, `https`,
  * or `http2` module.
  */
-type NodeHttpClientOptions =
+export type NodeHttpClientOptions =
   | {
       /**
        * Use the Node.js `http` or `https` module.


### PR DESCRIPTION
Looks like there are some missing types for `connect-node`