### PR TITLE
Release 2.0.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11545,7 +11545,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.0.0-beta.2",
@@ -11561,23 +11561,23 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect": "1.4.0",
-        "@connectrpc/connect-node": "1.4.0"
+        "@connectrpc/connect": "2.0.0-alpha.1",
+        "@connectrpc/connect-node": "2.0.0-alpha.1"
       },
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.0.0-beta.2",
         "@cloudflare/workers-types": "^4.20240603.0",
-        "@connectrpc/connect-conformance": "^1.4.0",
+        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
         "tsx": "^4.11.0",
         "wrangler": "^3.58.0"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect": "1.4.0",
+        "@connectrpc/connect": "2.0.0-alpha.1",
         "fflate": "^0.8.1",
         "tar-stream": "^3.1.7",
         "undici": "^5.28.4"
@@ -11594,10 +11594,10 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^1.4.0",
+        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
         "@types/express": "^4.17.18",
         "express": "^4.19.2",
         "tsx": "^4.11.0"
@@ -11607,30 +11607,30 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect": "1.4.0",
-        "@connectrpc/connect-node": "1.4.0"
+        "@connectrpc/connect": "2.0.0-alpha.1",
+        "@connectrpc/connect-node": "2.0.0-alpha.1"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^1.4.0"
+        "@connectrpc/connect-conformance": "^2.0.0-alpha.1"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect": "1.4.0",
-        "@connectrpc/connect-node": "1.4.0",
+        "@connectrpc/connect": "2.0.0-alpha.1",
+        "@connectrpc/connect-node": "2.0.0-alpha.1",
         "fastify": "^4.22.1"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.2",
@@ -11650,27 +11650,27 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect": "1.4.0",
-        "@connectrpc/connect-node": "1.4.0",
+        "@connectrpc/connect": "2.0.0-alpha.1",
+        "@connectrpc/connect-node": "2.0.0-alpha.1",
         "next": "^13.2.4"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^5.28.4"
       },
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^1.4.0",
+        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
         "@types/jasmine": "^5.0.0",
         "jasmine": "^5.1.0"
       },
@@ -11679,16 +11679,16 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect": "1.4.0"
+        "@connectrpc/connect": "2.0.0-alpha.1"
       }
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.0.0-beta.2",
-        "@connectrpc/connect-conformance": "^1.4.0",
+        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
         "jasmine": "^5.1.0",
         "karma": "^6.4.2",
         "karma-browserstack-launcher": "^1.6.0",
@@ -11699,7 +11699,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect": "1.4.0"
+        "@connectrpc/connect": "2.0.0-alpha.1"
       }
     },
     "packages/connect-web-bench": {
@@ -11707,7 +11707,7 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
         "@bufbuild/protoc-gen-es": "^2.0.0-beta.2",
-        "@connectrpc/connect-web": "1.4.0",
+        "@connectrpc/connect-web": "2.0.0-alpha.1",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
         "google-protobuf": "^3.21.0",
@@ -12098,8 +12098,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0-beta.2",
-        "@connectrpc/connect-node": "^1.4.0",
-        "@connectrpc/connect-web": "^1.4.0",
+        "@connectrpc/connect-node": "^2.0.0-alpha.1",
+        "@connectrpc/connect-web": "^2.0.0-alpha.1",
         "tsx": "^4.11.0"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -10,14 +10,14 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
-    "@connectrpc/connect": "1.4.0",
-    "@connectrpc/connect-node": "1.4.0"
+    "@connectrpc/connect": "2.0.0-alpha.1",
+    "@connectrpc/connect-node": "2.0.0-alpha.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240603.0",
     "wrangler": "^3.58.0",
     "tsx": "^4.11.0",
-    "@connectrpc/connect-conformance": "^1.4.0",
+    "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
     "@bufbuild/protoc-gen-es": "^2.0.0-beta.2"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/src/index.js",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
-    "@connectrpc/connect": "1.4.0",
+    "@connectrpc/connect": "2.0.0-alpha.1",
     "fflate": "^0.8.1",
     "tar-stream": "^3.1.7",
     "undici": "^5.28.4"

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -30,14 +30,14 @@
     "node": ">=16.0.0"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^1.4.0",
+    "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
     "@types/express": "^4.17.18",
     "express": "^4.19.2",
     "tsx": "^4.11.0"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
-    "@connectrpc/connect": "1.4.0",
-    "@connectrpc/connect-node": "1.4.0"
+    "@connectrpc/connect": "2.0.0-alpha.1",
+    "@connectrpc/connect-node": "2.0.0-alpha.1"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -28,12 +28,12 @@
     "node": ">=16.0.0"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^1.4.0"
+    "@connectrpc/connect-conformance": "^2.0.0-alpha.1"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
     "fastify": "^4.22.1",
-    "@connectrpc/connect": "1.4.0",
-    "@connectrpc/connect-node": "1.4.0"
+    "@connectrpc/connect": "2.0.0-alpha.1",
+    "@connectrpc/connect-node": "2.0.0-alpha.1"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
     "next": "^13.2.4",
-    "@connectrpc/connect": "1.4.0",
-    "@connectrpc/connect-node": "1.4.0"
+    "@connectrpc/connect": "2.0.0-alpha.1",
+    "@connectrpc/connect-node": "2.0.0-alpha.1"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -35,11 +35,11 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
-    "@connectrpc/connect": "1.4.0"
+    "@connectrpc/connect": "2.0.0-alpha.1"
   },
   "devDependencies": {
     "@types/jasmine": "^5.0.0",
     "jasmine": "^5.1.0",
-    "@connectrpc/connect-conformance": "^1.4.0"
+    "@connectrpc/connect-conformance": "^2.0.0-alpha.1"
   }
 }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 198,641 b | 101,095 b | 24,243 b |
