### PR TITLE
Fix normalization of partial messages

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 117,291 b | 50,936 b | 13,658 b |
+| connect        | 117,288 b | 50,936 b | 13,651 b |
 | grpc-web       | 415,212 b    | 300,936 b    | 53,420 b |

--- a/packages/connect/src/protocol/normalize.spec.ts
+++ b/packages/connect/src/protocol/normalize.spec.ts
@@ -1,0 +1,83 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createAsyncIterable } from "./async-iterable.js";
+import { normalize, normalizeIterable } from "./normalize.js";
+import { Duration, protoInt64, Timestamp } from "@bufbuild/protobuf";
+import { readAll } from "./async-iterable-helper.spec.js";
+
+describe("normalize()", function () {
+  it("should normalize from object literal", function () {
+    const normal = normalize(Timestamp, {
+      nanos: 123,
+    });
+    expect(normal).toBeInstanceOf(Timestamp);
+    expect(normal.nanos).toBe(123);
+    expect(normal.seconds).toBe(protoInt64.parse(0));
+  });
+  it("should normalize from different message type", function () {
+    const normal = normalize(
+      Timestamp,
+      new Duration({
+        nanos: 123,
+      }),
+    );
+    expect(normal).toBeInstanceOf(Timestamp);
+    expect(normal.nanos).toBe(123);
+    expect(normal.seconds).toBe(protoInt64.parse(0));
+  });
+  it("should not modify instance of the normal type", function () {
+    const original = new Timestamp();
+    const normal = normalize(Timestamp, original);
+    expect(normal).toBe(original);
+  });
+});
+
+describe("normalizeIterable()", function () {
+  it("should normalize from object literal", async function () {
+    const input = [{ nanos: 123 }, { nanos: 456 }];
+    const normal = await readAll(
+      normalizeIterable(Timestamp, createAsyncIterable(input)),
+    );
+    expect(normal.length).toBe(2);
+    expect(normal[0]).toBeInstanceOf(Timestamp);
+    expect(normal[0].nanos).toBe(123);
+    expect(normal[0].seconds).toBe(protoInt64.parse(0));
+    expect(normal[1]).toBeInstanceOf(Timestamp);
+    expect(normal[1].nanos).toBe(456);
+    expect(normal[1].seconds).toBe(protoInt64.parse(0));
+  });
+  it("should normalize from different message type", async function () {
+    const input = [new Duration({ nanos: 123 }), new Duration({ nanos: 456 })];
+    const normal = await readAll(
+      normalizeIterable(Timestamp, createAsyncIterable(input)),
+    );
+    expect(normal.length).toBe(2);
+    expect(normal[0]).toBeInstanceOf(Timestamp);
+    expect(normal[0].nanos).toBe(123);
+    expect(normal[0].seconds).toBe(protoInt64.parse(0));
+    expect(normal[1]).toBeInstanceOf(Timestamp);
+    expect(normal[1].nanos).toBe(456);
+    expect(normal[1].seconds).toBe(protoInt64.parse(0));
+  });
+  it("should not modify instance of the normal type", async function () {
+    const input = [new Timestamp(), new Timestamp()];
+    const normal = await readAll(
+      normalizeIterable(Timestamp, createAsyncIterable(input)),
+    );
+    expect(normal.length).toBe(2);
+    expect(normal[0]).toBe(input[0]);
+    expect(normal[1]).toBe(input[1]);
+  });
+});

--- a/packages/connect/src/protocol/normalize.ts
+++ b/packages/connect/src/protocol/normalize.ts
@@ -23,7 +23,9 @@ export function normalize<T extends Message<T>>(
   type: MessageType<T>,
   message: T | PartialMessage<T>,
 ) {
-  return message instanceof Message ? message : new type(message);
+  return message instanceof type
+    ? message
+    : new type(message as PartialMessage<T>);
 }
 
 /**


### PR DESCRIPTION
Connect supports two styles of passing a request message to a client. 

1) With a concrete instance:
```ts
const req = new SayRequest({ sentence: "hello" });
client.say(req);
```

2) Or with an object literal:

```ts
client.say({ sentence: "hello" });
```

The object literal is just a convenient shortcut, and simply calls `new SayRequest` with the given [partial message](https://github.com/bufbuild/protobuf-es/blob/main/docs/runtime_api.md#partialmessage) as an argument.

There is a flaw in the logic that converts a partial message to a concrete instance: If a different message instance is passed to the client, it is not converted to the correct instance. For example, provided that the Protobuf message `SimilarToSayRequest` also has a field `string sentence` like the [original](https://github.com/connectrpc/examples-go/blob/5322b9916c661b763fe0aee9477cbaacf971f687/proto/connectrpc/eliza/v1/eliza.proto#L40-L42), the following code compiles without error:

```ts
const req = new SimilarToSayRequest({ sentence: "hello" });
client.say(req);
```

Note that TypeScript does not use nominal typing, and passing a different message is not a type error if it structurally matches. The issue is that the message properties are not converted via `new SayRequest`, and the serialization logic of `SimilarToSayRequest` is applied, which will lead to corrupt data for the RPC unless the same Protobuf field numbers are used. 

We recommend to stick with one of the two styles above, and not pass different message types to an RPC, but it's only logical to treat a different message type the same way as we treat an object literal. 

This PR changes the behavior to convert the request message via `new SayRequest`, unless the message is an instance of `SayRequest` (required to retain [unknown fields](https://protobuf.dev/programming-guides/proto3/#unknowns)).
