### PR TITLE
Simplify conformance client implementation

### DIFF
--- a/packages/connect-conformance/src/callback-client.ts
+++ b/packages/connect-conformance/src/callback-client.ts
@@ -71,7 +71,7 @@ async function unary(
         compatRequest,
         idempotent ? IdempotentUnaryRequest : UnaryRequest,
       ),
-      (err, uRes) => {
+      (err, response) => {
         // Callback clients swallow client triggered cancellations and never
         // call the callback. This will trigger the global error handler and
         // fail the process.
@@ -89,7 +89,7 @@ async function unary(
           }
           result.responseTrailers = convertToProtoHeaders(err.metadata);
         } else {
-          result.payloads.push(uRes.payload!);
+          result.payloads.push(response.payload!);
         }
         resolve(result);
       },

--- a/packages/connect-conformance/src/callback-client.ts
+++ b/packages/connect-conformance/src/callback-client.ts
@@ -31,6 +31,7 @@ import {
   getCancelTiming,
   getRequestHeaders,
   getSingleRequestMessage,
+  setClientErrorResult,
 } from "./protocol.js";
 import { ConformanceService } from "./gen/connectrpc/conformance/v1/service_connect.js";
 
@@ -79,15 +80,7 @@ async function unary(
           throw new Error("Aborted requests should not trigger the callback");
         }
         if (err !== undefined) {
-          result.error = convertToProtoError(err);
-          // We can't distinguish between headers and trailers here, so we just
-          // add the metadata to both.
-          //
-          // But if the headers are already set, we don't need to overwrite them.
-          if (result.responseHeaders.length === 0) {
-            result.responseHeaders = convertToProtoHeaders(err.metadata);
-          }
-          result.responseTrailers = convertToProtoHeaders(err.metadata);
+          setClientErrorResult(result, err);
         } else {
           result.payloads.push(response.payload!);
         }
@@ -153,15 +146,7 @@ async function serverStream(
           );
         }
         if (err !== undefined) {
-          result.error = convertToProtoError(err);
-          // We can't distinguish between headers and trailers here, so we just
-          // add the metadata to both.
-          //
-          // But if the headers are already set, we don't need to overwrite them.
-          if (result.responseHeaders.length === 0) {
-            result.responseHeaders = convertToProtoHeaders(err.metadata);
-          }
-          result.responseTrailers = convertToProtoHeaders(err.metadata);
+          setClientErrorResult(result, err);
         }
         resolve(result);
       },
@@ -195,15 +180,7 @@ async function unimplemented(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       (err, _) => {
         if (err !== undefined) {
-          result.error = convertToProtoError(err);
-          // We can't distinguish between headers and trailers here, so we just
-          // add the metadata to both.
-          //
-          // But if the headers are already set, we don't need to overwrite them.
-          if (result.responseHeaders.length === 0) {
-            result.responseHeaders = convertToProtoHeaders(err.metadata);
-          }
-          result.responseTrailers = convertToProtoHeaders(err.metadata);
+          setClientErrorResult(result, err);
         }
         resolve(result);
       },

--- a/packages/connect-conformance/src/promise-client.ts
+++ b/packages/connect-conformance/src/promise-client.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { PromiseClient, Transport } from "@connectrpc/connect";
-import { ConnectError, createPromiseClient } from "@connectrpc/connect";
+import { createPromiseClient } from "@connectrpc/connect";
 import {
   ClientCompatRequest,
   ClientResponseResult,
@@ -27,12 +27,12 @@ import {
   UnimplementedRequest,
 } from "./gen/connectrpc/conformance/v1/service_pb.js";
 import {
-  convertToProtoError,
   convertToProtoHeaders,
   getCancelTiming,
   getRequestHeaders,
   getRequestMessages,
   getSingleRequestMessage,
+  setClientErrorResult,
   wait,
 } from "./protocol.js";
 import { ConformanceService } from "./gen/connectrpc/conformance/v1/service_connect.js";
@@ -95,16 +95,7 @@ async function unary(
     });
     result.payloads.push(response.payload!);
   } catch (e) {
-    const err = ConnectError.from(e);
-    result.error = convertToProtoError(err);
-    // We can't distinguish between headers and trailers here, so we just
-    // add the metadata to both.
-    //
-    // But if the headers are already set, we don't need to overwrite them.
-    if (result.responseHeaders.length === 0) {
-      result.responseHeaders = convertToProtoHeaders(err.metadata);
-    }
-    result.responseTrailers = convertToProtoHeaders(err.metadata);
+    setClientErrorResult(result, e);
   }
   return result;
 }
