### PR TITLE
adding support for Nestjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /packages/connect-web-test/local.log
 /packages/connect-node-test/.connect-node-h1-server.*
 node_modules
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ $(BUILD)/connect-express: $(BUILD)/connect $(BUILD)/connect-node packages/connec
 	@mkdir -p $(@D)
 	@touch $(@)
 
+$(BUILD)/connect-nest: $(BUILD)/connect $(BUILD)/connect-node packages/connect-nest/tsconfig.json $(shell find packages/connect-nest/src -name '*.ts')
+	npm run -w packages/connect-nest clean
+	npm run -w packages/connect-nest build
+	@mkdir -p $(@D)
+	@touch $(@)
+
 $(BUILD)/connect-next: $(BUILD)/connect $(BUILD)/connect-node packages/connect-next/tsconfig.json $(shell find packages/connect-next/src -name '*.ts')
 	npm run -w packages/connect-next clean
 	npm run -w packages/connect-next build
@@ -107,7 +113,7 @@ $(BUILD)/connect-web-test: $(BUILD)/connect-web $(GEN)/connect-web-test packages
 	@mkdir -p $(@D)
 	@touch $(@)
 
-$(BUILD)/connect-node-test: $(BUILD)/connect-node $(BUILD)/connect-fastify $(BUILD)/connect-express $(BUILD)/connect-next $(GEN)/connect-node-test packages/connect-node-test/tsconfig.json $(shell find packages/connect-node-test/src -name '*.ts')
+$(BUILD)/connect-node-test: $(BUILD)/connect-node $(BUILD)/connect-fastify $(BUILD)/connect-express $(BUILD)/connect-nest $(BUILD)/connect-next $(GEN)/connect-node-test packages/connect-node-test/tsconfig.json $(shell find packages/connect-node-test/src -name '*.ts')
 	npm run -w packages/connect-node-test clean
 	npm run -w packages/connect-node-test build
 	@mkdir -p $(@D)
@@ -181,7 +187,7 @@ clean: conformanceserverstop ## Delete build artifacts and installed dependencie
 	git clean -Xdf
 
 .PHONY: build
-build: $(BUILD)/connect $(BUILD)/connect-web $(BUILD)/connect-node $(BUILD)/connect-fastify $(BUILD)/connect-express $(BUILD)/connect-next $(BUILD)/protoc-gen-connect-es $(BUILD)/example $(BUILD)/connect-migrate ## Build
+build: $(BUILD)/connect $(BUILD)/connect-web $(BUILD)/connect-node $(BUILD)/connect-fastify $(BUILD)/connect-express $(BUILD)/connect-nest $(BUILD)/connect-next $(BUILD)/protoc-gen-connect-es $(BUILD)/example $(BUILD)/connect-migrate ## Build
 
 .PHONY: test
 test: testconnectpackage testconnectnodepackage testnode testconformance testwebnode testwebbrowser testconnectmigrate ## Run all tests, except browserstack
@@ -257,12 +263,13 @@ testconnectmigrate: $(BUILD)/connect-migrate
 	npm run -w packages/connect-migrate test
 
 .PHONY: lint
-lint: node_modules $(BUILD)/connect $(BUILD)/connect-express $(BUILD)/connect-fastify $(BUILD)/connect-next $(BUILD)/connect-node $(BUILD)/connect-web $(GEN)/connect-web-bench ## Lint all files
+lint: node_modules $(BUILD)/connect $(BUILD)/connect-express $(BUILD)/connect-fastify $(BUILD)/connect-nest $(BUILD)/connect-next $(BUILD)/connect-node $(BUILD)/connect-web $(GEN)/connect-web-bench ## Lint all files
 	npx eslint --max-warnings 0 .
 	@# Check type exports on npm packages to verify they're correct
 	npm run -w packages/connect attw
 	npm run -w packages/connect-express attw
 	npm run -w packages/connect-fastify attw
+	npm run -w packages/connect-nest attw
 	npm run -w packages/connect-next attw
 	npm run -w packages/connect-node attw
 	npm run -w packages/connect-web attw
@@ -299,6 +306,7 @@ release: all ## Release npm packages
 		--workspace packages/connect-node \
 		--workspace packages/connect-fastify \
 		--workspace packages/connect-express \
