### PR TITLE
Add migration to v2

### DIFF
--- a/packages/connect-migrate/src/cli.ts
+++ b/packages/connect-migrate/src/cli.ts
@@ -19,6 +19,8 @@ import { parseCommandLineArgs } from "./arguments";
 import { scan } from "./lib/scan";
 import { Logger } from "./lib/logger";
 import { v0_13_1 } from "./migrations/v0.13.1";
+import { v2_0_0 } from "./migrations/v2.0.0";
+import { Migration } from "./migration";
 
 const usage = `USAGE: connect-migrate [flags]
 Updates references to connect-es packages in your project to use @connectrpc.
@@ -32,7 +34,7 @@ Flags:
 `;
 
 const logger = new Logger();
-
+const migrations = [v0_13_1, v2_0_0];
 void main();
 
 async function main() {
@@ -51,12 +53,17 @@ async function main() {
     if (!scanned.ok) {
       return exitErr(scanned.errorMessage, false);
     }
-    if (v0_13_1.applicable(scanned)) {
-      const result = v0_13_1.migrate({ scanned, args, print, logger });
-      if (!result.ok) {
-        return exitErr(result.errorMessage, result.dumpLogfile ?? false);
+    const applied: Migration[] = [];
+    for (const migration of migrations) {
+      if (migration.applicable(scanned)) {
+        const result = migration.migrate({ scanned, args, print, logger });
+        if (!result.ok) {
+          return exitErr(result.errorMessage, result.dumpLogfile ?? false);
+        }
+        applied.push(migration);
       }
-    } else {
+    }
+    if (applied.length == 0) {
       exitOk("It looks like you are already up to date 🎉");
     }
   } catch (e) {

--- a/packages/connect-migrate/src/migration.ts
+++ b/packages/connect-migrate/src/migration.ts
@@ -18,6 +18,7 @@ import { Logger, PrintFn } from "./lib/logger";
 import { updateSourceFile } from "./lib/migrate-source-files";
 import { writePackageJsonFile } from "./lib/package-json";
 import { runInstall } from "./lib/run";
+import { writeBufGenYamlFile } from "./lib/bufgenyaml";
 
 export interface Migration {
   applicable(scanned: Scanned): boolean;
@@ -31,6 +32,7 @@ export interface MigrateOptions {
   logger?: Logger;
   updateSourceFileFn?: typeof updateSourceFile;
   writePackageJsonFileFn?: typeof writePackageJsonFile;
+  writeBufGenYamlFileFn?: typeof writeBufGenYamlFile;
   runInstallFn?: typeof runInstall;
 }
 

--- a/packages/connect-migrate/src/migrations/v0.13.1-transform.spec.ts
+++ b/packages/connect-migrate/src/migrations/v0.13.1-transform.spec.ts
@@ -15,7 +15,7 @@
 import transform from "./v0.13.1-transform";
 import { updateSourceFileInMemory } from "../lib/migrate-source-files";
 
-describe("modify-imports", () => {
+describe("v0.13.1 transform", () => {
   it("should modify import", () => {
     const input = `import a from "@bufbuild/connect";`;
     const output = `import a from "@connectrpc/connect";`;

--- a/packages/connect-migrate/src/migrations/v2.0.0-transform.spec.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0-transform.spec.ts
@@ -1,0 +1,61 @@
+// Copyright 2021-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { updateSourceFileInMemory } from "../lib/migrate-source-files";
+import transform from "./v2.0.0-transform";
+
+describe("v2.0.0 transform", () => {
+  it("should modify import from *_connect.js to *_pb.js", () => {
+    const input = `import { ElizaService } from "./gen/eliza_connect.js";`;
+    const output = `import { ElizaService } from "./gen/eliza_pb.js";`;
+    const result = updateSourceFileInMemory(transform, input, "foo.ts");
+    expect(result.source).toBe(output);
+  });
+  it("should modify import from *_connect to *_pb", () => {
+    const input = `import { ElizaService } from "./gen/eliza_connect";`;
+    const output = `import { ElizaService } from "./gen/eliza_pb";`;
+    const result = updateSourceFileInMemory(transform, input, "foo.ts");
+    expect(result.source).toBe(output);
+  });
+  it("should modify import from *_connect.ts to *_pb.ts", () => {
+    const input = `import { ElizaService } from "./gen/eliza_connect.ts";`;
+    const output = `import { ElizaService } from "./gen/eliza_pb.ts";`;
+    const result = updateSourceFileInMemory(transform, input, "foo.ts");
+    expect(result.source).toBe(output);
+  });
+  it("should modify js", () => {
+    const input = `import { ElizaService } from "./gen/eliza_connect.js";`;
+    const output = `import { ElizaService } from "./gen/eliza_pb.js";`;
+    const result = updateSourceFileInMemory(transform, input, "foo.js");
+    expect(result.source).toBe(output);
+  });
+  it("should modify tsx", () => {
+    const input = `import { ElizaService } from "./gen/eliza_connect.js";`;
+    const output = `import { ElizaService } from "./gen/eliza_pb.js";`;
+    const result = updateSourceFileInMemory(transform, input, "foo.tsx");
+    expect(result.source).toBe(output);
+  });
+  it("should not care about existing imports", () => {
+    const input = `
+      import { ElizaService } from "./gen/eliza_connect.js";
+      import { Foo } from "./gen/eliza_pb.js";
+    `;
+    const output = `
+      import { ElizaService } from "./gen/eliza_pb.js";
+      import { Foo } from "./gen/eliza_pb.js";
+    `;
+    const result = updateSourceFileInMemory(transform, input, "foo.ts");
+    expect(result.source).toBe(output);
+  });
+});

--- a/packages/connect-migrate/src/migrations/v2.0.0-transform.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0-transform.ts
@@ -1,0 +1,74 @@
+// Copyright 2021-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import j from "jscodeshift";
+
+const replacements = [
+  ["_connect", "_pb"],
+  ["_connect.js", "_pb.js"],
+  ["_connect.ts", "_pb.ts"],
+];
+
+const transform: j.Transform = (file, { j }, options) => {
+  const root = j(file.source);
+  const importPaths = root.find(j.ImportDeclaration);
+  if (importPaths.length == 0) {
+    // no imports in this file
+    return root.toSource();
+  }
+  let importModified = false;
+  importPaths.forEach((path) => {
+    if (typeof path.value.source.value === "string") {
+      const sourceValue = path.value.source.value;
+      for (const [old, repl] of replacements) {
+        if (sourceValue.endsWith(old)) {
+          path.value.source.value =
+            sourceValue.substring(0, sourceValue.length - old.length) + repl;
+          importModified = true;
+        }
+      }
+    }
+  });
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- eslint is unaware of forEach callback
+  if (!importModified) {
+    // no relevant imports in this file
+    return root.toSource();
+  }
+  return root.toSource(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- passing the printOptions onto toSource is safe
+    options.printOptions ?? {
+      quote: determineQuoteStyle(importPaths),
+    },
+  );
+};
+
+function determineQuoteStyle(
+  importPaths: j.Collection<j.ImportDeclaration>,
+): "double" | "single" {
+  let nodePath: unknown;
+  if (importPaths.length > 0) {
+    nodePath = importPaths.get("source", "extra", "raw") as unknown;
+  }
+  if (
+    typeof nodePath == "object" &&
+    nodePath != null &&
+    "value" in nodePath &&
+    typeof nodePath.value == "string"
+  ) {
+    return nodePath.value.startsWith("'") ? "single" : "double";
+  }
+  return "double";
+}
+
+export default transform;

--- a/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
@@ -1,0 +1,448 @@
+// Copyright 2021-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  targetVersionConnectEs,
+  targetVersionConnectPlaywright,
+  targetVersionConnectQuery,
+  targetVersionProtobufEs,
+  v2_0_0,
+} from "./v2.0.0";
+import { PackageJson } from "../lib/package-json";
+import { MigrateOptions } from "../migration";
+import { parseBufGenYaml, stringifyBufGenYaml } from "../lib/bufgenyaml";
+
+describe("migration to v2.0.0", function () {
+  const packageJsonWritten: { path: string; pkg: PackageJson }[] = [];
+  const bufGenYamlWritten: { path: string; yaml: string }[] = [];
+  const lockFilesUpdated: string[] = [];
+  let opt: MigrateOptions;
+  beforeEach(function () {
+    packageJsonWritten.splice(0);
+    lockFilesUpdated.splice(0);
+    bufGenYamlWritten.splice(0);
+    opt = {
+      scanned: {
+        ok: true,
+        lockFiles: ["package-lock.json"],
+        sourceFiles: [],
+        packageFiles: [],
+        bufGenYamlFiles: [],
+      },
+      args: {
+        ok: true,
+        help: false,
+        version: false,
+        ignorePatterns: [],
+        noInstall: false,
+        forceUpdate: false,
+      },
+      print: () => {
+        //
+      },
+      updateSourceFileFn: () => ({
+        ok: true,
+        modified: false,
+      }),
+      writePackageJsonFileFn: (path: string, pkg: PackageJson) =>
+        packageJsonWritten.push({ path, pkg }),
+      writeBufGenYamlFileFn: (path, yaml) =>
+        bufGenYamlWritten.push({ path, yaml: stringifyBufGenYaml(yaml) }),
+      runInstallFn: (lockfilePath) => {
+        lockFilesUpdated.push(lockfilePath);
+        return true;
+      },
+    };
+  });
+  describe("for protobuf-es v1", () => {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@bufbuild/protobuf": "^1.10.0",
+              "@bufbuild/protoplugin": "^1.10.0",
+              "@bufbuild/protoc-gen-es": "^1.10.0",
+            },
+          },
+        },
+      ];
+      opt.scanned.bufGenYamlFiles = [
+        {
+          path: "buf.gen.yaml",
+          yaml: parseBufGenYaml(
+            `version: v2
+plugins:
+  - remote: buf.build/bufbuild/es:v1.10.0
+    out: src/gen
+`,
+          ),
+        },
+      ];
+    });
+    it("should be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeTrue();
+    });
+    it("should migrate packages", () => {
+      const result = v2_0_0.migrate(opt);
+      expect(result).toEqual({
+        ok: true,
+      });
+      expect(packageJsonWritten.length).toBe(1);
+      expect(packageJsonWritten[0].pkg).toEqual({
+        dependencies: {
+          "@bufbuild/protobuf": `^${targetVersionProtobufEs}`,
+          "@bufbuild/protoplugin": `^${targetVersionProtobufEs}`,
+          "@bufbuild/protoc-gen-es": `^${targetVersionProtobufEs}`,
+        },
+      });
+      expect(lockFilesUpdated.length).toBe(1);
+    });
+    it("should migrate buf.gen.yaml", () => {
+      const result = v2_0_0.migrate(opt);
+      expect(result).toEqual({
+        ok: true,
+      });
+      expect(bufGenYamlWritten.length).toBe(1);
+      expect(bufGenYamlWritten[0]?.yaml).toEqual(`version: v2
+plugins:
+  - remote: buf.build/bufbuild/es:v2.0.0
+    out: src/gen
+`);
+    });
+  });
+  describe("for connect-es v1", () => {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@connectrpc/connect": "^1.4.0",
+              "@connectrpc/connect-express": "^1.4.0",
+              "@connectrpc/connect-fastify": "^1.4.0",
+              "@connectrpc/connect-next": "^1.4.0",
+              "@connectrpc/connect-node": "^1.4.0",
+              "@connectrpc/connect-web": "^1.4.0",
+              "@connectrpc/protoc-gen-connect-es": "^1.4.0",
+            },
+          },
+        },
+      ];
+      opt.scanned.bufGenYamlFiles = [
+        {
+          path: "buf.gen.yaml",
+          yaml: parseBufGenYaml(
+            `version: v2
+plugins:
+  - local: es
+    out: src/gen
+  - remote: buf.build/connectrpc/es
+    out: src/gen
+  - remote: buf.build/connectrpc/es:v1.4.0
+    out: src/gen
+`,
+            "buf.gen.yaml",
+          ),
+        },
+      ];
+    });
+    it("should be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeTrue();
+    });
+    it("should migrate packages", () => {
+      const result = v2_0_0.migrate(opt);
+      expect(result).toEqual({
+        ok: true,
+      });
+      expect(packageJsonWritten.length).toBe(1);
+      expect(packageJsonWritten[0].pkg).toEqual({
+        dependencies: {
+          "@connectrpc/connect": `^${targetVersionConnectEs}`,
+          "@connectrpc/connect-express": `^${targetVersionConnectEs}`,
+          "@connectrpc/connect-fastify": `^${targetVersionConnectEs}`,
+          "@connectrpc/connect-next": `^${targetVersionConnectEs}`,
+          "@connectrpc/connect-node": `^${targetVersionConnectEs}`,
+          "@connectrpc/connect-web": `^${targetVersionConnectEs}`,
+        },
+      });
+      expect(lockFilesUpdated.length).toBe(1);
+    });
+    it("should migrate buf.gen.yaml", () => {
+      const result = v2_0_0.migrate(opt);
+      expect(result).toEqual({
+        ok: true,
+      });
+      expect(bufGenYamlWritten.length).toBe(1);
+      expect(bufGenYamlWritten[0]?.yaml).toEqual(`version: v2
+plugins:
+  - local: es
+    out: src/gen
+`);
+    });
+  });
+  describe("for connect-query-es v1", () => {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@connectrpc/connect-query": "^1.4.1",
+              "@connectrpc/protoc-gen-connect-query": "^1.4.1",
+            },
+          },
+        },
+      ];
+      opt.scanned.bufGenYamlFiles = [
+        {
+          path: "buf.gen.yaml",
+          yaml: parseBufGenYaml(
+            `version: v2
+plugins:
+  - remote: buf.build/connectrpc/query-es:v1.4.1
+    out: src/gen
+`,
+          ),
+        },
+      ];
+    });
+    it("should be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeTrue();
+    });
+    it("should migrate packages", () => {
+      const result = v2_0_0.migrate(opt);
+      expect(result).toEqual({
+        ok: true,
+      });
+      expect(packageJsonWritten.length).toBe(1);
+      expect(packageJsonWritten[0].pkg).toEqual({
+        dependencies: {
+          "@connectrpc/connect-query": `^${targetVersionConnectQuery}`,
+          "@connectrpc/protoc-gen-connect-query": `^${targetVersionConnectQuery}`,
+        },
+      });
+      expect(lockFilesUpdated.length).toBe(1);
+    });
+    it("should migrate buf.gen.yaml", () => {
+      const result = v2_0_0.migrate(opt);
+      expect(result).toEqual({
+        ok: true,
+      });
+      expect(bufGenYamlWritten.length).toBe(1);
+      expect(bufGenYamlWritten[0]?.yaml).toEqual(`version: v2
+plugins:
+  - remote: buf.build/connectrpc/query-es:v2.0.0
+    out: src/gen
+`);
+    });
+  });
+  describe("for connect-playwright-es v1", () => {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@connectrpc/connect-playwright": "^0.3.2",
+            },
+          },
+        },
+      ];
+    });
+    it("should be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeTrue();
+    });
+    it("should migrate", () => {
+      const result = v2_0_0.migrate(opt);
+      expect(result).toEqual({
+        ok: true,
+      });
+      expect(packageJsonWritten.length).toBe(1);
+      expect(packageJsonWritten[0].pkg).toEqual({
+        dependencies: {
+          "@connectrpc/connect-playwright": `^${targetVersionConnectPlaywright}`,
+        },
+      });
+      expect(lockFilesUpdated.length).toBe(1);
+    });
+  });
+  describe("for up-to-date versions", () => {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@bufbuild/protobuf": `^${targetVersionProtobufEs}`,
+              "@bufbuild/protoplugin": `^${targetVersionProtobufEs}`,
+              "@bufbuild/protoc-gen-es": `^${targetVersionProtobufEs}`,
+
+              "@connectrpc/connect": `^${targetVersionConnectEs}`,
+              "@connectrpc/connect-web": `^${targetVersionConnectEs}`,
+              "@connectrpc/connect-node": `^${targetVersionConnectEs}`,
+              "@connectrpc/connect-express": `^${targetVersionConnectEs}`,
+              "@connectrpc/connect-fastify": `^${targetVersionConnectEs}`,
+              "@connectrpc/connect-next": `^${targetVersionConnectEs}`,
+              "@connectrpc/protoc-gen-connect-es": `^${targetVersionConnectEs}`,
+
+              "@connectrpc/connect-query": `^${targetVersionConnectQuery}`,
+              "@connectrpc/protoc-gen-connect-query": `^${targetVersionConnectQuery}`,
+              "@connectrpc/protoc-gen-connect-query-react": `^${targetVersionConnectQuery}`,
+
+              "@connectrpc/connect-playwright": `^${targetVersionConnectPlaywright}`,
+            },
+          },
+        },
+      ];
+      opt.scanned.bufGenYamlFiles = [
+        {
+          path: "buf.gen.yaml",
+          yaml: parseBufGenYaml(
+            `
+version: v2
+plugins:
+  - local: protoc-gen-es
+    out: src/gen
+  - remote: buf.build/bufbuild/es
+    out: src/gen
+  - remote: buf.build/connectrpc/query-es
+    out: src/gen
+  - remote: buf.build/bufbuild/es:v2.0.0
+    out: src/gen
+  - remote: buf.build/connectrpc/query-es:v2.0.0
+    out: src/gen
+`,
+            "buf.gen.yaml",
+          ),
+        },
+        {
+          path: "buf.v1.gen.yaml",
+          yaml: parseBufGenYaml(
+            `
+version: v1
+plugins:
+  - plugin: es
+    out: src/gen
+  - plugin: buf.build/bufbuild/es
+    out: src/gen
+  - plugin: buf.build/connectrpc/query-es
+    out: src/gen
+  - plugin: buf.build/bufbuild/es:v2.0.0
+    out: src/gen
+  - plugin: buf.build/connectrpc/query-es:v2.0.0
+    out: src/gen
+`,
+          ),
+        },
+      ];
+    });
+    it("should not be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeFalse();
+    });
+  });
+  describe("for protobuf-es pre v1 versions", () => {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@bufbuild/protobuf": "<1.0.0",
+              "@bufbuild/protoplugin": "<1.0.0",
+              "@bufbuild/protoc-gen-es": "<1.0.0",
+            },
+          },
+        },
+      ];
+    });
+    it("should not be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeFalse();
+    });
+  });
+  describe("for connect-es in @bufbuild", () => {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@bufbuild/connect": "*",
+              "@bufbuild/connect-web": "*",
+              "@bufbuild/connect-node": "*",
+              "@bufbuild/connect-express": "*",
+              "@bufbuild/connect-fastify": "*",
+              "@bufbuild/connect-next": "*",
+              "@bufbuild/protoc-gen-connect-es": "*",
+            },
+          },
+        },
+      ];
+      opt.scanned.bufGenYamlFiles = [
+        {
+          path: "buf.gen.yaml",
+          yaml: parseBufGenYaml(
+            `
+version: v2
+plugins:
+  - remote: remote: buf.build/bufbuild/connect-es:v0.13.0
+    out: src/gen
+`,
+            "buf.gen.yaml",
+          ),
+        },
+      ];
+    });
+    it("should not be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeFalse();
+    });
+  });
+  describe("for connect-query-es in @bufbuild", function () {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@bufbuild/connect-query": "*",
+              "@bufbuild/protoc-gen-connect-query": "*",
+              "@bufbuild/protoc-gen-connect-query-react": "*",
+            },
+          },
+        },
+      ];
+    });
+    it("should not be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeFalse();
+    });
+  });
+  describe("for connect-playwright-es in @bufbuild", function () {
+    beforeEach(function () {
+      opt.scanned.packageFiles = [
+        {
+          path: "package.json",
+          pkg: {
+            dependencies: {
+              "@bufbuild/connect-playwright": "*",
+            },
+          },
+        },
+      ];
+    });
+    it("should not be applicable", () => {
+      expect(v2_0_0.applicable(opt.scanned)).toBeFalse();
+    });
+  });
+});

