### PR TITLE
Rename argument for the sessionProvider option for the Node HTTP client

### DIFF
--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -156,13 +156,13 @@ export class Http2SessionManager {
   private verifying: Promise<void> | undefined;
 
   public constructor(
-    authority: URL | string,
+    url: URL | string,
     pingOptions?: Http2SessionOptions,
     http2SessionOptions?:
       | http2.ClientSessionOptions
       | http2.SecureClientSessionOptions,
   ) {
-    this.authority = new URL(authority).origin;
+    this.authority = new URL(url).origin;
     this.http2SessionOptions = http2SessionOptions;
     this.options = {
       pingIntervalMs: pingOptions?.pingIntervalMs ?? Number.POSITIVE_INFINITY,

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -62,11 +62,11 @@ export type NodeHttpClientOptions =
       httpVersion: "2";
 
       /**
-       * A function that must return a session manager for the given authority.
+       * A function that must return a session manager for the given URL.
        * The session manager may be taken from a pool.
        * By default, a new Http2SessionManager is created for every request.
        */
-      sessionProvider?: (authority: string) => NodeHttp2ClientSessionManager;
+      sessionProvider?: (url: string) => NodeHttp2ClientSessionManager;
     };
 
 /**
@@ -80,8 +80,7 @@ export function createNodeHttpClient(options: NodeHttpClientOptions) {
     return createNodeHttp1Client(options.nodeOptions);
   }
   const sessionProvider =
-    options.sessionProvider ??
-    ((authority: string) => new Http2SessionManager(authority));
+    options.sessionProvider ?? ((url: string) => new Http2SessionManager(url));
   return createNodeHttp2Client(sessionProvider);
 }
 
@@ -169,7 +168,7 @@ function createNodeHttp1Client(
  * an UniversalClientResponse.
  */
 function createNodeHttp2Client(
-  sessionProvider: (authority: string) => NodeHttp2ClientSessionManager,
+  sessionProvider: (url: string) => NodeHttp2ClientSessionManager,
 ): UniversalClientFn {
   return function request(
     req: UniversalClientRequest,


### PR DESCRIPTION
The universal Node HTTP client takes the option `sessionProvider` to create a HTTP/2 session for a given URL. The argument for the URL is named "authority", which is confusing. While it makes sense to manage sessions by authority, the argument is the full URL.