### PR TITLE
Allow specifying redirect

### DIFF
--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -93,6 +93,13 @@ export interface ConnectTransportOptions {
   credentials?: RequestCredentials;
 
   /**
+   * Controls what the fetch client will do with redirects. The default
+   * value is "error". For reference, see
+   * https://fetch.spec.whatwg.org/#concept-request-redirect-mode
+   */
+  redirect ?: RequestRedirect
+
+  /**
    * Interceptors that should be applied to all calls running through
    * this transport. See the Interceptor type for details.
    */
@@ -175,7 +182,7 @@ export function createConnectTransport(
           init: {
             method: "POST",
             credentials: options.credentials ?? "same-origin",
-            redirect: "error",
+            redirect: options.redirect ?? "error",
             mode: "cors",
           },
           header: requestHeader(
@@ -334,7 +341,7 @@ export function createConnectTransport(
           init: {
             method: "POST",
             credentials: options.credentials ?? "same-origin",
-            redirect: "error",
+            redirect: options.redirect ?? "error",
             mode: "cors",
           },
           header: requestHeader(


### PR DESCRIPTION
When using connect-web SDKs in edge workers, such as Vercel/NextJS, and Cloudflare, the redirect option 'error' is not supported:
```
ConnectError: [unknown] Invalid redirect value, must be one of "follow" or "manual" ("error" won't be implemented since it does not make sense at the edge; use "manual" and check the response status code).
```

There currently does not exist a way to overwrite the redirect option to get around this limitation.

This MR adds in the ability to specify redirect as a client option, while keeping the default error