### PR TITLE
Allow cloudflare environment variables in CI

### DIFF
--- a/packages/connect-cloudflare/turbo.json
+++ b/packages/connect-cloudflare/turbo.json
@@ -2,7 +2,15 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "conformance:client": { "cache": false, "dependsOn": ["^build"] },
-    "conformance:server": { "cache": false, "dependsOn": ["^build"] }
+    "conformance:client": {
+      "cache": false,
+      "dependsOn": ["^build"],
+      "env": ["CLOUDFLARE_*"]
+    },
+    "conformance:server": {
+      "cache": false,
+      "dependsOn": ["^build"],
+      "env": ["CLOUDFLARE_*"]
+    }
   }
 }


### PR DESCRIPTION
turborepo filters environment variables by default. We started using it in https://github.com/connectrpc/connect-es/pull/1194. This change allows variables for the cloudflare tests to be passed.