### PR TITLE
Remove prototype check from ConnectError

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 122,811 b | 53,916 b | 14,492 b |
+| connect        | 122,722 b | 53,874 b | 14,475 b |
 | grpc-web       | 415,212 b    | 300,936 b    | 53,420 b |

--- a/packages/connect/src/connect-error.ts
+++ b/packages/connect/src/connect-error.ts
@@ -134,9 +134,6 @@ export class ConnectError extends Error {
     if (!(v instanceof Error)) {
       return false;
     }
-    if (Object.getPrototypeOf(v) === ConnectError.prototype) {
-      return true;
-    }
     return (
       v.name === "ConnectError" &&
       "code" in v &&


### PR DESCRIPTION
This removes the prototype comparison from ConnectError's `hasInstance` implementation. The prototype comparison is susceptible to the same issues that `instanceof` has and could potentially report false negatives due to the dual package hazard.