+| connect        | 198,649 b | 101,103 b | 24,242 b |
 | grpc-web       | 415,212 b    | 300,936 b    | 53,420 b |

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
     "@bufbuild/protoc-gen-es": "^2.0.0-beta.2",
-    "@connectrpc/connect-web": "1.4.0",
+    "@connectrpc/connect-web": "2.0.0-alpha.1",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",
     "google-protobuf": "^3.21.0",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "webdriverio": "^8.36.1",
     "@bufbuild/protoc-gen-es": "^2.0.0-beta.2",
-    "@connectrpc/connect-conformance": "^1.4.0",
+    "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
     "jasmine": "^5.1.0",
     "karma": "^6.4.2",
     "karma-browserstack-launcher": "^1.6.0",
@@ -44,6 +44,6 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
-    "@connectrpc/connect": "1.4.0"
+    "@connectrpc/connect": "2.0.0-alpha.1"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.1",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0-beta.2",
-    "@connectrpc/connect-node": "^1.4.0",
-    "@connectrpc/connect-web": "^1.4.0",
+    "@connectrpc/connect-node": "^2.0.0-alpha.1",
+    "@connectrpc/connect-web": "^2.0.0-alpha.1",
     "tsx": "^4.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's new in version 2

To support protobuf editions, `@bufbuild/protobuf` had to make breaking changes, more on this [here](https://github.com/bufbuild/protobuf-es/pull/801). Upgrading to `v2` of `@bufbuild/protobuf` will be breaking change for connect users. 

The most notable change is that v2 doesn't require a separate plugin anymore! we only need `protoc-gen-es`. For most users this will be a simple change of just removing the connect plugin and changing the import path to point to the protobuf generated types:

```ts
import { createPromiseClient } from "@connectrpc/connect";
import { createConnectTransport } from "@connectrpc/connect-node";
// Before this was import { ElizaService } from "./gen/eliza_connect.js"
import { ElizaService } from "./gen/eliza_pb.js";

// Alternatively, use createGrpcTransport or createGrpcWebTransport here
// to use one of the other supported protocols.
const transport = createConnectTransport({
  httpVersion: "2",
  baseUrl: "https://localhost:8443",
  nodeOptions: { rejectUnauthorized },
});

const client = createPromiseClient(ElizaService, transport);
const res = await client.say({ sentence });
```

Please note that this is an alpha release, and APIs might still change. We're also missing documentation yet.  But if you want to try it out, we welcome your feedback!

This release is published with the `alpha` tag. To install the alpha packages, you can run:

```bash
npm install @connectrpc/connect@alpha @bufbuild/protobuf@beta @bufbuild/protoc-gen-es@beta
```

