### PR TITLE
V2: Correct type inference for ConnectError#findDetails

### DIFF
--- a/packages/connect/src/connect-error.ts
+++ b/packages/connect/src/connect-error.ts
@@ -161,7 +161,7 @@ export class ConnectError extends Error {
    * omitted from the list.
    */
   findDetails<Desc extends DescMessage>(
-    desc: DescMessage,
+    desc: Desc,
   ): MessageShape<Desc>[];
   findDetails(registry: Registry): Message[];
   findDetails(typeOrRegistry: DescMessage | Registry): Message[] {


### PR DESCRIPTION
I noticed a minor issue with the types for `findDetails` that prevented correct type inference for the return type. e.g.:

```
const details = e.findDetails(MyDetailsSchema)
```

I wanted `details` to be type `MyDetails[]` but instead it's `Message<string>[]`. The change in this PR fixes it.