### PR TITLE
V2: Use `Stream{Request|Response}` types in interceptors for all streaming rpcs

### DIFF
--- a/packages/connect/src/interceptor.ts
+++ b/packages/connect/src/interceptor.ts
@@ -140,6 +140,9 @@ export interface StreamResponse<
   readonly message: AsyncIterable<MessageShape<O>>;
 }
 
+/**
+ * @private
+ */
 export interface RequestCommon<I extends DescMessage, O extends DescMessage> {
   /**
    * Metadata related to the service that is being called.
@@ -178,6 +181,9 @@ export interface RequestCommon<I extends DescMessage, O extends DescMessage> {
   readonly contextValues: ContextValues;
 }
 
+/**
+ * @private
+ */
 export interface ResponseCommon<I extends DescMessage, O extends DescMessage> {
   /**
    * Metadata related to the service that is being called.

--- a/packages/connect/src/interceptor.ts
+++ b/packages/connect/src/interceptor.ts
@@ -140,7 +140,7 @@ export interface StreamResponse<
   readonly message: AsyncIterable<MessageShape<O>>;
 }
 
-interface RequestCommon<I extends DescMessage, O extends DescMessage> {
+export interface RequestCommon<I extends DescMessage, O extends DescMessage> {
   /**
    * Metadata related to the service that is being called.
    */
@@ -178,7 +178,7 @@ interface RequestCommon<I extends DescMessage, O extends DescMessage> {
   readonly contextValues: ContextValues;
 }
 
-interface ResponseCommon<I extends DescMessage, O extends DescMessage> {
+export interface ResponseCommon<I extends DescMessage, O extends DescMessage> {
   /**
    * Metadata related to the service that is being called.
    */

--- a/packages/connect/src/protocol/invoke-implementation.spec.ts
+++ b/packages/connect/src/protocol/invoke-implementation.spec.ts
@@ -147,7 +147,7 @@ describe("transformInvokeImplementation()", () => {
           expect(context.values.get(kFoo)).toEqual("bar");
           req.header.set("Key", "bar");
           const res = await next(req);
-          expect(res.stream).toEqual(false);
+          expect(res.stream).toEqual(true);
           expect(res.service).toEqual(TestService);
           expect(res.header.get("Key")).toEqual("bar");
           expect(res.method).toEqual(TestService.method.clientStreaming);
@@ -190,7 +190,7 @@ describe("transformInvokeImplementation()", () => {
       context,
       [
         (next) => async (req) => {
-          expect(req.stream).toEqual(false);
+          expect(req.stream).toEqual(true);
           expect(req.init.method).toEqual("POST");
           expect(req.service).toEqual(TestService);
           expect(req.header.get("Key")).toEqual("Value");


### PR DESCRIPTION
 In v1 the server used more exact types in interceptors, for example `UnaryRequest` for server streaming rpcs. The client always used streaming variants. This is inconsistent and was unintended. 
 
This change unifies the behavior, now all streaming rpcs will use the `StreamRequest` and `StreamResponse` on the server as well. This is breaking change.