### PR TITLE
Pass ConnectRouter directly

### DIFF
--- a/packages/connect-fastify/src/fastify-connect-plugin.ts
+++ b/packages/connect-fastify/src/fastify-connect-plugin.ts
@@ -50,6 +50,11 @@ interface FastifyConnectPluginOptions extends ConnectRouterOptions {
   routes?: (router: ConnectRouter) => void;
 
   /**
+   * If already got a ConnectRouter, pass this field to easily create routes
+   */
+  router?: ConnectRouter;
+
+  /**
    * If set, once `fastify.close` is called, waits for the requests to be finished for the specified duration
    * before aborting them.
    */
@@ -76,7 +81,7 @@ export function fastifyConnectPlugin(
   opts: FastifyConnectPluginOptions,
   done: (err?: Error) => void,
 ) {
-  if (opts.routes === undefined) {
+  if (opts.routes === undefined && opts.router === undefined) {
     done();
     return;
   }
@@ -93,7 +98,7 @@ export function fastifyConnectPlugin(
       done();
     });
   }
-  const router = createConnectRouter(opts);
+  const router = opts.router ?? createConnectRouter(opts);
   opts.routes(router);
 
   const uHandlers = router.handlers;


### PR DESCRIPTION
I added router field into Connect-Fastify plugin options

In my project, I'm using layered architecture so I've handlers layer for each domain, handlers would depend a lot of classes also my some of handlers would be depend each other. Whatever, I need to pass it ConnectRouter directly not in callback function.