### PR TITLE
Fix Node.js v16 error responses on HTTP1.1

### DIFF
--- a/.github/workflows/conformance-express.yaml
+++ b/.github/workflows/conformance-express.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [21.1.0, 20.9.0, 18.16.0]
+        node-version: [21.1.0, 20.9.0, 18.16.0, 16.20.0]
     name: "Node.js ${{ matrix.node-version }}"
     timeout-minutes: 10
     steps:

--- a/.github/workflows/conformance-fastify.yaml
+++ b/.github/workflows/conformance-fastify.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [21.1.0, 20.9.0, 18.16.0]
+        node-version: [21.1.0, 20.9.0, 18.16.0, 16.20.0]
     name: "Node.js ${{ matrix.node-version }}"
     timeout-minutes: 10
     steps:

--- a/.github/workflows/conformance-node.yaml
+++ b/.github/workflows/conformance-node.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [21.1.0, 20.9.0, 18.16.0]
+        node-version: [21.1.0, 20.9.0, 18.16.0, 16.20.0]
         side: [client, server]
     name: "Node.js ${{ matrix.node-version }} ${{ matrix.side }}"
     timeout-minutes: 10


### PR DESCRIPTION
This fixes a bug for Connect-ES servers running on Node.js v16: When an error occurred when parsing the request body, the server would silently fail to write the error to the response.

For technical reasons, we haven't been running the [Connect Conformance tests](https://github.com/connectrpc/conformance) on Node.js v16, and this bug went unnoticed. Now that we're more flexible with running tests on different versions of Node.js (thanks to https://github.com/connectrpc/connect-es/pull/1194), we can add v16 to CI to make sure we don't regress.
