### PR TITLE
Call cleanup in the finally of each method response instead of abort

### DIFF
--- a/packages/connect/src/implementation.ts
+++ b/packages/connect/src/implementation.ts
@@ -150,6 +150,7 @@ interface HandlerContextInit {
 }
 
 interface HandlerContextController extends HandlerContext {
+  cleanup(): void;
   abort(reason?: unknown): void;
 }
 
@@ -183,6 +184,7 @@ export function createHandlerContext(
     requestHeader: new Headers(init.requestHeader),
     responseHeader: new Headers(init.responseHeader),
     responseTrailer: new Headers(init.responseTrailer),
+    cleanup: deadline.cleanup,
     abort(reason?: unknown) {
       deadline.cleanup();
       abortController.abort(reason);

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -269,7 +269,7 @@ function createUnaryHandler<I extends Message<I>, O extends Message<O>>(
       });
       body = errorToJsonBytes(error, opt.jsonOptions);
     } finally {
-      context.abort();
+      context.cleanup();
     }
     if (compression.response && body.byteLength >= opt.compressMinBytes) {
       body = await compression.response.compress(body);


### PR DESCRIPTION
Fixes #1117, avoids user code from having to check the given abort signal to determine if an abort was a true abort or not, and avoids the small overhead of having to execute all abort event handlers.