### PR TITLE
Update `webdriverio` to fix CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1887,7 +1887,8 @@
     },
     "node_modules/@puppeteer/browsers": {
       "version": "1.9.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -1929,7 +1930,8 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dependencies": {
         "defer-to-connect": "^2.0.1"
       },
@@ -1997,7 +1999,8 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -2090,11 +2093,13 @@
     },
     "node_modules/@types/which": {
       "version": "2.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2302,12 +2307,13 @@
       "license": "ISC"
     },
     "node_modules/@wdio/config": {
-      "version": "8.31.1",
-      "license": "MIT",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.32.2.tgz",
+      "integrity": "sha512-ubqe4X+TgcERzXKIpMfisquNxPZNtRU5uPeV7hvas++mD75QyNpmWHCtea2+TjoXKxlZd1MVrtZAwtmqMmyhPw==",
       "dependencies": {
         "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.2",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.0.0",
         "glob": "^10.2.2",
@@ -2319,7 +2325,8 @@
     },
     "node_modules/@wdio/config/node_modules/glob": {
       "version": "10.3.10",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.5",
@@ -2339,7 +2346,8 @@
     },
     "node_modules/@wdio/logger": {
       "version": "8.28.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.28.0.tgz",
+      "integrity": "sha512-/s6zNCqwy1hoc+K4SJypis0Ud0dlJ+urOelJFO1x0G0rwDRWyFiUP6ijTaCcFxAm29jYEcEPWijl2xkVIHwOyA==",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -2352,7 +2360,8 @@
     },
     "node_modules/@wdio/logger/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "engines": {
         "node": ">=12"
       },
@@ -2362,7 +2371,8 @@
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
       "version": "5.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2372,7 +2382,8 @@
     },
     "node_modules/@wdio/logger/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2385,7 +2396,8 @@
     },
     "node_modules/@wdio/protocols": {
       "version": "8.32.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.32.0.tgz",
+      "integrity": "sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q=="
     },
     "node_modules/@wdio/repl": {
       "version": "8.24.12",
@@ -2398,8 +2410,9 @@
       }
     },
     "node_modules/@wdio/types": {
-      "version": "8.31.1",
-      "license": "MIT",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.32.2.tgz",
+      "integrity": "sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2408,12 +2421,13 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "8.31.1",
-      "license": "MIT",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.32.2.tgz",
+      "integrity": "sha512-PJcP4d1Fr8Zp+YIfGN93G0fjDj/6J0I6Gf6p0IpJk8qKQpdFDm4gB+lc202iv2YkyC+oT6b4Ik2W9LzvpSKNoQ==",
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.28.0",
-        "@wdio/types": "8.31.1",
+        "@wdio/types": "8.32.2",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.3.5",
@@ -2935,17 +2949,22 @@
     },
     "node_modules/big-integer": {
       "version": "1.6.52",
-      "license": "Unlicense",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/binary": {
       "version": "0.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
       "dependencies": {
         "buffers": "~0.1.1",
         "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -2963,7 +2982,8 @@
     },
     "node_modules/bluebird": {
       "version": "3.4.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -3116,13 +3136,16 @@
     },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/buffers": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
       "engines": {
         "node": ">=0.2.0"
       }
@@ -3165,14 +3188,16 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "engines": {
         "node": ">=14.16"
       }
     },
     "node_modules/cacheable-request": {
       "version": "10.2.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.2",
         "get-stream": "^6.0.1",
@@ -3188,7 +3213,8 @@
     },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "6.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "engines": {
         "node": ">=10"
       },
@@ -3258,9 +3284,13 @@
     },
     "node_modules/chainsaw": {
       "version": "0.1.0",
-      "license": "MIT/X11",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
       "dependencies": {
         "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -3614,7 +3644,8 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
       }
@@ -3643,7 +3674,8 @@
     },
     "node_modules/decamelize": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -3653,7 +3685,8 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -3666,7 +3699,8 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "engines": {
         "node": ">=10"
       },
@@ -3681,14 +3715,16 @@
     },
     "node_modules/deepmerge-ts": {
       "version": "5.1.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
+      "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "engines": {
         "node": ">=10"
       }
