### PR TITLE
V2: Use base64Encoding options from @bufbuild/protobuf v2

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect        | 198,649 b | 101,103 b | 24,242 b |
+| connect        | 198,597 b | 101,053 b | 24,217 b |
 | grpc-web       | 415,212 b    | 300,936 b    | 53,420 b |

--- a/packages/connect-web/browserstack/gen/connectrpc/eliza/v1/eliza_pb.ts
+++ b/packages/connect-web/browserstack/gen/connectrpc/eliza/v1/eliza_pb.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 The Connect Authors
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,26 +16,15 @@
 // @generated from file connectrpc/eliza/v1/eliza.proto (package connectrpc.eliza.v1, syntax proto3)
 /* eslint-disable */
 
-import type {
-  GenDescFile,
-  GenDescMessage,
-  GenDescService,
-} from "@bufbuild/protobuf/codegenv1";
-import {
-  fileDesc,
-  messageDesc,
-  serviceDesc,
-} from "@bufbuild/protobuf/codegenv1";
+import type { GenDescFile, GenDescMessage, GenDescService } from "@bufbuild/protobuf/codegenv1";
+import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
 import type { Message } from "@bufbuild/protobuf";
 
 /**
  * Describes the file connectrpc/eliza/v1/eliza.proto.
  */
-export const file_connectrpc_eliza_v1_eliza: GenDescFile =
-  /*@__PURE__*/
-  fileDesc(
-    "Ch9jb25uZWN0cnBjL2VsaXphL3YxL2VsaXphLnByb3RvEhNjb25uZWN0cnBjLmVsaXphLnYxIh4KClNheVJlcXVlc3QSEAoIc2VudGVuY2UYASABKAkiHwoLU2F5UmVzcG9uc2USEAoIc2VudGVuY2UYASABKAkiIwoPQ29udmVyc2VSZXF1ZXN0EhAKCHNlbnRlbmNlGAEgASgJIiQKEENvbnZlcnNlUmVzcG9uc2USEAoIc2VudGVuY2UYASABKAkiIAoQSW50cm9kdWNlUmVxdWVzdBIMCgRuYW1lGAEgASgJIiUKEUludHJvZHVjZVJlc3BvbnNlEhAKCHNlbnRlbmNlGAEgASgJMpwCCgxFbGl6YVNlcnZpY2USTQoDU2F5Eh8uY29ubmVjdHJwYy5lbGl6YS52MS5TYXlSZXF1ZXN0GiAuY29ubmVjdHJwYy5lbGl6YS52MS5TYXlSZXNwb25zZSIDkAIBEl0KCENvbnZlcnNlEiQuY29ubmVjdHJwYy5lbGl6YS52MS5Db252ZXJzZVJlcXVlc3QaJS5jb25uZWN0cnBjLmVsaXphLnYxLkNvbnZlcnNlUmVzcG9uc2UiACgBMAESXgoJSW50cm9kdWNlEiUuY29ubmVjdHJwYy5lbGl6YS52MS5JbnRyb2R1Y2VSZXF1ZXN0GiYuY29ubmVjdHJwYy5lbGl6YS52MS5JbnRyb2R1Y2VSZXNwb25zZSIAMAFiBnByb3RvMw",
-  );
+export const file_connectrpc_eliza_v1_eliza: GenDescFile = /*@__PURE__*/
+  fileDesc("Ch9jb25uZWN0cnBjL2VsaXphL3YxL2VsaXphLnByb3RvEhNjb25uZWN0cnBjLmVsaXphLnYxIh4KClNheVJlcXVlc3QSEAoIc2VudGVuY2UYASABKAkiHwoLU2F5UmVzcG9uc2USEAoIc2VudGVuY2UYASABKAkiIwoPQ29udmVyc2VSZXF1ZXN0EhAKCHNlbnRlbmNlGAEgASgJIiQKEENvbnZlcnNlUmVzcG9uc2USEAoIc2VudGVuY2UYASABKAkiIAoQSW50cm9kdWNlUmVxdWVzdBIMCgRuYW1lGAEgASgJIiUKEUludHJvZHVjZVJlc3BvbnNlEhAKCHNlbnRlbmNlGAEgASgJMpwCCgxFbGl6YVNlcnZpY2USTQoDU2F5Eh8uY29ubmVjdHJwYy5lbGl6YS52MS5TYXlSZXF1ZXN0GiAuY29ubmVjdHJwYy5lbGl6YS52MS5TYXlSZXNwb25zZSIDkAIBEl0KCENvbnZlcnNlEiQuY29ubmVjdHJwYy5lbGl6YS52MS5Db252ZXJzZVJlcXVlc3QaJS5jb25uZWN0cnBjLmVsaXphLnYxLkNvbnZlcnNlUmVzcG9uc2UiACgBMAESXgoJSW50cm9kdWNlEiUuY29ubmVjdHJwYy5lbGl6YS52MS5JbnRyb2R1Y2VSZXF1ZXN0GiYuY29ubmVjdHJwYy5lbGl6YS52MS5JbnRyb2R1Y2VSZXNwb25zZSIAMAFiBnByb3RvMw");
 
 /**
  * SayRequest is a single-sentence request.
@@ -53,8 +42,7 @@ export type SayRequest = Message<"connectrpc.eliza.v1.SayRequest"> & {
  * Describes the message connectrpc.eliza.v1.SayRequest.
  * Use `create(SayRequestSchema)` to create a new message.
  */
