### PR TITLE
Update conformance proto version

### DIFF
--- a/packages/connect-conformance/conformance-node.yaml
+++ b/packages/connect-conformance/conformance-node.yaml
@@ -16,6 +16,6 @@ features:
   supportsTls: true
   supportsTlsClientCerts: true
   supportsConnectGet: true
-  supportsHalfDuplexBidiOverHttp1: true
+  supportsHalfDuplexBidiOverHttp1: false
   requiresConnectVersionHeader: false
   supportsMessageReceiveLimit: true

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -7,7 +7,7 @@
     "connectconformance": "bin/connectconformance"
   },
   "scripts": {
-    "generate": "buf generate buf.build/connectrpc/conformance:v1.0.0-rc1",
+    "generate": "buf generate buf.build/connectrpc/conformance:v1.0.0-rc2",
     "clean": "rm -rf ./dist/cjs/*",
     "build": "tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs",
     "test:node:server": "./bin/connectconformance --mode server --conf conformance-node.yaml -v ./bin/conformancenodeserver",

--- a/packages/connect-conformance/src/gen/connectrpc/conformance/v1/service_connect.ts
+++ b/packages/connect-conformance/src/gen/connectrpc/conformance/v1/service_connect.ts
@@ -16,8 +16,8 @@
 // @generated from file connectrpc/conformance/v1/service.proto (package connectrpc.conformance.v1, syntax proto3)
 /* eslint-disable */
 
-import { BidiStreamRequest, BidiStreamResponse, ClientStreamRequest, ClientStreamResponse, ServerStreamRequest, ServerStreamResponse, UnaryRequest, UnaryResponse, UnimplementedRequest, UnimplementedResponse } from "./service_pb.js";
-import { MethodKind } from "@bufbuild/protobuf";
+import { BidiStreamRequest, BidiStreamResponse, ClientStreamRequest, ClientStreamResponse, IdempotentUnaryRequest, IdempotentUnaryResponse, ServerStreamRequest, ServerStreamResponse, UnaryRequest, UnaryResponse, UnimplementedRequest, UnimplementedResponse } from "./service_pb.js";
+import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
 
 /**
  * The service implemented by conformance test servers. This is implemented by
@@ -26,21 +26,26 @@ import { MethodKind } from "@bufbuild/protobuf";
  *
  * Test servers must implement the service as described.
  *
+ * A unary operation. The request indicates the response headers and trailers
+ * and also indicates either a response message or an error to send back.
+ *
+ * Response message data is specified as bytes. The service should echo back
+ * request properties in the ConformancePayload and then include the message
+ * data in the data field.
+ *
  * @generated from service connectrpc.conformance.v1.ConformanceService
  */
 export const ConformanceService = {
   typeName: "connectrpc.conformance.v1.ConformanceService",
   methods: {
     /**
-     * A unary operation. The request indicates the response headers and trailers
-     * and also indicates either a response message or an error to send back.
-     *
-     * Response message data is specified as bytes. The service should echo back
-     * request properties in the ConformancePayload and then include the message
-     * data in the data field.
+     * If the response_delay_ms duration is specified, the server should wait the
+     * given duration after reading the request before sending the corresponding
+     * response.
      *
      * Servers should allow the response definition to be unset in the request and
-     * if it is, set no response headers or trailers and send back an empty response.
+     * if it is, set no response headers or trailers and return no response data.
+     * The returned payload should only contain the request info.
      *
      * @generated from rpc connectrpc.conformance.v1.ConformanceService.Unary
      */
@@ -61,10 +66,26 @@ export const ConformanceService = {
      * message data in the data field. Subsequent messages after the first one
      * should contain only the data field.
      *
-     * Servers should allow the response definition to be unset in the request and
-     * if so, all responses should contain no response headers or trailers and
-     * contain empty response data.
+     * Servers should immediately send response headers on the stream before sleeping
+     * for any specified response delay and/or sending the first message so that
+     * clients can be unblocked reading response headers.
      *
+     * If a response definition is not specified OR is specified, but response data
+     * is empty, the server should skip sending anything on the stream. When there
+     * are no responses to send, servers should throw an error if one is provided
+     * and return without error if one is not. Stream headers and trailers should
+     * still be set on the stream if provided regardless of whether a response is
+     * sent or an error is thrown.
+     *
+     * @generated from rpc connectrpc.conformance.v1.ConformanceService.ServerStream
+     */
+    serverStream: {
+      name: "ServerStream",
+      I: ServerStreamRequest,
+      O: ServerStreamResponse,
+      kind: MethodKind.ServerStreaming,
+    },
+    /**
      * A client-streaming operation. The first request indicates the response
      * headers and trailers and also indicates either a response message or an
      * error to send back.
@@ -80,17 +101,9 @@ export const ConformanceService = {
      * Servers should only read the response definition from the first message in
      * the stream and should ignore any definition set in subsequent messages.
      *
-     * @generated from rpc connectrpc.conformance.v1.ConformanceService.ServerStream
-     */
-    serverStream: {
-      name: "ServerStream",
-      I: ServerStreamRequest,
-      O: ServerStreamResponse,
-      kind: MethodKind.ServerStreaming,
-    },
-    /**
      * Servers should allow the response definition to be unset in the request and
-     * if it is, set no response headers or trailers and send back empty response data.
+     * if it is, set no response headers or trailers and return no response data.
+     * The returned payload should only contain the request info.
      *
      * @generated from rpc connectrpc.conformance.v1.ConformanceService.ClientStream
      */
@@ -104,30 +117,51 @@ export const ConformanceService = {
      * A bidirectional-streaming operation. The first request indicates the response
      * headers, response messages, trailers, and an optional error to send back.
      * The response data should be sent in the order indicated, and the server
-     * should wait between sending response messages as indicated. If the
-     * full_duplex field is true, the handler should read one request
-     * and then send back one response, and then alternate, reading another
-     * request and then sending back another response, etc. If the response_delay_ms
-     * duration is specified, the server should wait that long in between sending each
-     * response message. If both are specified, the server should wait the given
-     * duration after reading the request before sending the corresponding
-     * response.
+     * should wait between sending response messages as indicated.
      *
      * Response message data is specified as bytes and should be included in the
      * data field of the ConformancePayload in each response.
      *
-     * If the full_duplex field is true, the service should echo back all request
-     * properties in the first response including the last received request.
-     * Subsequent responses should only echo back the last received request.
+     * Servers should send responses indicated according to the rules of half duplex
+     * vs. full duplex streams. Once all responses are sent, the server should either
+     * return an error if specified or close the stream without error.
      *
-     * If the full_duplex field is false, the service should echo back all request
-     * properties, including all request messages in the order they were
-     * received, in the ConformancePayload. Subsequent responses should only include
-     * the message data in the data field.
+     * Servers should immediately send response headers on the stream before sleeping
+     * for any specified response delay and/or sending the first message so that
+     * clients can be unblocked reading response headers.
      *
-     * If the input stream is empty, the server should send a single response
-     * message that includes no data and only the request properties (headers,
-     * timeout).
+     * If a response definition is not specified OR is specified, but response data
+     * is empty, the server should skip sending anything on the stream. Stream
+     * headers and trailers should always be set on the stream if provided
+     * regardless of whether a response is sent or an error is thrown.
+     *
+     * If the full_duplex field is true:
+     * - the handler should read one request and then send back one response, and
+     *   then alternate, reading another request and then sending back another response, etc.
+     *
+     * - if the server receives a request and has no responses to send, it
+     *   should throw the error specified in the request.
+     *
+     * - the service should echo back all request properties in the first response
+     *   including the last received request. Subsequent responses should only
+     *   echo back the last received request.
+     *
+     * - if the response_delay_ms duration is specified, the server should wait the given
+     *   duration after reading the request before sending the corresponding
+     *   response.
+     *
+     * If the full_duplex field is false:
+     * - the handler should read all requests until the client is done sending.
+     *   Once all requests are read, the server should then send back any responses
+     *   specified in the response definition.
+     *
+     * - the server should echo back all request properties, including all request
+     *   messages in the order they were received, in the first response. Subsequent
+     *   responses should only include the message data in the data field.
+     *
+     * - if the response_delay_ms duration is specified, the server should wait that
+     *   long in between sending each response message.
+     *
      *
      * @generated from rpc connectrpc.conformance.v1.ConformanceService.BidiStream
      */
@@ -148,6 +182,20 @@ export const ConformanceService = {
       I: UnimplementedRequest,
       O: UnimplementedResponse,
       kind: MethodKind.Unary,
+    },
+    /**
+     * A unary endpoint denoted as having no side effects (i.e. idempotent).
+     * Implementations should use an HTTP GET when invoking this endpoint and
+     * leverage query parameters to send data.
+     *
+     * @generated from rpc connectrpc.conformance.v1.ConformanceService.IdempotentUnary
+     */
+    idempotentUnary: {
+      name: "IdempotentUnary",
+      I: IdempotentUnaryRequest,
+      O: IdempotentUnaryResponse,
+      kind: MethodKind.Unary,
+      idempotency: MethodIdempotency.NoSideEffects,
     },
   }
 } as const;

--- a/packages/connect-conformance/src/gen/connectrpc/conformance/v1/service_pb.ts
+++ b/packages/connect-conformance/src/gen/connectrpc/conformance/v1/service_pb.ts
@@ -65,6 +65,13 @@ export class UnaryResponseDefinition extends Message<UnaryResponseDefinition> {
   responseTrailers: Header[] = [];
 
   /**
+   * Wait this many milliseconds before sending a response message
+   *
+   * @generated from field: uint32 response_delay_ms = 6;
+   */
+  responseDelayMs = 0;
+
+  /**
    * This field is only used by the reference server. If you are implementing a
    * server under test, you can ignore this field or respond with an error if the
    * server receives a request where it is set.
@@ -87,6 +94,7 @@ export class UnaryResponseDefinition extends Message<UnaryResponseDefinition> {
     { no: 2, name: "response_data", kind: "scalar", T: 12 /* ScalarType.BYTES */, oneof: "response" },
     { no: 3, name: "error", kind: "message", T: Error, oneof: "response" },
     { no: 4, name: "response_trailers", kind: "message", T: Header, repeated: true },
+    { no: 6, name: "response_delay_ms", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
     { no: 5, name: "raw_response", kind: "message", T: RawHTTPResponse },
   ]);
 
@@ -280,6 +288,92 @@ export class UnaryResponse extends Message<UnaryResponse> {
 
   static equals(a: UnaryResponse | PlainMessage<UnaryResponse> | undefined, b: UnaryResponse | PlainMessage<UnaryResponse> | undefined): boolean {
     return proto3.util.equals(UnaryResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message connectrpc.conformance.v1.IdempotentUnaryRequest
+ */
+export class IdempotentUnaryRequest extends Message<IdempotentUnaryRequest> {
+  /**
+   * The response definition which should be returned in the conformance payload
+   *
+   * @generated from field: connectrpc.conformance.v1.UnaryResponseDefinition response_definition = 1;
+   */
+  responseDefinition?: UnaryResponseDefinition;
+
+  /**
+   * Additional data. Only used to pad the request size to test large request messages.
+   *
+   * @generated from field: bytes request_data = 2;
+   */
+  requestData = new Uint8Array(0);
+
+  constructor(data?: PartialMessage<IdempotentUnaryRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "connectrpc.conformance.v1.IdempotentUnaryRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "response_definition", kind: "message", T: UnaryResponseDefinition },
+    { no: 2, name: "request_data", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): IdempotentUnaryRequest {
+    return new IdempotentUnaryRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): IdempotentUnaryRequest {
+    return new IdempotentUnaryRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): IdempotentUnaryRequest {
+    return new IdempotentUnaryRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: IdempotentUnaryRequest | PlainMessage<IdempotentUnaryRequest> | undefined, b: IdempotentUnaryRequest | PlainMessage<IdempotentUnaryRequest> | undefined): boolean {
+    return proto3.util.equals(IdempotentUnaryRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message connectrpc.conformance.v1.IdempotentUnaryResponse
+ */
+export class IdempotentUnaryResponse extends Message<IdempotentUnaryResponse> {
+  /**
+   * The conformance payload to respond with.
+   *
+   * @generated from field: connectrpc.conformance.v1.ConformancePayload payload = 1;
+   */
+  payload?: ConformancePayload;
+
+  constructor(data?: PartialMessage<IdempotentUnaryResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "connectrpc.conformance.v1.IdempotentUnaryResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "payload", kind: "message", T: ConformancePayload },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): IdempotentUnaryResponse {
+    return new IdempotentUnaryResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): IdempotentUnaryResponse {
+    return new IdempotentUnaryResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): IdempotentUnaryResponse {
+    return new IdempotentUnaryResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: IdempotentUnaryResponse | PlainMessage<IdempotentUnaryResponse> | undefined, b: IdempotentUnaryResponse | PlainMessage<IdempotentUnaryResponse> | undefined): boolean {
+    return proto3.util.equals(IdempotentUnaryResponse, a, b);
   }
 }
 

--- a/packages/connect-conformance/src/node/server.ts
+++ b/packages/connect-conformance/src/node/server.ts
@@ -75,8 +75,6 @@ export function run() {
         requestCert: true,
         rejectUnauthorized: true,
         ca: Buffer.from(req.clientTlsCert),
-        highWaterMark:
-          req.messageReceiveLimit === 0 ? undefined : req.messageReceiveLimit,
       };
     }
   }
@@ -84,15 +82,7 @@ export function run() {
     case HTTPVersion.HTTP_VERSION_1:
       server = req.useTls
         ? https.createServer(serverOptions, adapter)
-        : http.createServer(
-            {
-              highWaterMark:
-                req.messageReceiveLimit === 0
-                  ? undefined
-                  : req.messageReceiveLimit,
-            },
-            adapter,
-          );
+        : http.createServer(adapter);
       break;
     case HTTPVersion.HTTP_VERSION_2:
       server = req.useTls

--- a/packages/connect-conformance/src/node/transport.ts
+++ b/packages/connect-conformance/src/node/transport.ts
@@ -31,6 +31,7 @@ import { Compression } from "@connectrpc/connect/protocol";
 import {
   BidiStreamRequest,
   ClientStreamRequest,
+  IdempotentUnaryRequest,
   ServerStreamRequest,
   UnaryRequest,
 } from "../gen/connectrpc/conformance/v1/service_pb.js";
@@ -58,13 +59,16 @@ export function createTransport(req: ClientCompatRequest) {
   }
 
   let sendCompression: Compression | undefined = undefined;
+  let acceptCompression: Compression[] = [];
 
   switch (req.compression) {
     case ConformanceCompression.GZIP:
       sendCompression = compressionGzip;
+      acceptCompression = [compressionGzip];
       break;
     case ConformanceCompression.BR:
       sendCompression = compressionBrotli;
+      acceptCompression = [compressionBrotli];
       break;
     case ConformanceCompression.DEFLATE:
     case ConformanceCompression.SNAPPY:
@@ -88,6 +92,7 @@ export function createTransport(req: ClientCompatRequest) {
     httpVersion,
     useBinaryFormat: req.codec === Codec.PROTO,
     sendCompression,
+    acceptCompression: acceptCompression,
     defaultTimeoutMs: req.timeoutMs,
     compressMinBytes: -1, // To account for empty messages
     jsonOptions: {
@@ -96,6 +101,7 @@ export function createTransport(req: ClientCompatRequest) {
         ServerStreamRequest,
         ClientStreamRequest,
         BidiStreamRequest,
+        IdempotentUnaryRequest,
       ),
     },
     nodeOptions: {


### PR DESCRIPTION
Update conformance proto version to rc2. Some of the client tests (get and cacelation) fail with rc2 runner but pass when run against latest main. So not updating the runner yet.