--- a/packages/connect-migrate/src/migrations/v2.0.0.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.ts
@@ -1,0 +1,217 @@
+// Copyright 2021-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Scanned } from "../lib/scan";
+import modifyImports from "./v2.0.0-transform";
+import { MigrateError, MigrateSuccess, Migration } from "../migration";
+import { runInstall } from "../lib/run";
+import { writePackageJsonFile } from "../lib/package-json";
+import {
+  DependencyMigration,
+  migrateDependencies,
+} from "../lib/migrate-dependencies";
+import {
+  migrateSourceFiles,
+  updateSourceFile,
+} from "../lib/migrate-source-files";
+import { migratePackages } from "../lib/migrate-packages";
+import { migrateLockFiles } from "../lib/migrate-lock-files";
+import {
+  BufGenYamlMigration,
+  migrateBufGenYaml,
+  migrateBufGenYamls,
+} from "../lib/migrate-bufgenyaml";
+import { writeBufGenYamlFile } from "../lib/bufgenyaml";
+
+export const targetVersionProtobufEs = "2.0.0-beta.2";
+export const targetVersionConnectEs = "2.0.0-alpha.1";
+export const targetVersionConnectQuery = "2.0.0-alpha.1";
+export const targetVersionConnectPlaywright = "0.4.0";
+
+const dependencyMigrations: DependencyMigration[] = [
+  // https://github.com/bufbuild/protobuf-es
+  {
+    from: { name: "@bufbuild/protobuf", range: "^1.0.0" },
+    to: { version: targetVersionProtobufEs },
+  },
+  {
+    from: { name: "@bufbuild/protoplugin", range: "^1.0.0" },
+    to: { version: targetVersionProtobufEs },
+  },
+  {
+    from: { name: "@bufbuild/protoc-gen-es", range: "^1.0.0" },
+    to: { version: targetVersionProtobufEs },
+  },
+
+  // https://github.com/connectrpc/connect-es
+  {
+    from: { name: "@connectrpc/connect", range: "^1.0.0" },
+    to: { version: targetVersionConnectEs },
+  },
+  {
+    from: { name: "@connectrpc/connect-express", range: "^1.0.0" },
+    to: { version: targetVersionConnectEs },
+  },
+  {
+    from: { name: "@connectrpc/connect-fastify", range: "^1.0.0" },
+    to: { version: targetVersionConnectEs },
+  },
+  {
+    from: { name: "@connectrpc/connect-next", range: "^1.0.0" },
+    to: { version: targetVersionConnectEs },
+  },
+  {
+    from: { name: "@connectrpc/connect-node", range: "^1.0.0" },
+    to: { version: targetVersionConnectEs },
+  },
+  {
+    from: { name: "@connectrpc/connect-web", range: "^1.0.0" },
+    to: { version: targetVersionConnectEs },
+  },
+  {
+    remove: { name: "@connectrpc/protoc-gen-connect-es", range: "^1.0.0" },
+  },
+
+  // https://github.com/connectrpc/connect-query-es
+  {
+    from: { name: "@connectrpc/connect-query", range: "^1.0.0" },
+    to: { version: targetVersionConnectQuery },
+  },
+  {
+    from: { name: "@connectrpc/protoc-gen-connect-query", range: "^1.0.0" },
+    to: { version: targetVersionConnectQuery },
+  },
+
+  // https://github.com/connectrpc/connect-playwright-es
+  {
+    from: { name: "@connectrpc/connect-playwright", range: "^0.3.0" },
+    to: { version: targetVersionConnectPlaywright },
+  },
+];
+
+const bufGenYamlMigrations: BufGenYamlMigration[] = [
+  {
+    removePlugin: {
+      local: "protoc-gen-connect-es",
+      remote: "buf.build/connectrpc/es",
+    },
+  },
+  {
+    updatePlugin: {
+      remote: "buf.build/bufbuild/es",
+      from: "^1.0.0",
+      to: "2.0.0",
+    },
+  },
+  {
+    updatePlugin: {
+      remote: "buf.build/connectrpc/es",
+      from: "^1.0.0",
+      to: "2.0.0",
+    },
+  },
+  {
+    updatePlugin: {
+      remote: "buf.build/connectrpc/query-es",
+      from: "^1.0.0",
+      to: "2.0.0",
+    },
+  },
+];
+
+/**
+ * Migrates to protobuf-es and connect-es v2.
+ */
+export const v2_0_0: Migration = {
+  applicable(scanned: Scanned) {
+    return (
+      scanned.bufGenYamlFiles.some(
+        ({ yaml }) => migrateBufGenYaml(yaml, bufGenYamlMigrations) !== null,
+      ) ||
+      scanned.packageFiles.some(
+        ({ pkg }) => migrateDependencies(pkg, dependencyMigrations) !== null,
+      )
+    );
+  },
+  migrate({
+    scanned,
+    args,
+    print,
+    logger,
+    updateSourceFileFn = updateSourceFile,
+    writePackageJsonFileFn = writePackageJsonFile,
+    writeBufGenYamlFileFn = writeBufGenYamlFile,
+    runInstallFn = runInstall,
+  }): MigrateError | MigrateSuccess {
+    const { updatedPackageFiles } = migratePackages(
+      scanned,
+      dependencyMigrations,
+      print,
+      writePackageJsonFileFn,
+    );
+    const errorLines: string[] = [];
+    const { sourceFileErrors } = migrateSourceFiles(
+      scanned,
+      modifyImports,
+      print,
+      logger,
+      updateSourceFileFn,
+    );
+    if (sourceFileErrors > 0) {
+      errorLines.push(
+        `⚠️${sourceFileErrors} source ${
+          sourceFileErrors == 1 ? "file" : "files"
+        } could not be updated.`,
+        `You may have to update the files manually. Check the log for details.`,
+      );
+    }
+    const { updatedBufGenYamls } = migrateBufGenYamls(
+      scanned,
+      bufGenYamlMigrations,
+      print,
+      writeBufGenYamlFileFn,
+    );
+    if (updatedBufGenYamls.length > 0) {
+      print(
+        "  Make sure to re-generate code, for example with `npx buf generate`!\n",
+      );
+    }
+    const { lockFileErrors } = migrateLockFiles(
+      scanned,
+      updatedPackageFiles,
+      args,
+      print,
+      logger,
+      runInstallFn,
+    );
+    if (lockFileErrors > 0) {
+      errorLines.push(
+        `⚠️${lockFileErrors} lock ${
+          sourceFileErrors == 1 ? "file" : "files"
+        } could not be updated.`,
+        `To skip lock file updates, use the --no-install flag.`,
+      );
+    }
+    if (errorLines.length > 0) {
+      return {
+        ok: false,
+        errorMessage: errorLines.join("\n"),
+        dumpLogfile: true,
+      };
+    }
+    return {
+      ok: true,
+    };
+  },
+};


