### PR TITLE
Add missed fields for service and method, in grpc-web unary response

### DIFF
--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -219,6 +219,8 @@ export function createGrpcWebTransport(
           }
           return <UnaryResponse<I, O>>{
             stream: false,
+            service,
+            method,
             header: response.headers,
             message,
             trailer,


### PR DESCRIPTION
In grcp-web-transport.ts, unary response missed service and method fileds.
I add these fields like connect-transport.ts