### PR TITLE
Remove buf setup action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.29.0
-        with:
-          github_token: ${{ github.token }}
       - name: cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/cloudflare.yaml
+++ b/.github/workflows/cloudflare.yaml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.29.0
-        with:
-          github_token: ${{ github.token }}
       - name: cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This removes the usage of `buf-setup-action` in CI as it is currently unneeded.