### PR TITLE
V2: Fix connect-migrate tsconfig.json

### DIFF
--- a/packages/connect-migrate/bin/connect-migrate
+++ b/packages/connect-migrate/bin/connect-migrate
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require("../dist/cli.js");
+require("../dist/cjs/cli.js");

--- a/packages/connect-migrate/bin/connect-migrate
+++ b/packages/connect-migrate/bin/connect-migrate
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require("../dist/cjs/cli.js");
+require("../dist/cli.js");

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,20 +1,19 @@
 {
   "name": "@connectrpc/connect-migrate",
   "version": "2.0.0-alpha.1",
-  "description": "This tool updates your Connect project to use the new @connectrpc packages.",
+  "description": "This tool updates your Connect project to use the latest @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/connectrpc/connect-es.git",
     "directory": "packages/connect-migrate"
   },
-  "sideEffects": true,
   "bin": {
     "connect-migrate": "bin/connect-migrate"
   },
   "scripts": {
-    "clean": "rm -rf ./dist/cjs/*",
-    "build": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs",
+    "clean": "rm -rf ./dist/*",
+    "build": "tsc --project tsconfig.json --outDir ./dist",
     "test": "jasmine --config=jasmine.json",
     "build+test": "npm run build && npm run test"
   },

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -12,8 +12,8 @@
     "connect-migrate": "bin/connect-migrate"
   },
   "scripts": {
-    "clean": "rm -rf ./dist/*",
-    "build": "tsc --project tsconfig.json --outDir ./dist",
+    "clean": "rm -rf ./dist/cjs/*",
+    "build": "tsc --project tsconfig.json --outDir ./dist/cjs",
     "test": "jasmine --config=jasmine.json",
     "build+test": "npm run build && npm run test"
   },

--- a/packages/connect-migrate/tsconfig.json
+++ b/packages/connect-migrate/tsconfig.json
@@ -2,6 +2,11 @@
   "include": ["src/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "esModuleInterop": true // required for jscodeshift
+    // required for jscodeshift
+    "esModuleInterop": true,
+    // This package is CommonJS
+    "verbatimModuleSyntax": false,
+    "module": "CommonJS",
+    "moduleResolution": "Node10"
   }
 }


### PR DESCRIPTION
In my IDE, I saw many errors like the following in packages/connect-migrate/src:

> TS1286: ESM syntax is not allowed in a CommonJS module when verbatimModuleSyntax is enabled.

The errors do not manifest in the build tasks because it changes the TypeScript compiler options via command line flags, while the language service run by the IDE does not.

The solution is to use the same tsconfig settings for build as for the IDE. We should only use flags for a CJS build if we're building both CJS and ESM.