-export const SayRequestSchema: GenDescMessage<SayRequest> =
-  /*@__PURE__*/
+export const SayRequestSchema: GenDescMessage<SayRequest> = /*@__PURE__*/
   messageDesc(file_connectrpc_eliza_v1_eliza, 0);
 
 /**
@@ -73,8 +61,7 @@ export type SayResponse = Message<"connectrpc.eliza.v1.SayResponse"> & {
  * Describes the message connectrpc.eliza.v1.SayResponse.
  * Use `create(SayResponseSchema)` to create a new message.
  */
-export const SayResponseSchema: GenDescMessage<SayResponse> =
-  /*@__PURE__*/
+export const SayResponseSchema: GenDescMessage<SayResponse> = /*@__PURE__*/
   messageDesc(file_connectrpc_eliza_v1_eliza, 1);
 
 /**
@@ -94,8 +81,7 @@ export type ConverseRequest = Message<"connectrpc.eliza.v1.ConverseRequest"> & {
  * Describes the message connectrpc.eliza.v1.ConverseRequest.
  * Use `create(ConverseRequestSchema)` to create a new message.
  */
-export const ConverseRequestSchema: GenDescMessage<ConverseRequest> =
-  /*@__PURE__*/
+export const ConverseRequestSchema: GenDescMessage<ConverseRequest> = /*@__PURE__*/
   messageDesc(file_connectrpc_eliza_v1_eliza, 2);
 
 /**
@@ -104,20 +90,18 @@ export const ConverseRequestSchema: GenDescMessage<ConverseRequest> =
  *
  * @generated from message connectrpc.eliza.v1.ConverseResponse
  */
-export type ConverseResponse =
-  Message<"connectrpc.eliza.v1.ConverseResponse"> & {
-    /**
-     * @generated from field: string sentence = 1;
-     */
-    sentence: string;
-  };
+export type ConverseResponse = Message<"connectrpc.eliza.v1.ConverseResponse"> & {
+  /**
+   * @generated from field: string sentence = 1;
+   */
+  sentence: string;
+};
 
 /**
  * Describes the message connectrpc.eliza.v1.ConverseResponse.
  * Use `create(ConverseResponseSchema)` to create a new message.
  */
-export const ConverseResponseSchema: GenDescMessage<ConverseResponse> =
-  /*@__PURE__*/
+export const ConverseResponseSchema: GenDescMessage<ConverseResponse> = /*@__PURE__*/
   messageDesc(file_connectrpc_eliza_v1_eliza, 3);
 
 /**
@@ -125,20 +109,18 @@ export const ConverseResponseSchema: GenDescMessage<ConverseResponse> =
  *
  * @generated from message connectrpc.eliza.v1.IntroduceRequest
  */
-export type IntroduceRequest =
-  Message<"connectrpc.eliza.v1.IntroduceRequest"> & {
-    /**
-     * @generated from field: string name = 1;
-     */
-    name: string;
-  };
+export type IntroduceRequest = Message<"connectrpc.eliza.v1.IntroduceRequest"> & {
+  /**
+   * @generated from field: string name = 1;
+   */
+  name: string;
+};
 
 /**
  * Describes the message connectrpc.eliza.v1.IntroduceRequest.
  * Use `create(IntroduceRequestSchema)` to create a new message.
  */
-export const IntroduceRequestSchema: GenDescMessage<IntroduceRequest> =
-  /*@__PURE__*/
+export const IntroduceRequestSchema: GenDescMessage<IntroduceRequest> = /*@__PURE__*/
   messageDesc(file_connectrpc_eliza_v1_eliza, 4);
 
 /**
@@ -146,20 +128,18 @@ export const IntroduceRequestSchema: GenDescMessage<IntroduceRequest> =
  *
  * @generated from message connectrpc.eliza.v1.IntroduceResponse
  */
