### PR TITLE
Avoid instanceof Message

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 122,817 b | 53,918 b | 14,494 b |
+| connect        | 122,811 b | 53,916 b | 14,497 b |
 | grpc-web       | 415,212 b    | 300,936 b    | 53,420 b |

--- a/packages/connect/src/connect-error.ts
+++ b/packages/connect/src/connect-error.ts
@@ -14,12 +14,12 @@
 
 import { Code } from "./code.js";
 import type {
+  Message,
   AnyMessage,
   IMessageTypeRegistry,
   JsonValue,
   MessageType,
 } from "@bufbuild/protobuf";
-import { Message } from "@bufbuild/protobuf";
 import { codeToString } from "./protocol-connect/code-string.js";
 
 /**
@@ -172,7 +172,7 @@ export class ConnectError extends Error {
         : typeOrRegistry;
     const details: AnyMessage[] = [];
     for (const data of this.details) {
-      if (data instanceof Message) {
+      if ("getType" in data) {
         if (registry.findMessage(data.getType().typeName)) {
           details.push(data);
         }

--- a/packages/connect/src/http-headers.ts
+++ b/packages/connect/src/http-headers.ts
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { BinaryReadOptions, MessageType } from "@bufbuild/protobuf";
-import { Message, protoBase64 } from "@bufbuild/protobuf";
+import type {
+  Message,
+  BinaryReadOptions,
+  MessageType,
+} from "@bufbuild/protobuf";
+import { protoBase64 } from "@bufbuild/protobuf";
 import { ConnectError } from "./connect-error.js";
 import { Code } from "./code.js";
 
@@ -30,7 +34,7 @@ export function encodeBinaryHeader(
   value: Uint8Array | ArrayBufferLike | Message | string,
 ): string {
   let bytes: Uint8Array;
-  if (value instanceof Message) {
+  if (typeof value == "object" && "getType" in value) {
     bytes = value.toBinary();
   } else if (typeof value == "string") {
     bytes = new TextEncoder().encode(value);

--- a/packages/connect/src/protocol-connect/error-json.ts
+++ b/packages/connect/src/protocol-connect/error-json.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Message, protoBase64 } from "@bufbuild/protobuf";
+import { protoBase64 } from "@bufbuild/protobuf";
 import type {
   JsonObject,
   JsonValue,
@@ -132,7 +132,7 @@ export function errorToJson(
     };
     o.details = error.details
       .map((value) => {
-        if (value instanceof Message) {
+        if ("getType" in value) {
           const i: IncomingDetail = {
             type: value.getType().typeName,
             value: value.toBinary(),

--- a/packages/connect/src/protocol-grpc/trailer-status.ts
+++ b/packages/connect/src/protocol-grpc/trailer-status.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Any, Message } from "@bufbuild/protobuf";
+import { Any } from "@bufbuild/protobuf";
 import { Status } from "./gen/status_pb.js";
 import { ConnectError } from "../connect-error.js";
 import { decodeBinaryHeader, encodeBinaryHeader } from "../http-headers.js";
@@ -52,7 +52,7 @@ export function setTrailerStatus(
         code: error.code,
         message: error.rawMessage,
         details: error.details.map((value) =>
-          value instanceof Message
+          "getType" in value
             ? Any.pack(value)
             : new Any({
                 typeUrl: `type.googleapis.com/${value.type}`,


### PR DESCRIPTION
We want to remove the "node" condition from our exports - see https://github.com/connectrpc/connect-es/pull/1017. 

ConnectError has been made resilient against the dual package hazard with https://github.com/connectrpc/connect-es/pull/974, but we have a handful of code paths branching on `instanceof Message`. 

The exports of `@bufbuild/protobuf` still have the "node" condition and an ESM shim, but it will be removed in the future as well.

To mitigate, this PR replaces `instanceof Message` with alternative means: Checking for the presence of the "getType" property. For the relevant call sites, this check is sufficient because the incoming union types are limited, and presence of "getType" exhaustively discriminates.