### PR TITLE
Fix conformance tests for @connectrpc/connect-web on Firefox

### DIFF
--- a/packages/connect-web/conformance/browserscript.ts
+++ b/packages/connect-web/conformance/browserscript.ts
@@ -36,6 +36,9 @@ async function runTestCase(
   useCallbackClient: boolean,
 ): Promise<number[]> {
   const req = ClientCompatRequest.fromBinary(new Uint8Array(data));
+  const p = document.createElement("p");
+  p.innerText = req.testName;
+  document.body.append(p);
   const res = new ClientCompatResponse({
     testName: req.testName,
   });

--- a/packages/connect-web/conformance/known-failing-promise-client-firefox.txt
+++ b/packages/connect-web/conformance/known-failing-promise-client-firefox.txt
@@ -1,4 +1,0 @@
-# In firefox with the promise client, the failure is: 
-#     actual error {code: 2 (unknown), message: "AbortError: The operation was aborted. "} does not match expected code 1 (canceled)
-**/server-stream/cancel-after-zero-responses
-**/server-stream/cancel-after-responses

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -15,7 +15,7 @@
     "attw": "attw --pack",
     "conformance:client:chrome:promise": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v -- ./conformance/client.ts --browser chrome",
     "conformance:client:chrome:callback": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v --known-failing @./conformance/known-failing-callback-client.txt -- ./conformance/client.ts --browser chrome --useCallbackClient",
-    "conformance:client:firefox:promise": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v --known-failing @./conformance/known-failing-promise-client-firefox.txt -- ./conformance/client.ts --browser firefox",
+    "conformance:client:firefox:promise": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v -- ./conformance/client.ts --browser firefox",
     "conformance:client:firefox:callback": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v --known-failing @./conformance/known-failing-callback-client.txt -- ./conformance/client.ts --browser firefox --useCallbackClient",
     "conformance:client:safari:promise": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v -- ./conformance/client.ts --browser safari",
     "conformance:client:safari:callback": "connectconformance --mode client --conf ./conformance/conformance-web.yaml -v --known-failing @./conformance/known-failing-callback-client.txt -- ./conformance/client.ts --browser safari --useCallbackClient",


### PR DESCRIPTION
Following up on https://github.com/connectrpc/connect-es/pull/1183, this updates our test setup to avoid an issue with the Firefox webdriver:

Instead of passing our script to FF's JS engine via `WebdriverIO.Browser.executeScript`, we serve a HTML document that embeds the script. This slightly complicates our test setup, but it's well worth it, since there could be similar other issues that we just haven't run into yet.