-export type IntroduceResponse =
-  Message<"connectrpc.eliza.v1.IntroduceResponse"> & {
-    /**
-     * @generated from field: string sentence = 1;
-     */
-    sentence: string;
-  };
+export type IntroduceResponse = Message<"connectrpc.eliza.v1.IntroduceResponse"> & {
+  /**
+   * @generated from field: string sentence = 1;
+   */
+  sentence: string;
+};
 
 /**
  * Describes the message connectrpc.eliza.v1.IntroduceResponse.
  * Use `create(IntroduceResponseSchema)` to create a new message.
  */
-export const IntroduceResponseSchema: GenDescMessage<IntroduceResponse> =
-  /*@__PURE__*/
+export const IntroduceResponseSchema: GenDescMessage<IntroduceResponse> = /*@__PURE__*/
   messageDesc(file_connectrpc_eliza_v1_eliza, 5);
 
 /**
@@ -182,7 +162,7 @@ export const ElizaService: GenDescService<{
     methodKind: "unary";
     input: typeof SayRequestSchema;
     output: typeof SayResponseSchema;
-  };
+  },
   /**
    * Converse is a bidirectional RPC. The caller may exchange multiple
    * back-and-forth messages with Eliza over a long-lived connection. Eliza
@@ -194,7 +174,7 @@ export const ElizaService: GenDescService<{
     methodKind: "bidi_streaming";
     input: typeof ConverseRequestSchema;
     output: typeof ConverseResponseSchema;
-  };
+  },
   /**
    * Introduce is a server streaming RPC. Given the caller's name, Eliza
    * returns a stream of sentences to introduce itself.
@@ -205,5 +185,8 @@ export const ElizaService: GenDescService<{
     methodKind: "server_streaming";
     input: typeof IntroduceRequestSchema;
     output: typeof IntroduceResponseSchema;
-  };
-}> = /*@__PURE__*/ serviceDesc(file_connectrpc_eliza_v1_eliza, 0);
+  },
+}
+> = /*@__PURE__*/
+  serviceDesc(file_connectrpc_eliza_v1_eliza, 0);
+

--- a/packages/connect/src/http-headers.ts
+++ b/packages/connect/src/http-headers.ts
@@ -51,7 +51,7 @@ export function encodeBinaryHeader(
         ? value
         : new Uint8Array(value as ArrayBufferLike);
   }
-  return base64Encode(bytes).replace(/=+$/, "");
+  return base64Encode(bytes, "std_raw");
 }
 
 /**

--- a/packages/connect/src/protocol-connect/error-json.spec.ts
+++ b/packages/connect/src/protocol-connect/error-json.spec.ts
@@ -62,6 +62,7 @@ describe("errorToJson()", () => {
                 domain: "example.com",
               }),
             ),
+            "std_raw",
           ),
           debug: {
             reason: "soirée 🎉",
@@ -170,6 +171,7 @@ describe("errorFromJson()", () => {
                 domain: "example.com",
               }),
             ),
+            "std_raw",
           ),
         },
       ],

--- a/packages/connect/src/protocol-connect/error-json.ts
+++ b/packages/connect/src/protocol-connect/error-json.ts
@@ -151,7 +151,7 @@ export function errorToJson(
       })
       .map(({ value, ...rest }) => ({
         ...rest,
-        value: base64Encode(value).replace(/=+$/, ""),
+        value: base64Encode(value, "std_raw"),
       }));
   }
   return o;

--- a/packages/connect/src/protocol-connect/get-request.ts
+++ b/packages/connect/src/protocol-connect/get-request.ts
@@ -28,12 +28,7 @@ const contentTypePrefix = "application/";
 
 function encodeMessageForUrl(message: Uint8Array, useBase64: boolean): string {
   if (useBase64) {
-    // TODO(jchadwick-buf): Three regex replaces seems excessive.
-    // Can we make protoBase64.enc more flexible?
-    return base64Encode(message)
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=+$/, "");
+    return base64Encode(message, "url");
   } else {
     return encodeURIComponent(new TextDecoder().decode(message));
   }


### PR DESCRIPTION
`base64Encode()` from `@bufbuild/protobuf/wire` takes an optional argument to omit padding or to use base64url encoding.

We can use it here to replace several regex replaces.