@@ -3765,8 +3801,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1260275",
-      "license": "BSD-3-Clause"
+      "version": "0.0.1261483",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1261483.tgz",
+      "integrity": "sha512-7vJvejpzA5DTfZVkr7a8sGpEAzEiAqcgmRTB0LSUrWeOicwL09lMQTzxHtFNVhJ1OOJkgYdH6Txvy9E5j3VOUQ=="
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -3810,18 +3847,21 @@
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
     },
     "node_modules/duplexer2/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/duplexer2/node_modules/readable-stream": {
       "version": "2.3.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3834,11 +3874,13 @@
     },
     "node_modules/duplexer2/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3849,7 +3891,8 @@
     },
     "node_modules/edge-paths": {
       "version": "3.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
+      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
       "dependencies": {
         "@types/which": "^2.0.1",
         "which": "^2.0.2"
@@ -3863,8 +3906,9 @@
     },
     "node_modules/edgedriver": {
       "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.3.10.tgz",
+      "integrity": "sha512-RFSHYMNtcF1PjaGZCA2rdQQ8hSTLPZgcYgeY1V6dC+tR4NhZXwFAku+8hCbRYh7ZlwKKrTbVu9FwknjFddIuuw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "^8.28.0",
         "decamelize": "^6.0.0",
@@ -3879,14 +3923,16 @@
     },
     "node_modules/edgedriver/node_modules/isexe": {
       "version": "3.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/edgedriver/node_modules/which": {
       "version": "4.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -5128,6 +5174,8 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "funding": [
         {
           "type": "github",
@@ -5138,7 +5186,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -5314,14 +5361,16 @@
     },
     "node_modules/form-data-encoder": {
       "version": "2.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
       "engines": {
         "node": ">= 14.17"
       }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -5376,7 +5425,8 @@
     },
     "node_modules/fstream": {
       "version": "1.0.12",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -5389,7 +5439,8 @@
     },
     "node_modules/fstream/node_modules/rimraf": {
       "version": "2.7.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5431,8 +5482,9 @@
     },
     "node_modules/geckodriver": {
       "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.3.2.tgz",
+      "integrity": "sha512-TNOoy+ULXJWI5XOq7CXD3PAD9TJa4NjMe7nKUXjlIsf+vezuaRsFgPwcgYdEem1K7106wabYsqr7Kqn51g0sJg==",
       "hasInstallScript": true,
-      "license": "MPL-2.0",
       "dependencies": {
         "@wdio/logger": "^8.28.0",
         "decamelize": "^6.0.0",
@@ -5452,7 +5504,8 @@
     },
     "node_modules/geckodriver/node_modules/agent-base": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -5461,8 +5514,9 @@
       }
     },
     "node_modules/geckodriver/node_modules/https-proxy-agent": {
-      "version": "7.0.3",
-      "license": "MIT",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -5473,14 +5527,16 @@
     },
     "node_modules/geckodriver/node_modules/isexe": {
       "version": "3.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/geckodriver/node_modules/which": {
       "version": "4.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -5520,7 +5576,8 @@
     },
     "node_modules/get-port": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.0.0.tgz",
+      "integrity": "sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==",
       "engines": {
         "node": ">=16"
       },
@@ -5745,7 +5802,8 @@
     },
     "node_modules/got": {
       "version": "12.6.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -5768,7 +5826,8 @@
     },
     "node_modules/got/node_modules/@sindresorhus/is": {
       "version": "5.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "engines": {
         "node": ">=14.16"
       },
@@ -5778,7 +5837,8 @@
     },
     "node_modules/got/node_modules/get-stream": {
       "version": "6.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "engines": {
         "node": ">=10"
       },
@@ -5873,7 +5933,8 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5924,7 +5985,8 @@
     },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -6014,7 +6076,8 @@
     },
     "node_modules/import-meta-resolve": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+      "integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6740,7 +6803,8 @@
     },
     "node_modules/ky": {
       "version": "0.33.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
+      "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
       "engines": {
         "node": ">=14.16"
       },
@@ -6813,20 +6877,23 @@
     },
     "node_modules/listenercount": {
       "version": "1.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
     },
     "node_modules/locate-app": {
-      "version": "2.2.18",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.2.19.tgz",
+      "integrity": "sha512-mjhvrYRHnLAVwreShl8NTwq9EUyfRoCqB0UsOlMKXo2KBmtb4dhlHbZH4mcfDsoNoLkHZ1Rq4TsWP/59Ix62Ww==",
       "dependencies": {
-        "n12": "1.8.21",
+        "n12": "1.8.22",
         "type-fest": "2.13.0",
         "userhome": "1.0.0"
       }
     },
     "node_modules/locate-app/node_modules/type-fest": {
       "version": "2.13.0",
-      "license": "(MIT OR CC0-1.0)",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+      "integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
       "engines": {
         "node": ">=12.20"
       },
@@ -6885,7 +6952,8 @@
     },
     "node_modules/loglevel": {
       "version": "1.9.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -6896,7 +6964,8 @@
     },
     "node_modules/loglevel-plugin-prefix": {
       "version": "0.8.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
     },
     "node_modules/long": {
       "version": "5.2.3",
@@ -6915,7 +6984,8 @@
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -7069,7 +7139,8 @@
     },
     "node_modules/mimic-response": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -7162,8 +7233,9 @@
       }
     },
     "node_modules/n12": {
-      "version": "1.8.21",
-      "license": "SEE LICENSE IN LICENSE"
+      "version": "1.8.22",
+      "resolved": "https://registry.npmjs.org/n12/-/n12-1.8.22.tgz",
+      "integrity": "sha512-nzPCOuLOIoUuninAMRXfrbkB7O9XkWS7iv7fzDW1pRUaQhMpatj8iX55evwcNRWnm0UF29uuoHpwubYbsV7OGw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -7279,6 +7351,8 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "funding": [
         {
           "type": "github",
@@ -7289,7 +7363,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -7310,7 +7383,8 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -7344,7 +7418,8 @@
     },
     "node_modules/normalize-url": {
       "version": "8.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "engines": {
         "node": ">=14.16"
       },
@@ -7488,7 +7563,8 @@
     },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "engines": {
         "node": ">=12.20"
       }
