### PR TITLE
Listens to response close event for aborted request trigger on http 1

### DIFF
--- a/packages/connect-express/src/express-connect-middleware.ts
+++ b/packages/connect-express/src/express-connect-middleware.ts
@@ -87,6 +87,7 @@ export function expressConnectMiddleware(
     }
     const uReq = universalRequestFromNodeRequest(
       req,
+      res,
       getPreparsedBody(req),
       options.contextValues?.(req),
     );

--- a/packages/connect-fastify/src/fastify-connect-plugin.ts
+++ b/packages/connect-fastify/src/fastify-connect-plugin.ts
@@ -115,6 +115,7 @@ export function fastifyConnectPlugin(
           const uRes = await uHandler(
             universalRequestFromNodeRequest(
               req.raw,
+              reply.raw,
               req.body as JsonValue | undefined,
               opts.contextValues?.(req),
             ),

--- a/packages/connect-next/src/connect-nextjs-adapter.ts
+++ b/packages/connect-next/src/connect-nextjs-adapter.ts
@@ -95,6 +95,7 @@ export function nextJsApiRouter(options: NextJsApiRouterOptions): ApiRoute {
       const uRes = await uHandler(
         universalRequestFromNodeRequest(
           req,
+          res,
           req.body as JsonValue | undefined,
           options.contextValues?.(req),
         ),

--- a/packages/connect-node/src/connect-node-adapter.ts
+++ b/packages/connect-node/src/connect-node-adapter.ts
@@ -96,6 +96,7 @@ export function connectNodeAdapter(
     }
     const uReq = universalRequestFromNodeRequest(
       req,
+      res,
       undefined,
       options.contextValues?.(req),
     );


### PR DESCRIPTION
Fixes #1025.

This breaks some backwards compatibility. Up until now the "aborted" state of the request was always set as soon as the body of the request had been read. This is undesired, buggy behavior, as #1025 documents. For any applications using the abort controller's signal, they would be aborted every time!

The [Node.js documentation on the request close event](https://nodejs.org/api/http.html#event-close) is misleading at best, inaccurate at worst, as discussed in https://github.com/nodejs/node/issues/40775. Nevertheless, listening to the `close` event of the _response_ for aborted client requests is the functionally correct implementation. For example, see New Relic changing their instrumentation library to do so https://github.com/newrelic/node-newrelic/pull/1510

The exported `universalRequestFromNodeRequest` function now requires the `response` parameter as well.