### PR TITLE
V2: Allow inline type imports in linter

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -74,7 +74,7 @@ module.exports = {
             "@typescript-eslint/no-invalid-void-type": "error",
             "@typescript-eslint/no-base-to-string": "error",
             "import/no-cycle": "error",
-            "import/no-duplicates": "error"
+            "import/no-duplicates": "error",
           },
         };
       }),

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -74,12 +74,7 @@ module.exports = {
             "@typescript-eslint/no-invalid-void-type": "error",
             "@typescript-eslint/no-base-to-string": "error",
             "import/no-cycle": "error",
-            "import/no-duplicates": "error",
-            // TS 4.5 adds type modifiers on import names, but we want to support lower versions
-            "import/consistent-type-specifier-style": [
-              "error",
-              "prefer-top-level",
-            ],
+            "import/no-duplicates": "error"
           },
         };
       }),


### PR DESCRIPTION
In V1, we support TypeScript versions earlier than 4.5, and have to take care not to use inline type imports. For V2, we support TypeScript 4.9.5 and later, so we can relax the linter to allow these import statements.