@@ -140,16 +131,7 @@ async function serverStream(
       }
     }
   } catch (e) {
-    const err = ConnectError.from(e);
-    result.error = convertToProtoError(err);
-    // We can't distinguish between headers and trailers here, so we just
-    // add the metadata to both.
-    //
-    // But if the headers are already set, we don't need to overwrite them.
-    if (result.responseHeaders.length === 0) {
-      result.responseHeaders = convertToProtoHeaders(err.metadata);
-    }
-    result.responseTrailers = convertToProtoHeaders(err.metadata);
+    setClientErrorResult(result, e);
   }
   return result;
 }
@@ -192,16 +174,7 @@ async function clientStream(
     );
     result.payloads.push(response.payload!);
   } catch (e) {
-    const err = ConnectError.from(e);
-    result.error = convertToProtoError(err);
-    // We can't distinguish between headers and trailers here, so we just
-    // add the metadata to both.
-    //
-    // But if the headers are already set, we don't need to overwrite them.
-    if (result.responseHeaders.length === 0) {
-      result.responseHeaders = convertToProtoHeaders(err.metadata);
-    }
-    result.responseTrailers = convertToProtoHeaders(err.metadata);
+    setClientErrorResult(result, e);
   }
   return result;
 }
@@ -267,16 +240,7 @@ async function bidiStream(
       }
     }
   } catch (e) {
-    const err = ConnectError.from(e);
-    result.error = convertToProtoError(err);
-    // We can't distinguish between headers and trailers here, so we just
-    // add the metadata to both.
-    //
-    // But if the headers are already set, we don't need to overwrite them.
-    if (result.responseHeaders.length === 0) {
-      result.responseHeaders = convertToProtoHeaders(err.metadata);
-    }
-    result.responseTrailers = convertToProtoHeaders(err.metadata);
+    setClientErrorResult(result, e);
   }
   return result;
 }
@@ -298,16 +262,7 @@ async function unimplemented(
       },
     });
   } catch (e) {
-    const err = ConnectError.from(e);
-    result.error = convertToProtoError(err);
-    // We can't distinguish between headers and trailers here, so we just
-    // add the metadata to both.
-    //
-    // But if the headers are already set, we don't need to overwrite them.
-    if (result.responseHeaders.length === 0) {
-      result.responseHeaders = convertToProtoHeaders(err.metadata);
-    }
-    result.responseTrailers = convertToProtoHeaders(err.metadata);
+    setClientErrorResult(result, e);
   }
   return result;
 }

--- a/packages/connect-conformance/src/promise-client.ts
+++ b/packages/connect-conformance/src/promise-client.ts
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createPromiseClient, ConnectError } from "@connectrpc/connect";
 import type { PromiseClient, Transport } from "@connectrpc/connect";
+import { ConnectError, createPromiseClient } from "@connectrpc/connect";
 import {
   ClientCompatRequest,
   ClientResponseResult,
 } from "./gen/connectrpc/conformance/v1/client_compat_pb.js";
 import {
-  UnaryRequest,
-  Header as ConformanceHeader,
-  ClientStreamRequest,
-  ServerStreamRequest,
-  ConformancePayload,
   BidiStreamRequest,
-  UnimplementedRequest,
+  ClientStreamRequest,
   IdempotentUnaryRequest,
+  ServerStreamRequest,
+  UnaryRequest,
+  UnimplementedRequest,
 } from "./gen/connectrpc/conformance/v1/service_pb.js";
 import {
   convertToProtoError,
   convertToProtoHeaders,
-  appendProtoHeaders,
-  wait,
   getCancelTiming,
+  getRequestHeaders,
+  getRequestMessages,
+  getSingleRequestMessage,
+  wait,
 } from "./protocol.js";
 import { ConformanceService } from "./gen/connectrpc/conformance/v1/service_connect.js";
 import { createWritableIterable } from "@connectrpc/connect/protocol";
