### PR TITLE
Fix cloudflare server conformance tests

### DIFF
--- a/packages/connect-conformance/conformance-cloudflare-server.yaml
+++ b/packages/connect-conformance/conformance-cloudflare-server.yaml
@@ -17,7 +17,6 @@ features:
   supportsTlsClientCerts: false
   supportsConnectGet: true
   supportsHalfDuplexBidiOverHttp1: true
-  requiresConnectVersionHeader: false
   supportsMessageReceiveLimit: false
 excludeCases:
   - useTls: false

--- a/packages/connect-conformance/src/cloudflare/compression.ts
+++ b/packages/connect-conformance/src/cloudflare/compression.ts
@@ -16,10 +16,7 @@ import { Code, ConnectError } from "@connectrpc/connect";
 import type { Compression } from "@connectrpc/connect/protocol";
 
 export const compressionGzip = createCompression("gzip");
-export const compressionDeflate = {
-  ...createCompression("deflate-raw"),
-  name: "deflate",
-};
+export const compressionDeflate = createCompression("deflate");
 
 function createCompression(name: CompressionFormat): Compression {
   return {
@@ -55,7 +52,7 @@ async function readAll(
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
   let length = 0;
-  for (;;) {
+  for (; ;) {
     const next = await reader.read();
     if (next.value !== undefined) {
       chunks.push(next.value as Uint8Array);

--- a/packages/connect-conformance/src/cloudflare/compression.ts
+++ b/packages/connect-conformance/src/cloudflare/compression.ts
@@ -52,7 +52,7 @@ async function readAll(
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
   let length = 0;
-  for (; ;) {
+  for (;;) {
     const next = await reader.read();
     if (next.value !== undefined) {
       chunks.push(next.value as Uint8Array);


### PR DESCRIPTION
Fix cloudflare server conformance tests. This removes prev v1 config option which was missed in #1063. This was causing the tests to fail. It also corrects the deflate encoding which previously gave different results on early version of the runner.

CI run of this branch: https://github.com/connectrpc/connect-es/actions/runs/8968060962