### PR TITLE
V2: Remove protoc-gen-connect-es

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Connect for ECMAScript
 
-[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![Build](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-es/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-es)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es)
+[![License](https://img.shields.io/github/license/connectrpc/connect-es?color=blue)](./LICENSE) [![Build](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-es/actions/workflows/ci.yaml) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect/latest?color=green&label=%40connectrpc%2Fconnect)](https://www.npmjs.com/package/@connectrpc/connect)
 
 Connect is a family of libraries for building type-safe APIs with different languages and platforms.
 [@connectrpc/connect](https://www.npmjs.com/package/@connectrpc/connect) brings them to TypeScript,
@@ -77,8 +77,6 @@ be more than happy to chat!
 
 - [@connectrpc/connect](https://www.npmjs.com/package/@connectrpc/connect):
   RPC clients and servers for your schema ([source code](packages/connect)).
-- [@connectrpc/protoc-gen-connect-es](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es):
-  Code generator plugin for the services in your schema ([source code](packages/protoc-gen-connect-es)).
 - [@connectrpc/connect-web](https://www.npmjs.com/package/@connectrpc/connect-web):
   Adapters for web browsers, and any other platform that has the fetch API on board.
 - [@connectrpc/connect-node](https://www.npmjs.com/package/@connectrpc/connect-node):

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "name": "connect-es",
       "workspaces": [
         "packages/connect",
-        "packages/protoc-gen-connect-es",
         "packages/connect-web",
         "packages/connect-node",
         "packages/connect-fastify",
@@ -9971,9 +9970,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "packages/protoc-gen-connect-es": {
-      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "workspaces": [
     "packages/connect",
-    "packages/protoc-gen-connect-es",
     "packages/connect-web",
     "packages/connect-node",
     "packages/connect-fastify",

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -100,10 +100,7 @@ Of course, you can use `protoc` as well if desired:
 protoc -I . eliza.proto \
   --plugin=protoc-gen-es=../../node_modules/.bin/protoc-gen-es \
   --es_out src/gen \
-  --es_opt target=ts \
-  --plugin=protoc-gen-connect-es=../../node_modules/.bin/protoc-gen-connect-es \
-  --connect-es_out src/gen \
-  --connect-es_opt target=ts
+  --es_opt target=ts
 ```
 
 ## More examples

--- a/packages/protoc-gen-connect-es/turbo.json
+++ b/packages/protoc-gen-connect-es/turbo.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "tasks": {
-    "lint": {
-      "dependsOn": ["format", "^build", "generate", "build"]
-    }
-  }
-}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -47,8 +47,7 @@ function npmPublish() {
     " --workspace packages/connect-fastify" +
     " --workspace packages/connect-express" +
     " --workspace packages/connect-next" +
-    " --workspace packages/connect-migrate" +
-    " --workspace packages/protoc-gen-connect-es";
+    " --workspace packages/connect-migrate";
   execSync(command, {
     stdio: "inherit",
   });


### PR DESCRIPTION
`@connectrpc/protoc-gen-connect-es` is no longer needed - `@bufbuild/protoc-gen-es` v2 already generates service information.
