### PR TITLE
Handle multiple set-cookie headers when using Node client

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   152,637 b |  66,472 b |   16,369 b |
-| Connect-ES     |    4 |   168,079 b |  72,412 b |   16,863 b |
-| Connect-ES     |    8 |   193,392 b |  82,136 b |   17,475 b |
-| Connect-ES     |   16 |   227,031 b |  96,402 b |   18,225 b |
+| Connect-ES     |    1 |   152,643 b |  66,478 b |   16,380 b |
+| Connect-ES     |    4 |   168,085 b |  72,418 b |   16,852 b |
+| Connect-ES     |    8 |   193,398 b |  82,142 b |   17,475 b |
+| Connect-ES     |   16 |   227,037 b |  96,408 b |   18,237 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.64248046875 140,242.24345703125 280,240.51025390625 420,238.38623046875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.611328125 140,242.274609375 280,240.51025390625 420,238.35224609375">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="243.64248046875" r="4" fill="#ffa600"><title>Connect-ES 15.99 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="242.24345703125" r="4" fill="#ffa600"><title>Connect-ES 16.47 KiB for 4 RPCs</title></circle>
+<circle cx="0" cy="243.611328125" r="4" fill="#ffa600"><title>Connect-ES 16 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="242.274609375" r="4" fill="#ffa600"><title>Connect-ES 16.46 KiB for 4 RPCs</title></circle>
 <circle cx="280" cy="240.51025390625" r="4" fill="#ffa600"><title>Connect-ES 17.07 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="238.38623046875" r="4" fill="#ffa600"><title>Connect-ES 17.8 KiB for 16 RPCs</title></circle>
+<circle cx="420" cy="238.35224609375" r="4" fill="#ffa600"><title>Connect-ES 17.81 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect/src/protocol-connect/trailer-mux.ts
+++ b/packages/connect/src/protocol-connect/trailer-mux.ts
@@ -28,9 +28,9 @@ export function trailerDemux(
     t = new Headers();
   header.forEach((value, key) => {
     if (key.toLowerCase().startsWith("trailer-")) {
-      t.set(key.substring(8), value);
+      t.append(key.substring(8), value);
     } else {
-      h.set(key, value);
+      h.append(key, value);
     }
   });
   return [h, t];
@@ -47,7 +47,7 @@ export function trailerDemux(
 export function trailerMux(header: Headers, trailer: Headers): Headers {
   const h = new Headers(header);
   trailer.forEach((value, key) => {
-    h.set(`trailer-${key}`, value);
+    h.append(`trailer-${key}`, value);
   });
   return h;
 }

--- a/packages/connect/src/protocol-connect/transport.spec.ts
+++ b/packages/connect/src/protocol-connect/transport.spec.ts
@@ -384,4 +384,36 @@ describe("Connect transport", function () {
       }
     });
   });
+  if ("getSetCookie" in new Headers()) {
+    describe("when there is support for set-cookie", function () {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      const setMultiValueHeaders: UniversalClientFn = async () => {
+        return {
+          status: 200,
+          header: new Headers({
+            "Content-Type": contentTypeUnaryProto,
+            "set-cookie": "a=a; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
+            "Set-Cookie": "b=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
+          }),
+          body: createAsyncIterable([new StringValue({ value: "abc" }).toBinary()]),
+          trailer: new Headers(),
+        };
+      };
+      it("should produce the correct array of values in the response", async function () {
+        const t = createTransport({ ...defaultTransportOptions, httpClient: setMultiValueHeaders });
+        const res = await t.unary(
+          TestService,
+          TestService.methods.unary,
+          undefined,
+          undefined,
+          undefined,
+          {}
+        )
+        expect(res.header.getSetCookie()).toEqual([
+          "a=a; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
+          "b=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
+        ]);
+      });
+    });
+  }
 });

--- a/packages/connect/src/protocol-connect/transport.spec.ts
+++ b/packages/connect/src/protocol-connect/transport.spec.ts
@@ -395,20 +395,25 @@ describe("Connect transport", function () {
             "set-cookie": "a=a; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
             "Set-Cookie": "b=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
           }),
-          body: createAsyncIterable([new StringValue({ value: "abc" }).toBinary()]),
+          body: createAsyncIterable([
+            new StringValue({ value: "abc" }).toBinary(),
+          ]),
           trailer: new Headers(),
         };
       };
       it("should produce the correct array of values in the response", async function () {
-        const t = createTransport({ ...defaultTransportOptions, httpClient: setMultiValueHeaders });
+        const t = createTransport({
+          ...defaultTransportOptions,
+          httpClient: setMultiValueHeaders,
+        });
         const res = await t.unary(
           TestService,
           TestService.methods.unary,
           undefined,
           undefined,
           undefined,
-          {}
-        )
+          {},
+        );
         expect(res.header.getSetCookie()).toEqual([
           "a=a; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
           "b=b; Expires=Wed, 21 Oct 2015 07:28:00 GMT",


### PR DESCRIPTION
This allows for the special multi-value header of `set-cookie` to be processed properly by appending values instead of setting them when processing the header/trailer muxing and demuxing. Including a test that demonstrates issue without the change. Fixes https://github.com/connectrpc/connect-es/issues/1154.