### PR TITLE
Update script to bump workspace version to include package-lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,9 +298,7 @@ bench: node_modules $(GEN)/connect-web-bench $(BUILD)/connect-web ## Benchmark c
 .PHONY: setversion
 setversion: ## Set a new version in for the project, i.e. make setversion SET_VERSION=1.2.3
 	node scripts/set-workspace-version.js $(SET_VERSION)
-	rm package-lock.json
-	rm -rf node_modules
-	npm i
+	npm ci
 	$(MAKE) all
 
 # Recommended procedure:


### PR DESCRIPTION
To cut a release, we run `scripts/set-workspace-version.js`, which modifies all package versions in the workspace, delete `package-lock.json`, and run `npm install` to re-generate it.

This process is not ideal, because npm gathers version information from `node_modules`, but does not populate the hash fields in the lock file. 

This PR updates the script to modify the `package-lock.json` along with the workspace packages, so that we don't have to re-generate it.