@@ -43,181 +43,133 @@ type ConformanceClient = PromiseClient<typeof ConformanceService>;
 
 export function invokeWithPromiseClient(
   transport: Transport,
-  req: ClientCompatRequest,
+  compatRequest: ClientCompatRequest,
 ) {
   const client = createPromiseClient(ConformanceService, transport);
 
-  switch (req.method) {
+  switch (compatRequest.method) {
     case ConformanceService.methods.unary.name:
-      return unary(client, req);
+      return unary(client, compatRequest);
     case ConformanceService.methods.idempotentUnary.name:
-      return unary(client, req, true);
+      return unary(client, compatRequest, true);
     case ConformanceService.methods.serverStream.name:
-      return serverStream(client, req);
+      return serverStream(client, compatRequest);
     case ConformanceService.methods.clientStream.name:
-      return clientStream(client, req);
+      return clientStream(client, compatRequest);
     case ConformanceService.methods.bidiStream.name:
-      return bidiStream(client, req);
+      return bidiStream(client, compatRequest);
     case ConformanceService.methods.unimplemented.name:
-      return unimplemented(client, req);
+      return unimplemented(client, compatRequest);
     default:
-      throw new Error(`Unknown method: ${req.method}`);
+      throw new Error(`Unknown method: ${compatRequest.method}`);
   }
 }
 
 async function unary(
   client: ConformanceClient,
-  req: ClientCompatRequest,
+  compatRequest: ClientCompatRequest,
   idempotent: boolean = false,
 ) {
-  if (req.requestMessages.length !== 1) {
-    throw new Error("Unary method requires exactly one request message");
-  }
-  const msg = req.requestMessages[0];
-  const uReq = idempotent ? new IdempotentUnaryRequest() : new UnaryRequest();
-  if (!msg.unpackTo(uReq)) {
-    throw new Error("Could not unpack request message to unary request");
-  }
-  const reqHeader = new Headers();
-  appendProtoHeaders(reqHeader, req.requestHeaders);
-  let error: ConnectError | undefined = undefined;
-  let resHeaders: ConformanceHeader[] = [];
-  let resTrailers: ConformanceHeader[] = [];
-  const payloads: ConformancePayload[] = [];
+  await wait(compatRequest.requestDelayMs);
+  const result = new ClientResponseResult();
   try {
-    let call = client.unary;
-    if (idempotent) {
-      call = client.idempotentUnary;
-    }
     const controller = new AbortController();
-    await wait(req.requestDelayMs);
-    const { afterCloseSendMs } = getCancelTiming(req);
+    const { afterCloseSendMs } = getCancelTiming(compatRequest);
     if (afterCloseSendMs >= 0) {
-      wait(afterCloseSendMs)
-        .then(() => controller.abort())
-        .catch(() => {});
+      void wait(afterCloseSendMs).then(() => controller.abort());
     }
-    const uRes = await call(uReq, {
-      headers: reqHeader,
+    const request = getSingleRequestMessage(
+      compatRequest,
+      idempotent ? IdempotentUnaryRequest : UnaryRequest,
+    );
+    const call = idempotent ? client.idempotentUnary : client.unary;
+    const response = await call(request, {
+      headers: getRequestHeaders(compatRequest),
       signal: controller.signal,
       onHeader(headers) {
-        resHeaders = convertToProtoHeaders(headers);
+        result.responseHeaders = convertToProtoHeaders(headers);
       },
       onTrailer(trailers) {
-        resTrailers = convertToProtoHeaders(trailers);
+        result.responseTrailers = convertToProtoHeaders(trailers);
       },
     });
-    payloads.push(uRes.payload!);
+    result.payloads.push(response.payload!);
   } catch (e) {
-    error = ConnectError.from(e);
+    const err = ConnectError.from(e);
+    result.error = convertToProtoError(err);
     // We can't distinguish between headers and trailers here, so we just
     // add the metadata to both.
     //
     // But if the headers are already set, we don't need to overwrite them.
-    resHeaders =
-      resHeaders.length === 0
-        ? convertToProtoHeaders(error.metadata)
-        : resHeaders;
-    resTrailers = convertToProtoHeaders(error.metadata);
+    if (result.responseHeaders.length === 0) {
+      result.responseHeaders = convertToProtoHeaders(err.metadata);
+    }
+    result.responseTrailers = convertToProtoHeaders(err.metadata);
   }
-  return new ClientResponseResult({
-    payloads: payloads,
-    responseHeaders: resHeaders,
-    responseTrailers: resTrailers,
-    error: convertToProtoError(error),
-  });
+  return result;
 }
 
 async function serverStream(
   client: ConformanceClient,
-  req: ClientCompatRequest,
+  compatRequest: ClientCompatRequest,
 ) {
-  if (req.requestMessages.length !== 1) {
-    throw new Error("ServerStream method requires exactly one request message");
-  }
-  const msg = req.requestMessages[0];
-  const uReq = new ServerStreamRequest();
-  if (!msg.unpackTo(uReq)) {
-    throw new Error(
-      "Could not unpack request message to server stream request",
-    );
-  }
-  const reqHeader = new Headers();
-  appendProtoHeaders(reqHeader, req.requestHeaders);
-  let error: ConnectError | undefined = undefined;
-  let resHeaders: ConformanceHeader[] = [];
-  let resTrailers: ConformanceHeader[] = [];
-  const payloads: ConformancePayload[] = [];
-  const cancelTiming = getCancelTiming(req);
+  const cancelTiming = getCancelTiming(compatRequest);
   const controller = new AbortController();
+  await wait(compatRequest.requestDelayMs);
+  const result = new ClientResponseResult();
+  const request = getSingleRequestMessage(compatRequest, ServerStreamRequest);
   try {
-    await wait(req.requestDelayMs);
-    const res = client.serverStream(uReq, {
-      headers: reqHeader,
+    const res = client.serverStream(request, {
+      headers: getRequestHeaders(compatRequest),
       signal: controller.signal,
       onHeader(headers) {
-        resHeaders = convertToProtoHeaders(headers);
+        result.responseHeaders = convertToProtoHeaders(headers);
       },
       onTrailer(trailers) {
-        resTrailers = convertToProtoHeaders(trailers);
+        result.responseTrailers = convertToProtoHeaders(trailers);
       },
     });
     if (cancelTiming.afterCloseSendMs >= 0) {
       await wait(cancelTiming.afterCloseSendMs);
       controller.abort();
     }
-    let count = 0;
     for await (const msg of res) {
-      payloads.push(msg.payload!);
-      count++;
-      if (count === cancelTiming.afterNumResponses) {
+      result.payloads.push(msg.payload!);
+      if (result.payloads.length === cancelTiming.afterNumResponses) {
         controller.abort();
       }
     }
   } catch (e) {
-    error = ConnectError.from(e);
+    const err = ConnectError.from(e);
+    result.error = convertToProtoError(err);
     // We can't distinguish between headers and trailers here, so we just
     // add the metadata to both.
     //
     // But if the headers are already set, we don't need to overwrite them.
-    resHeaders =
-      resHeaders.length === 0
-        ? convertToProtoHeaders(error.metadata)
-        : resHeaders;
-    resTrailers = convertToProtoHeaders(error.metadata);
+    if (result.responseHeaders.length === 0) {
+      result.responseHeaders = convertToProtoHeaders(err.metadata);
+    }
+    result.responseTrailers = convertToProtoHeaders(err.metadata);
   }
-  return new ClientResponseResult({
-    responseHeaders: resHeaders,
-    responseTrailers: resTrailers,
-    payloads: payloads,
-    error: convertToProtoError(error),
-  });
+  return result;
 }
 
 async function clientStream(
   client: ConformanceClient,
-  req: ClientCompatRequest,
+  compatRequest: ClientCompatRequest,
 ) {
-  const reqHeaders = new Headers();
-  appendProtoHeaders(reqHeaders, req.requestHeaders);
-  let error: ConnectError | undefined = undefined;
-  let resHeaders: ConformanceHeader[] = [];
-  let resTrailers: ConformanceHeader[] = [];
-  const payloads: ConformancePayload[] = [];
-  const cancelTiming = getCancelTiming(req);
+  const cancelTiming = getCancelTiming(compatRequest);
   const controller = new AbortController();
+  const result = new ClientResponseResult();
   try {
-    const csRes = await client.clientStream(
+    const response = await client.clientStream(
       (async function* () {
-        for (const msg of req.requestMessages) {
-          const csReq = new ClientStreamRequest();
-          if (!msg.unpackTo(csReq)) {
-            throw new Error(
-              "Could not unpack request message to client stream request",
-            );
-          }
-          await wait(req.requestDelayMs);
-          yield csReq;
+        for (const msg of getRequestMessages(
+          compatRequest,
+          ClientStreamRequest,
+        )) {
+          await wait(compatRequest.requestDelayMs);
+          yield msg;
         }
         if (cancelTiming.beforeCloseSend !== undefined) {
           controller.abort();
@@ -229,79 +181,64 @@ async function clientStream(
       })(),
       {
         signal: controller.signal,
-        headers: reqHeaders,
+        headers: getRequestHeaders(compatRequest),
         onHeader(headers) {
-          resHeaders = convertToProtoHeaders(headers);
+          result.responseHeaders = convertToProtoHeaders(headers);
         },
         onTrailer(trailers) {
-          resTrailers = convertToProtoHeaders(trailers);
+          result.responseTrailers = convertToProtoHeaders(trailers);
         },
       },
     );
-    payloads.push(csRes.payload!);
+    result.payloads.push(response.payload!);
   } catch (e) {
-    error = ConnectError.from(e);
+    const err = ConnectError.from(e);
+    result.error = convertToProtoError(err);
     // We can't distinguish between headers and trailers here, so we just
     // add the metadata to both.
     //
     // But if the headers are already set, we don't need to overwrite them.
-    resHeaders =
-      resHeaders.length === 0
-        ? convertToProtoHeaders(error.metadata)
-        : resHeaders;
-    resTrailers = convertToProtoHeaders(error.metadata);
+    if (result.responseHeaders.length === 0) {
+      result.responseHeaders = convertToProtoHeaders(err.metadata);
+    }
+    result.responseTrailers = convertToProtoHeaders(err.metadata);
   }
-  return new ClientResponseResult({
-    responseHeaders: resHeaders,
-    responseTrailers: resTrailers,
-    payloads: payloads,
-    error: convertToProtoError(error),
-  });
+  return result;
 }
 
-async function bidiStream(client: ConformanceClient, req: ClientCompatRequest) {
-  const reqHeaders = new Headers();
-  appendProtoHeaders(reqHeaders, req.requestHeaders);
-  let error: ConnectError | undefined = undefined;
-  let resHeaders: ConformanceHeader[] = [];
-  let resTrailers: ConformanceHeader[] = [];
-  const payloads: ConformancePayload[] = [];
-  const cancelTiming = getCancelTiming(req);
+async function bidiStream(
+  client: ConformanceClient,
+  compatRequest: ClientCompatRequest,
+) {
+  const cancelTiming = getCancelTiming(compatRequest);
   const controller = new AbortController();
-  let recvCount = 0;
+  const result = new ClientResponseResult();
   try {
-    const reqIt = createWritableIterable<BidiStreamRequest>();
-    const sRes = client.bidiStream(reqIt, {
+    const request = createWritableIterable<BidiStreamRequest>();
+    const responses = client.bidiStream(request, {
       signal: controller.signal,
-      headers: reqHeaders,
+      headers: getRequestHeaders(compatRequest),
       onHeader(headers) {
-        resHeaders = convertToProtoHeaders(headers);
+        result.responseHeaders = convertToProtoHeaders(headers);
       },
       onTrailer(trailers) {
-        resTrailers = convertToProtoHeaders(trailers);
+        result.responseTrailers = convertToProtoHeaders(trailers);
       },
     });
-    const resIt = sRes[Symbol.asyncIterator]();
-    for (const msg of req.requestMessages) {
-      const bdReq = new BidiStreamRequest();
-      if (!msg.unpackTo(bdReq)) {
-        throw new Error(
-          "Could not unpack request message to client stream request",
-        );
-      }
-      await wait(req.requestDelayMs);
-      await reqIt.write(bdReq);
-      if (req.streamType === StreamType.FULL_DUPLEX_BIDI_STREAM) {
+    const responseIterator = responses[Symbol.asyncIterator]();
+    for (const msg of getRequestMessages(compatRequest, BidiStreamRequest)) {
+      await wait(compatRequest.requestDelayMs);
+      await request.write(msg);
+      if (compatRequest.streamType === StreamType.FULL_DUPLEX_BIDI_STREAM) {
         if (cancelTiming.afterNumResponses === 0) {
           controller.abort();
         }
-        const next = await resIt.next();
+        const next = await responseIterator.next();
         if (next.done === true) {
           continue;
         }
-        payloads.push(next.value.payload!);
-        recvCount++;
-        if (cancelTiming.afterNumResponses === recvCount) {
+        result.payloads.push(next.value.payload!);
+        if (result.payloads.length === cancelTiming.afterNumResponses) {
           controller.abort();
         }
       }
@@ -309,7 +246,7 @@ async function bidiStream(client: ConformanceClient, req: ClientCompatRequest) {
     if (cancelTiming.beforeCloseSend !== undefined) {
       controller.abort();
     }
-    reqIt.close();
+    request.close();
     if (cancelTiming.afterCloseSendMs >= 0) {
       setTimeout(() => {
         controller.abort();
@@ -320,75 +257,57 @@ async function bidiStream(client: ConformanceClient, req: ClientCompatRequest) {
     }
     // Drain the response iterator
     for (;;) {
-      const next = await resIt.next();
+      const next = await responseIterator.next();
       if (next.done === true) {
         break;
       }
-      payloads.push(next.value.payload!);
-      recvCount++;
-      if (cancelTiming.afterNumResponses === recvCount) {
+      result.payloads.push(next.value.payload!);
+      if (result.payloads.length === cancelTiming.afterNumResponses) {
         controller.abort();
       }
     }
   } catch (e) {
-    error = ConnectError.from(e);
+    const err = ConnectError.from(e);
+    result.error = convertToProtoError(err);
     // We can't distinguish between headers and trailers here, so we just
     // add the metadata to both.
     //
     // But if the headers are already set, we don't need to overwrite them.
-    resHeaders =
-      resHeaders.length === 0
-        ? convertToProtoHeaders(error.metadata)
-        : resHeaders;
-    resTrailers = convertToProtoHeaders(error.metadata);
+    if (result.responseHeaders.length === 0) {
+      result.responseHeaders = convertToProtoHeaders(err.metadata);
+    }
+    result.responseTrailers = convertToProtoHeaders(err.metadata);
   }
-  return new ClientResponseResult({
-    responseHeaders: resHeaders,
-    responseTrailers: resTrailers,
-    payloads: payloads,
-    error: convertToProtoError(error),
-  });
+  return result;
 }
 
 async function unimplemented(
   client: ConformanceClient,
-  req: ClientCompatRequest,
+  compatRequest: ClientCompatRequest,
 ) {
-  const msg = req.requestMessages[0];
-  const unReq = new UnimplementedRequest();
-  if (!msg.unpackTo(unReq)) {
-    throw new Error("Could not unpack request message to unary request");
-  }
-  const reqHeader = new Headers();
-  appendProtoHeaders(reqHeader, req.requestHeaders);
-  let error: ConnectError | undefined = undefined;
-  let resHeaders: ConformanceHeader[] = [];
-  let resTrailers: ConformanceHeader[] = [];
+  const request = getSingleRequestMessage(compatRequest, UnimplementedRequest);
+  const result = new ClientResponseResult();
   try {
-    await client.unimplemented(unReq, {
-      headers: reqHeader,
+    await client.unimplemented(request, {
+      headers: getRequestHeaders(compatRequest),
       onHeader(headers) {
-        resHeaders = convertToProtoHeaders(headers);
+        result.responseHeaders = convertToProtoHeaders(headers);
       },
       onTrailer(trailers) {
-        resTrailers = convertToProtoHeaders(trailers);
+        result.responseTrailers = convertToProtoHeaders(trailers);
       },
     });
   } catch (e) {
-    error = ConnectError.from(e);
+    const err = ConnectError.from(e);
+    result.error = convertToProtoError(err);
     // We can't distinguish between headers and trailers here, so we just
     // add the metadata to both.
     //
     // But if the headers are already set, we don't need to overwrite them.
-    resHeaders =
-      resHeaders.length === 0
-        ? convertToProtoHeaders(error.metadata)
-        : resHeaders;
-    resTrailers = convertToProtoHeaders(error.metadata);
+    if (result.responseHeaders.length === 0) {
+      result.responseHeaders = convertToProtoHeaders(err.metadata);
+    }
+    result.responseTrailers = convertToProtoHeaders(err.metadata);
   }
-  return new ClientResponseResult({
-    responseHeaders: resHeaders,
-    responseTrailers: resTrailers,
-    error: convertToProtoError(error),
-  });
+  return result;
 }

--- a/packages/connect-conformance/src/protocol.ts
+++ b/packages/connect-conformance/src/protocol.ts
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import { ConnectError, Code } from "@connectrpc/connect";
-import { createRegistry, Any, Message } from "@bufbuild/protobuf";
+import {
+  createRegistry,
+  Any,
+  Message,
+  type MessageType,
+} from "@bufbuild/protobuf";
 import {
   Error as ConformanceError,
   Header as ConformanceHeader,
@@ -22,26 +27,80 @@ import {
 import { Code as ConformanceCode } from "./gen/connectrpc/conformance/v1/config_pb.js";
 import { ClientCompatRequest } from "./gen/connectrpc/conformance/v1/client_compat_pb.js";
 
-const detailsRegitry = createRegistry(ConformancePayload_RequestInfo);
+const detailsRegistry = createRegistry(ConformancePayload_RequestInfo);
 
-export function getCancelTiming(req: ClientCompatRequest) {
+export function getCancelTiming(compatRequest: ClientCompatRequest) {
   const def = {
     beforeCloseSend: undefined,
     afterCloseSendMs: -1,
     afterNumResponses: -1,
   };
-  switch (req.cancel?.cancelTiming.case) {
+  switch (compatRequest.cancel?.cancelTiming.case) {
     case "beforeCloseSend":
       return { ...def, beforeCloseSend: {} };
     case "afterCloseSendMs":
       return {
         ...def,
-        afterCloseSendMs: req.cancel.cancelTiming.value,
+        afterCloseSendMs: compatRequest.cancel.cancelTiming.value,
       };
     case "afterNumResponses":
-      return { ...def, afterNumResponses: req.cancel.cancelTiming.value };
+      return {
+        ...def,
+        afterNumResponses: compatRequest.cancel.cancelTiming.value,
+      };
     case undefined:
       return def;
+  }
+}
+
+/**
+ * Get the headers for a conformance client request.
+ */
+export function getRequestHeaders(
+  compatRequest: ClientCompatRequest,
+): HeadersInit {
+  const headers = new Headers();
+  appendProtoHeaders(headers, compatRequest.requestHeaders);
+  return headers;
+}
+
+/**
+ * Get a single request message for a conformance client call.
+ */
+export function getSingleRequestMessage<T extends Message<T>>(
+  compatRequest: ClientCompatRequest,
+  type: MessageType<T>,
+): T {
+  if (compatRequest.requestMessages.length !== 1) {
+    throw new Error(
+      `Expected exactly one request_message in ClientCompatRequest, found ${compatRequest.requestMessages.length}`,
+    );
+  }
+  const any = compatRequest.requestMessages[0];
+  const target = new type();
+  if (!any.unpackTo(target)) {
+    throw new Error(
+      `Could not unpack request_message from ClientCompatRequest into ${type.typeName}`,
+    );
+  }
+  return target;
+}
+
+/**
+ * Get a request messages for a conformance client call.
+ */
+export function* getRequestMessages<T extends Message<T>>(
+  compatRequest: ClientCompatRequest,
+  type: MessageType<T>,
+): Iterable<T> {
+  for (const any of compatRequest.requestMessages) {
+    const target = new type();
+    if (!any.unpackTo(target)) {
+      throw new Error(
+        `Could not unpack request_message from ClientCompatRequest into ${type.typeName}`,
+      );
+    }
+    yield target;
   }
 }
 
@@ -54,7 +113,7 @@ export function connectErrorFromProto(err: ConformanceError) {
     err.code as unknown as Code,
     undefined,
     err.details.map((d) => {
-      const m = d.unpack(detailsRegitry);
+      const m = d.unpack(detailsRegistry);
       if (m === undefined) {
         throw new Error(`Cannot unpack ${d.typeUrl}`);
       }


### PR DESCRIPTION
- Use a ClientResponseResult message to track results instead of intermediate variables.
- Move code to unpack request messages from a ClientCompatRequest to a shared function.
- Move code to get request headers for a call to a shared function.
- Move code to record a failed call to a shared function.
- Rename variables, always use `compatRequest` for a ClientCompatRequest, and use `request` and `response` for the client under test.
