### PR TITLE
Add service and method in grpc-web unary response

### DIFF
--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -219,7 +219,7 @@ export function createConnectTransport(
             response.headers,
           );
 
-          return <UnaryResponse<I, O>>{
+          return {
             stream: false,
             service,
             method,

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -219,6 +219,8 @@ export function createGrpcWebTransport(
           }
           return <UnaryResponse<I, O>>{
             stream: false,
+            service,
+            method,
             header: response.headers,
             message,
             trailer,

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -217,7 +217,7 @@ export function createGrpcWebTransport(
           if (message === undefined) {
             throw "missing message";
           }
-          return <UnaryResponse<I, O>>{
+          return {
             stream: false,
             service,
             method,


### PR DESCRIPTION
Unary response of gRPC-Web missed a service and a method field.
So I add these like connect-transport.ts