### PR TITLE
Fix gRPC trailers only response

### DIFF
--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -147,6 +147,10 @@ export function createTransport(opt: CommonTransportOptions): Transport {
           );
           validateTrailer(uRes.trailer, uRes.header);
           if (message === undefined) {
+            // Trailers only response
+            if (headerError) {
+              throw headerError;
+            }
             throw new ConnectError(
               "protocol error: missing output message for unary method",
               uRes.trailer.has(headerGrpcStatus)


### PR DESCRIPTION
Fix gRPC trailers only response. Conformance test `v1.0.3` include test cases for this. Upgrade PR: #1208. Closes #1161