### PR DESCRIPTION
This updates the command `@bufbuild/connect-migrate` to migrate to v2. 

It updates the following packages:

- `@bufbuild/protobuf` → 2.0.0-beta.2
- `@bufbuild/protoplugin` → 2.0.0-beta.2
- `@bufbuild/protoc-gen-es` → 2.0.0-beta.2
- `@connectrpc/connect` → 2.0.0-alpha.1
- `@connectrpc/connect-express` → 2.0.0-alpha.1
- `@connectrpc/connect-fastify` → 2.0.0-alpha.1
- `@connectrpc/connect-next` → 2.0.0-alpha.1
- `@connectrpc/connect-node` → 2.0.0-alpha.1
- `@connectrpc/connect-web` → 2.0.0-alpha.1
- `@connectrpc/connect-query` → 2.0.0-alpha.1
- `@connectrpc/connect-playwright` → 0.4.0

It removes the following packages (the plugin is no longer needed):
- `@connectrpc/protoc-gen-connect-es`

For buf.gen.yaml files, it:
- Removes any plugin `local: protoc-gen-connect-es` or `remote: buf.build/connectrpc/es`.
- Updates pinned remote plugins, for example `remote: buf.build/bufbuild/es:v1.10.0` → `remote: buf.build/bufbuild/es:v2.0.0`.

It updates the following imports in source files:
- `import { ElizaService } from "./gen/eliza_connect.js"`  → `import { ElizaService } from "./gen/eliza_pb.js"`