### PR TITLE
Fix type type error in `bigint` test

### DIFF
--- a/packages/connect-web/browserstack/bigint.spec.ts
+++ b/packages/connect-web/browserstack/bigint.spec.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import { create, fromBinary, protoInt64, toBinary } from "@bufbuild/protobuf";
 import { Int64ValueSchema } from "@bufbuild/protobuf/wkt";
 
 describe("bigint", () => {
@@ -23,8 +23,7 @@ describe("bigint", () => {
           Int64ValueSchema,
           toBinary(
             Int64ValueSchema,
-            //@ts-expect-error TODO: fix the typescript error.
-            create(Int64ValueSchema, { value: "3409819015" }),
+            create(Int64ValueSchema, { value: protoInt64.parse("3409819015") }),
           ),
         ).value,
       ),


### PR DESCRIPTION
Fix type type error in `bigint` test. In v1 we were constructing a dynamic message which didn't cause a type error, but for v2 hand writing a descriptor is not ideal, so we changed it to use well-known type. This cause a type-error, which was incorrectly ignored. This fixes that.