@@ -7902,7 +7978,8 @@
     },
     "node_modules/proxy-agent": {
       "version": "6.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -7919,7 +7996,8 @@
     },
     "node_modules/proxy-agent/node_modules/agent-base": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -7928,8 +8006,9 @@
       }
     },
     "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.3",
-      "license": "MIT",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -7940,7 +8019,8 @@
     },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
         "node": ">=12"
       }
@@ -8185,7 +8265,8 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "engines": {
         "node": ">=10"
       },
@@ -8358,7 +8439,8 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -8386,7 +8468,8 @@
     },
     "node_modules/responselike": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -8497,7 +8580,8 @@
     },
     "node_modules/safaridriver": {
       "version": "0.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-0.1.2.tgz",
+      "integrity": "sha512-4R309+gWflJktzPXBQCobbWEHlzC4aK3a+Ov3tz2Ib2aBxiwd11phkdIBH1l0EO22x24CJMUQkpKFumRriCSRg=="
     },
     "node_modules/safe-array-concat": {
       "version": "1.0.1",
@@ -8718,7 +8802,8 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -9279,7 +9364,11 @@
     },
     "node_modules/traverse": {
       "version": "0.3.9",
-      "license": "MIT/X11"
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -9538,7 +9627,8 @@
     },
     "node_modules/unzipper": {
       "version": "0.10.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
       "dependencies": {
         "big-integer": "^1.6.17",
         "binary": "~0.3.0",
@@ -9554,11 +9644,13 @@
     },
     "node_modules/unzipper/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/unzipper/node_modules/readable-stream": {
       "version": "2.3.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -9571,11 +9663,13 @@
     },
     "node_modules/unzipper/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/unzipper/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -9617,6 +9711,8 @@
     },
     "node_modules/userhome": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
+      "integrity": "sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -9670,7 +9766,8 @@
     },
     "node_modules/wait-port": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
@@ -9685,7 +9782,8 @@
     },
     "node_modules/wait-port/node_modules/commander": {
       "version": "9.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9703,23 +9801,25 @@
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "3.3.2",
-      "license": "MIT",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/webdriver": {
-      "version": "8.32.0",
-      "license": "MIT",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.32.2.tgz",
+      "integrity": "sha512-uyCT2QzCqoz+EsMLTApG5/+RvHJR9MVbdEnjMoxpJDt+IeZCG2Vy/Gq9oNgNQfpxrvZme/EY+PtBsltZi7BAyg==",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "8.31.1",
+        "@wdio/config": "8.32.2",
         "@wdio/logger": "8.28.0",
         "@wdio/protocols": "8.32.0",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.2",
         "deepmerge-ts": "^5.1.0",
         "got": "^12.6.1",
         "ky": "^0.33.0",
@@ -9730,21 +9830,22 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "8.32.0",
-      "license": "MIT",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.32.2.tgz",
+      "integrity": "sha512-Z0Wc/dHFfWGWJZpaQ8u910/LG0E9EIVTO7J5yjqWx2XtXz2LzQMxYwNRnvNLhY/1tI4y/cZxI6kFMWr8wD2TtA==",
       "dependencies": {
         "@types/node": "^20.1.0",
-        "@wdio/config": "8.31.1",
+        "@wdio/config": "8.32.2",
         "@wdio/logger": "8.28.0",
         "@wdio/protocols": "8.32.0",
         "@wdio/repl": "8.24.12",
-        "@wdio/types": "8.31.1",
-        "@wdio/utils": "8.31.1",
+        "@wdio/types": "8.32.2",
+        "@wdio/utils": "8.32.2",
         "archiver": "^6.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1260275",
+        "devtools-protocol": "^0.0.1261483",
         "grapheme-splitter": "^1.0.2",
         "import-meta-resolve": "^4.0.0",
         "is-plain-obj": "^4.1.0",
@@ -9756,7 +9857,7 @@
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.1",
-        "webdriver": "8.32.0"
+        "webdriver": "8.32.2"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -10138,7 +10239,7 @@
         "node-forge": "^1.3.1",
         "tar-stream": "^3.1.7",
         "undici": "^5.28.2",
-        "webdriverio": "^8.32.0"
+        "webdriverio": "^8.32.2"
       },
       "bin": {
         "conformancecloudflareserver": "bin/conformancecloudflareserver",

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -28,7 +28,7 @@
     "fflate": "^0.8.1",
     "tar-stream": "^3.1.7",
     "undici": "^5.28.2",
-    "webdriverio": "^8.32.0",
+    "webdriverio": "^8.32.2",
     "esbuild": "^0.20.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `webdriverio` to fix CI. Chrome changed their download url which has now been patched in webdriverio. Original issue: https://github.com/webdriverio/webdriverio/issues/12251