### PR TITLE
Create pregenerate scripts for relevant packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,20 +119,17 @@ $(BUILD)/connect-migrate: packages/connect-migrate/package.json packages/connect
 	@touch $(@)
 
 $(GEN)/connect: node_modules/.bin/protoc-gen-es packages/connect/buf.gen.yaml $(shell find packages/connect/src -name '*.proto') Makefile
-	rm -rf packages/connect/src/gen/*
 	npm run -w packages/connect generate
 	@mkdir -p $(@D)
 	@touch $(@)
 
 $(GEN)/connect-conformance: node_modules/.bin/protoc-gen-es $(BUILD)/protoc-gen-connect-es packages/connect-conformance/buf.gen.yaml packages/connect-conformance/package.json Makefile
-	rm -rf packages/connect-conformance/src/gen/*
 	npm run -w packages/connect-conformance generate
 	@mkdir -p $(@D)
 	@touch $(@)
 
 $(GEN)/connect-web: node_modules/.bin/protoc-gen-es $(BUILD)/protoc-gen-connect-es packages/connect-web/browserstack/buf.gen.yaml Makefile
-	rm -rf packages/connect-web/browserstack/gen/*
-	npm run -w packages/connect-web generate:browserstack
+	npm run -w packages/connect-web generate
 	@mkdir -p $(@D)
 	@touch $(@)
 
@@ -142,8 +139,7 @@ $(GEN)/connect-web-bench: node_modules/.bin/protoc-gen-es $(BUILD)/protoc-gen-co
 	@touch $(@)
 
 $(GEN)/example: node_modules/.bin/protoc-gen-es $(BUILD)/protoc-gen-connect-es packages/example/buf.gen.yaml $(shell find packages/example -name '*.proto')
-	rm -rf packages/example/src/gen/*
-	npx -w packages/example buf generate
+	npm run -w packages/example generate
 	@mkdir -p $(@D)
 	@touch $(@)
 

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -14,6 +14,7 @@
     "connectconformance": "bin/connectconformance.cjs"
   },
   "scripts": {
+    "pregenerate": "rm -rf src/gen/*",
     "generate": "buf generate buf.build/connectrpc/conformance:v1.0.2",
     "clean": "rm -rf ./dist/*",
     "build": "npm run build:cjs && npm run build:esm",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -19,7 +19,8 @@
     "conformance:client:node": "connectconformance --mode client --conf ./conformance/conformance-web-node.yaml -v -- ./conformance/client.ts --browser node && connectconformance --mode client --conf ./conformance/conformance-web-node.yaml -v --known-failing @./conformance/known-failing-callback-client.txt -- ./conformance/client.ts --browser node --useCallbackClient",
     "conformance:client:browser": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v -- ./conformance/client.ts && connectconformance --mode client --conf ./conformance/conformance-web.yaml -v --known-failing @./conformance/known-failing-callback-client.txt -- ./conformance/client.ts --useCallbackClient",
     "jasmine": "jasmine --config=jasmine.json",
-    "generate:browserstack": "buf generate buf.build/connectrpc/eliza --template browserstack/buf.gen.yaml",
+    "pregenerate": "rm -rf browserstack/gen/*",
+    "generate": "buf generate buf.build/connectrpc/eliza --template browserstack/buf.gen.yaml",
     "karma:browserstack": "karma start browserstack/karma.browserstack.conf.cjs"
   },
   "type": "module",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "clean": "rm -rf ./dist/*",
+    "pregenerate": "rm -rf src/protocol-grpc/gen/*",
     "generate": "buf generate src/protocol-grpc/proto",
     "build": "npm run build:cjs && npm run build:esm && node scripts/update-user-agent.mjs",
     "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs --declaration --declarationDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -6,6 +6,7 @@
     "lint": "tsc --noEmit",
     "start": "tsx src/server.ts",
     "client": "tsx src/client.ts",
+    "pregenerate": "rm -rf src/gen/*",
     "generate": "buf generate"
   },
   "engines": {


### PR DESCRIPTION
This creates `pregenerate` scripts for all relevant packages, which does the removal of the generated files directories. In doing so, it moves logic from the Makefile to npm.