+		--workspace packages/connect-nest \
 		--workspace packages/connect-next \
 		--workspace packages/protoc-gen-connect-es \
 		--workspace packages/connect-migrate \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ service ElizaService {
 And with the magic of code generation, this schema produces servers and clients:
 
 ```ts
-const answer = await eliza.say({sentence: "I feel happy."});
+const answer = await eliza.say({ sentence: "I feel happy." });
 console.log(answer);
 // {sentence: 'When you feel happy, what do you do?'}
 ```
@@ -43,7 +43,6 @@ gRPC-web protocols, and Connect's [own protocol](https://connectrpc.com/docs/pro
 optimized for the web. This gives you unparalleled interoperability across many
 platforms and languages, with type-safety end-to-end.
 
-
 ## Get started on the web
 
 Follow our [10 minute tutorial](https://connectrpc.com/docs/web/getting-started) where
@@ -56,7 +55,6 @@ We support all modern web browsers that implement the widely available
 [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API).
 
-
 ## Get started on Node.js
 
 Follow our [10 minute tutorial](https://connectrpc.com/docs/node/getting-started)
@@ -67,7 +65,6 @@ You can serve your Connect RPCs with vanilla Node.js, or use our [server plugins
 for **Fastify**, **Next.js**, and **Express**. We support Node.js v16 and later with
 the builtin `http` and `http2` modules.
 
-
 ## Other platforms
 
 Would you like to use Connect on other platforms like Bun, Deno, Vercel’s Edge Runtime,
@@ -75,7 +72,6 @@ or Cloudflare Workers? We’d love to learn about your use cases and what you’
 with Connect. You can reach us either through the [Buf Slack](https://buf.build/links/slack/)
 or by filing a [GitHub issue](https://github.com/connectrpc/connect-es/issues) and we’d
 be more than happy to chat!
-
 
 ## Packages
 
@@ -93,28 +89,28 @@ be more than happy to chat!
   Serve your RPCs with [Next.js](https://nextjs.org/) API routes.
 - [@connectrpc/connect-express](https://www.npmjs.com/package/@connectrpc/connect-express):
   Adds your services to an [Express](https://expressjs.com/) server.
+- [@connectrpc/connect-nest](https://www.npmjs.com/package/@connectrpc/connect-nest):
+  Serve your RPCs with [Nestjs](https://https://nestjs.com) Decorators.
 
 The libraries and the generated code are compatible with ES2017 and TypeScript 4.1.
 
-
 ## Ecosystem
 
-* [examples-es](https://github.com/connectrpc/examples-es):
+- [examples-es](https://github.com/connectrpc/examples-es):
   Examples for using Connect with various TypeScript web frameworks and tooling
-* [connect-query-es](https://github.com/connectrpc/connect-query-es):
+- [connect-query-es](https://github.com/connectrpc/connect-query-es):
   TypeScript-first expansion pack for TanStack Query that gives you Protobuf superpowers
-* [connect-playwright-es](https://github.com/connectrpc/connect-playwright-es):
+- [connect-playwright-es](https://github.com/connectrpc/connect-playwright-es):
   Playwright tests for your Connect application
-* [connect-swift](https://github.com/connectrpc/connect-swift):
+- [connect-swift](https://github.com/connectrpc/connect-swift):
   Idiomatic gRPC & Connect RPCs for Swift
-* [connect-go](https://github.com/connectrpc/connect-go):
+- [connect-go](https://github.com/connectrpc/connect-go):
   Go implementation of gRPC, gRPC-Web, and Connect
-* [examples-go](https://github.com/connectrpc/examples-go):
+- [examples-go](https://github.com/connectrpc/examples-go):
   Example RPC service powering https://demo.connectrpc.com and built with connect-go
-* [conformance](https://github.com/connectrpc/conformance):
+- [conformance](https://github.com/connectrpc/conformance):
   gRPC-Web and Connect interoperability tests
-* [Buf Studio](https://buf.build/studio): web UI for ad-hoc RPCs
-
+- [Buf Studio](https://buf.build/studio): web UI for ad-hoc RPCs
 
 ## Status: Stable
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "connect-web",
+  "name": "connect-es",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -10,6 +10,7 @@
         "./packages/connect-web",
         "./packages/connect-node",
         "./packages/connect-fastify",
+        "./packages/connect-nest",
         "./packages/connect-next",
         "./packages/connect-express",
         "./packages/connect-node-test",
@@ -1076,6 +1077,10 @@
       "resolved": "packages/connect-migrate",
       "link": true
     },
+    "node_modules/@connectrpc/connect-nest": {
+      "resolved": "packages/connect-nest",
+      "link": true
+    },
     "node_modules/@connectrpc/connect-next": {
       "resolved": "packages/connect-next",
       "link": true
@@ -1801,6 +1806,42 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nestjs/common": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.0.tgz",
+      "integrity": "sha512-DGv34UHsZBxCM3H5QGE2XE/+oLJzz5+714JQjBhjD9VccFlQs3LRxo/epso4l7nJIiNlZkPyIUC8WzfU/5RTsQ==",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@next/env": {
@@ -5464,6 +5505,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/iterare": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+      "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
@@ -6984,6 +7033,12 @@
         "esprima": "~4.0.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
+      "peer": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
@@ -7112,6 +7167,15 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -8024,6 +8088,17 @@
         "node": "*"
       }
     },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8428,6 +8503,23 @@
       },
       "devDependencies": {
         "@types/jscodeshift": "0.11.11"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "packages/connect-nest": {
+      "name": "@connectrpc/connect-nest",
+      "version": "1.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.6.0",
+        "@connectrpc/connect": "1.3.0",
+        "@connectrpc/connect-express": "1.3.0",
+        "@connectrpc/connect-fastify": "1.3.0",
+        "@connectrpc/connect-node": "1.3.0",
+        "@nestjs/common": "^10.3.0",
+        "fastify": "^4.25.2"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "./packages/connect-web",
     "./packages/connect-node",
     "./packages/connect-fastify",
+    "./packages/connect-nest",
     "./packages/connect-next",
     "./packages/connect-express",
     "./packages/connect-node-test",

--- a/packages/connect-nest/README.md
+++ b/packages/connect-nest/README.md
@@ -1,0 +1,117 @@
+# @connectrpc/connect-nest
+
+Connect is a family of libraries for building and consuming APIs on different languages and platforms, and
+[@connectrpc/connect](https://www.npmjs.com/package/@connectrpc/connect) brings type-safe APIs with Protobuf to
+TypeScript.
+
+`@connectrpc/connect-nest` provides a plugin for [Nestjs](https://https://nestjs.com),
+A progressive Node.js framework.
+
+### nestConnectMiddleware()
+
+#### Express (default)
+
+```ts
+// main.ts
+import { AppModule } from "./app.module";
+import { NestFactory } from "@nestjs/core";
+import { nestConnectMiddleware } from "./connect.middleware";
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  // Enable nestjs middleware
+  app.use(nestConnectMiddleware);
+
+  await app.listen(3000);
+}
+
+bootstrap();
+```
+
+#### Fastify
+
+```ts
+// main.ts
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from "@nestjs/platform-fastify";
+
+import { AppModule } from "./app.module";
+import { NestFactory } from "@nestjs/core";
+import { nestConnectMiddleware } from "./connect.middleware";
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter()
+  );
+
+  // Enable nestjs middleware
+  app.use(nestConnectMiddleware);
+
+  await app.listen(3000, "0.0.0.0");
+}
+
+bootstrap();
+```
+
+### @ConnectController() (Manual Mapping)
+
+```ts
+// ...controller.ts
+import { ConnectController, ConnectMethod } from "./connect.decorators";
+
+import { Get } from "@nestjs/common";
+import { TodoAPI } from "./gen/todo/v1/todo_api_connect";
+import { ListTodosRequest, ListTodosResponse } from "./gen/todo/v1/todo_api_pb";
+
+@ConnectController({ serviceType: TodoAPI })
+export class AppController {
+  // regular http method
+  @Get()
+  getHello() {
+    return "hello world";
+  }
+
+  @ConnectController({
+    serviceType: TodoAPI,
+  })
+  async listTodos(req: ListTodosRequest): Promise<ListTodosResponse> {
+    return { todos: [] };
+  }
+}
+```
+
+### @ConnectController() (Auto Mapping)
+
+```ts
+// ...controller.ts
+import { ConnectController, ConnectMethod } from "./connect.decorators";
+
+import { Get } from "@nestjs/common";
+import { TodoAPI } from "./gen/todo/v1/todo_api_connect";
+
+@ConnectController({
+  serviceType: TodoAPI,
+  autoMappping: {
+    enable: true,
+  },
+})
+export class AppController {
+  // regular http method
+  @Get()
+  getHello() {
+    return "hello world";
+  }
+
+  // auto mapped due to name matching
+  async listTodos() {}
+}
+```
+
+## Getting started
+
+To get started with Connect, head over to the [docs](https://connectrpc.com/docs/node/getting-started)
+for a tutorial, or take a look at [our example](https://github.com/connectrpc/connect-es/tree/main/packages/example).

--- a/packages/connect-nest/package.json
+++ b/packages/connect-nest/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@connectrpc/connect-nest",
+  "version": "1.3.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/connectrpc/connect-es.git",
+    "directory": "packages/connect-nest"
+  },
+  "scripts": {
+    "clean": "rm -rf ./dist/*",
+    "build": "npm run build:cjs && npm run build:esm && npm run build:proxy",
+    "build:cjs": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "tsc --project tsconfig.json --module ES2015 --verbatimModuleSyntax --outDir ./dist/esm --declaration --declarationDir ./dist/esm",
+    "build:proxy": "node ../../scripts/gen-esm-proxy.mjs .",
+    "attw": "attw --pack"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "node": {
+        "import": "./dist/proxy/index.js",
+        "require": "./dist/cjs/index.js"
+      },
+      "module": "./dist/esm/index.js",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "peerDependencies": {},
+  "files": [
+    "dist/**"
+  ],
+  "dependencies": {
+    "@bufbuild/protobuf": "^1.6.0",
+    "@nestjs/common": "^10.3.0",
+    "@connectrpc/connect": "1.3.0",
+    "@connectrpc/connect-express": "1.3.0",
+    "@connectrpc/connect-node": "1.3.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  }
+}

--- a/packages/connect-nest/src/connect.decorators.ts
+++ b/packages/connect-nest/src/connect.decorators.ts
@@ -1,0 +1,136 @@
+import { Controller, Logger } from "@nestjs/common";
+import type { MethodInfo, ServiceType } from "@bufbuild/protobuf";
+
+import { ConnectStore } from "./connect.store";
+import { MethodIdempotency } from "@bufbuild/protobuf";
+
+export interface ConnectControllerOptions {
+  serviceType: ServiceType;
+  autoMappping?: {
+    enable: boolean;
+    replace?: {
+      [key: string]: string;
+    };
+  };
+}
+
+const store = ConnectStore.getInstance();
+const logger = new Logger("ConnectRouter");
+
+const ConnectControllerMetadataKey = Symbol("ConnectControllerMetadataKey");
+
+interface ConnectControllerMetadata {
+  methodInfo: MethodInfo;
+  target: any;
+  propertyKey: string;
+  descriptor: PropertyDescriptor;
+}
+
+export function ConnectController(options: ConnectControllerOptions) {
+  return (target: any) => {
+    // custom mapping
+    const metadata: Set<ConnectControllerMetadata> | undefined =
+      Reflect.getMetadata(ConnectControllerMetadataKey, target);
+    if (metadata) {
+      for (const item of metadata) {
+        if (
+          store.addHandler({
+            serviceType: options.serviceType,
+            methodInfo: item.methodInfo,
+            handler: item.descriptor.value,
+          })
+        ) {
+          logger.log(
+            `Custom Mapped {/${options.serviceType.typeName}/${
+              item.methodInfo.name
+            }, ${target.name}.${item.propertyKey}, ${
+              item.methodInfo.idempotency === MethodIdempotency.NoSideEffects
+                ? "GET|POST"
+                : "POST"
+            }} route`
+          );
+        }
+      }
+    }
+    // auto mapping
+    if (options.autoMappping?.enable) {
+      for (const methodKey in options.serviceType.methods) {
+        const methodInfo = options.serviceType.methods[methodKey];
+
+        let methodName = methodKey;
+        if (options.autoMappping?.replace) {
+          for (const key in options.autoMappping.replace) {
+            methodName = methodName.replace(
+              key,
+              options.autoMappping?.replace[key]
+            );
+          }
+        }
+
+        const descriptor = getMethodDescriptor(target.prototype, methodName);
+        if (descriptor) {
+          if (
+            store.addHandler({
+              serviceType: options.serviceType,
+              methodInfo: methodInfo,
+              handler: descriptor.value,
+            })
+          ) {
+            logger.log(
+              `Auto Mapped {/${options.serviceType.typeName}/${
+                methodInfo.name
+              }, ${target.name}.${methodName}, ${
+                methodInfo.idempotency === MethodIdempotency.NoSideEffects
+                  ? "GET|POST"
+                  : "POST"
+              }} route`
+            );
+          }
+        }
+      }
+    }
+    // default nest mapping
+    Controller()(target);
+  };
+}
+
+export interface ConnectMethodOptions {
+  methodInfo: MethodInfo;
+}
+
+export function ConnectMethod(options: ConnectMethodOptions) {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    const metadata: Set<ConnectControllerMetadata> =
+      Reflect.getMetadata(ConnectControllerMetadataKey, target.constructor) ||
+      new Set<ConnectControllerMetadata>();
+
+    metadata.add({
+      methodInfo: options.methodInfo,
+      target,
+      propertyKey,
+      descriptor,
+    });
+
+    Reflect.defineMetadata(
+      ConnectControllerMetadataKey,
+      metadata,
+      target.constructor
+    );
+  };
+}
+
+function getMethodDescriptor(target: any, methodName: string) {
+  // If target is null or undefined, return undefined
+  if (target === null || target === undefined) {
+    return undefined;
+  }
+
+  // Check if the method exists directly on the target
+  const descriptor = Object.getOwnPropertyDescriptor(target, methodName);
+  if (descriptor) {
+    return descriptor;
+  }
+
+  // Recursively check the prototype chain
+  return getMethodDescriptor(Object.getPrototypeOf(target), methodName);
+}

--- a/packages/connect-nest/src/connect.middleware.ts
+++ b/packages/connect-nest/src/connect.middleware.ts
@@ -1,0 +1,16 @@
+import type { NextFunction, Request, Response } from "express";
+
+import { ConnectStore } from "./connect.store";
+import { expressConnectMiddleware } from "@connectrpc/connect-express";
+
+export function nestConnectMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const routes = ConnectStore.routes;
+
+  expressConnectMiddleware({
+    routes,
+  })(req, res, next);
+}

--- a/packages/connect-nest/src/connect.store.ts
+++ b/packages/connect-nest/src/connect.store.ts
@@ -1,0 +1,53 @@
+import type { MethodInfo, ServiceType } from '@bufbuild/protobuf';
+
+import type { ConnectRouter } from '@connectrpc/connect';
+
+export interface HandlerInfo {
+  serviceType: ServiceType;
+  methodInfo: MethodInfo;
+  handler: any;
+}
+
+export class ConnectStore {
+  private static instance: ConnectStore;
+  private data: Set<HandlerInfo> = new Set();
+
+  constructor() {}
+
+  static getInstance() {
+    if (!ConnectStore.instance) {
+      ConnectStore.instance = new ConnectStore();
+    }
+
+    return ConnectStore.instance;
+  }
+
+  addHandler(handlerData: HandlerInfo) {
+    for (const handler of this.data) {
+      if (
+        handler.serviceType.typeName === handlerData.serviceType.typeName &&
+        handler.methodInfo.name === handlerData.methodInfo.name
+      ) {
+        return false;
+      }
+    }
+    this.data.add(handlerData);
+    return true;
+  }
+
+  getHandlers() {
+    return this.data;
+  }
+
+  static routes(router: ConnectRouter) {
+    ConnectStore.getInstance()
+      .getHandlers()
+      .forEach((handlerInfo) => {
+        router.rpc(
+          handlerInfo.serviceType,
+          handlerInfo.methodInfo,
+          handlerInfo.handler,
+        );
+      });
+  }
+}

--- a/packages/connect-nest/src/index.ts
+++ b/packages/connect-nest/src/index.ts
@@ -1,0 +1,2 @@
+export { ConnectController, ConnectMethod } from "./connect.decorators";
+export { nestConnectMiddleware } from "./connect.middleware";

--- a/packages/connect-nest/tsconfig.json
+++ b/packages/connect-nest/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "files": ["src/index.ts"],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    // We see a row of errors from Next.js typings here, most likely simply
+    // because of dependencies we do not install. For simplicity, we are
+    // ignoring them, because we do not want to check Next.js typings.
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Draft Proposal

New connect-nest package to natively support Buf Connect in Nestjs.

This packages uses [NestMiddleware](https://docs.nestjs.com/middleware) to integrate with Buf Connect with the underlying express or fastify server (agnostic implementation).