### PR TITLE
build(connect): export UniversalHandler and UniversalHandlerOptions

### DIFF
--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -56,3 +56,7 @@ export {
 } from "./implementation.js";
 export type { ServiceImplSpec, MethodImplSpec } from "./implementation.js";
 export { createRouterTransport } from "./router-transport.js";
+export {
+  UniversalHandler,
+  UniversalHandlerOptions,
+} from "./protocol/universal-handler.js";


### PR DESCRIPTION
Currently the only way to import these types is to do something like this:

```typescript
import { UniversalHandlerOptions } from "@connectrpc/connect/dist/cjs/protocol/universal-handler";
```

but it would be preferred to be able to import it through the official API surface like this:

```typescript
import type { UniversalHandlerOptions } from "@connectrpc/connect";
```

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>