### PR TITLE
Deprecate `createPromiseClient` in favor of `createClient`

### DIFF
--- a/packages/connect-cloudflare/conformance/client.ts
+++ b/packages/connect-cloudflare/conformance/client.ts
@@ -24,7 +24,7 @@ import {
   createGrpcTransport,
   createGrpcWebTransport,
 } from "@connectrpc/connect-node";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import type { Transport } from "@connectrpc/connect";
 import { InvokeService } from "./invoke-service.js";
 import { parseArgs } from "node:util";
@@ -64,7 +64,7 @@ async function main() {
     default:
       throw new Error(`Unknown protocol: ${flags.protocol}`);
   }
-  const client = createPromiseClient(InvokeService, transport);
+  const client = createClient(InvokeService, transport);
   for await (const next of readSizeDelimitedBuffers(process.stdin)) {
     const req = ClientCompatRequest.fromBinary(next);
     req.host = process.env["CLOUDFLARE_WORKERS_REFERENCE_SERVER_HOST"]!;

--- a/packages/connect-conformance/src/promise-client.ts
+++ b/packages/connect-conformance/src/promise-client.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { PromiseClient, Transport } from "@connectrpc/connect";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import {
   ClientCompatRequest,
   ClientResponseResult,
@@ -48,7 +48,7 @@ export function invokeWithPromiseClient(
   transport: Transport,
   compatRequest: ClientCompatRequest,
 ) {
-  const client = createPromiseClient(ConformanceService, transport);
+  const client = createClient(ConformanceService, transport);
 
   switch (compatRequest.method) {
     case ConformanceService.methods.unary.name:

--- a/packages/connect-express/README.md
+++ b/packages/connect-express/README.md
@@ -53,7 +53,7 @@ curl \
 Node.js with the gRPC-web protocol (using a transport from [@connectrpc/connect-node](https://www.npmjs.com/package/@connectrpc/connect-node)):
 
 ```ts
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createGrpcWebTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -62,7 +62,7 @@ const transport = createGrpcWebTransport({
   httpVersion: "1.1",
 });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence); // you said: I feel happy.
 ```

--- a/packages/connect-express/src/express-readme.spec.ts
+++ b/packages/connect-express/src/express-readme.spec.ts
@@ -14,7 +14,7 @@
 
 import * as http from "http";
 import { Message, MethodKind, proto3 } from "@bufbuild/protobuf";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import type { ConnectRouter } from "@connectrpc/connect";
 import { createGrpcWebTransport } from "@connectrpc/connect-node";
 import express from "express";
@@ -83,7 +83,7 @@ describe("express readme", function () {
         baseUrl: `http://localhost:${port}`,
         httpVersion: "1.1",
       });
-      const client = createPromiseClient(ElizaService, transport);
+      const client = createClient(ElizaService, transport);
       const res = await client.say({ sentence: "I feel happy." });
       // console.log(res.sentence) // you said: I feel happy.
       expect(res.sentence).toBe("you said: I feel happy.");

--- a/packages/connect-fastify/README.md
+++ b/packages/connect-fastify/README.md
@@ -67,7 +67,7 @@ curl \
 Node.js with the gRPC protocol (using a transport from [@connectrpc/connect-node](https://www.npmjs.com/package/@connectrpc/connect-node)):
 
 ```ts
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -76,7 +76,7 @@ const transport = createGrpcTransport({
   httpVersion: "2",
 });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence); // you said: I feel happy.
 ```

--- a/packages/connect-next/README.md
+++ b/packages/connect-next/README.md
@@ -65,7 +65,7 @@ curl \
 Node.js with the gRPC-web protocol (using a transport from [@connectrpc/connect-node](https://www.npmjs.com/package/@connectrpc/connect-node)):
 
 ```ts
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createGrpcWebTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -74,7 +74,7 @@ const transport = createGrpcWebTransport({
   httpVersion: "1.1",
 });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence); // you said: I feel happy.
 ```

--- a/packages/connect-node/README.md
+++ b/packages/connect-node/README.md
@@ -11,7 +11,7 @@ TypeScript.
 Lets your clients running on Node.js talk to a server with the Connect protocol:
 
 ```diff
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 + import { createConnectTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -21,7 +21,7 @@ import { ElizaService } from "./gen/eliza_connect.js";
 +   httpVersion: "1.1"
 + });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence) // you said: I feel happy.
 ```
@@ -31,7 +31,7 @@ console.log(sentence) // you said: I feel happy.
 Lets your clients running on Node.js talk to a server with the gRPC protocol:
 
 ```diff
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 + import { createGrpcTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -41,7 +41,7 @@ import { ElizaService } from "./gen/eliza_connect.js";
 +   httpVersion: "2"
 + });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence) // you said: I feel happy.
 ```
@@ -51,7 +51,7 @@ console.log(sentence) // you said: I feel happy.
 Lets your clients running on Node.js talk to a server with the gRPC-web protocol:
 
 ```diff
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 + import { createGrpcWebTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -61,7 +61,7 @@ import { ElizaService } from "./gen/eliza_connect.js";
 +   httpVersion: "1.1"
 + });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence) // you said: I feel happy.
 ```
@@ -117,7 +117,7 @@ curl \
 Node.js with the gRPC protocol:
 
 ```ts
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -126,7 +126,7 @@ const transport = createGrpcTransport({
   httpVersion: "2",
 });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence); // you said: I feel happy.
 ```

--- a/packages/connect-node/src/connect-transport.spec.ts
+++ b/packages/connect-node/src/connect-transport.spec.ts
@@ -98,7 +98,7 @@ describe("using a session manager to explicitly close all connections", function
       baseUrl: "https://demo.connectrpc.com",
       sessionManager,
     });
-    // const client = createPromiseClient(..., transport);
+    // const client = createClient(..., transport);
 
     // make calls with the client
 

--- a/packages/connect-node/src/node-readme.spec.ts
+++ b/packages/connect-node/src/node-readme.spec.ts
@@ -18,7 +18,7 @@ import type { PartialMessage } from "@bufbuild/protobuf";
 import {
   createContextKey,
   createContextValues,
-  createPromiseClient,
+  createClient,
   createRouterTransport,
 } from "@connectrpc/connect";
 import type { ConnectRouter } from "@connectrpc/connect";
@@ -103,7 +103,7 @@ describe("node readme", function () {
       baseUrl: "https://demo.connectrpc.com",
       httpVersion: "1.1",
     });
-    const client = createPromiseClient(ElizaService, transport);
+    const client = createClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();
   });
@@ -111,7 +111,7 @@ describe("node readme", function () {
   it("createGrpcTransport()", async function () {
     // A transport for clients using the gRPC protocol with Node.js `http2` module
     const transport = createGrpcTransport(optionsHttp2);
-    const client = createPromiseClient(ElizaService, transport);
+    const client = createClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();
   });
@@ -119,7 +119,7 @@ describe("node readme", function () {
   it("createGrpcWebTransport()", async function () {
     // A transport for clients using the gRPC-web protocol with Node.js `http` module
     const transport = createGrpcWebTransport(optionsHttp1);
-    const client = createPromiseClient(ElizaService, transport);
+    const client = createClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();
   });
@@ -138,7 +138,7 @@ describe("node readme", function () {
         transport: optionsHttp1,
       },
     );
-    const client = createPromiseClient(ElizaService, transport);
+    const client = createClient(ElizaService, transport);
     const { sentence } = await client.say({ sentence: "I feel happy." });
     expect(sentence).toBeDefined();
   });
@@ -170,7 +170,7 @@ describe("node readme", function () {
         baseUrl: `http://localhost:${port}`,
         httpVersion: "2",
       });
-      const client = createPromiseClient(ElizaService, transport);
+      const client = createClient(ElizaService, transport);
       const res = await client.say({ sentence: "I feel happy." });
       // console.log(res.sentence) // you said: I feel happy.
       expect(res.sentence).toBe("you said: I feel happy.");
@@ -217,7 +217,7 @@ describe("node readme", function () {
         baseUrl: `http://localhost:${port}`,
         httpVersion: "2",
       });
-      const client = createPromiseClient(ElizaService, transport);
+      const client = createClient(ElizaService, transport);
       const res = await client.say(
         { sentence: "I feel happy." },
         { headers: { "x-user": "alice" } },
@@ -265,7 +265,7 @@ describe("node readme", function () {
         baseUrl: `http://localhost:${port}`,
         httpVersion: "2",
       });
-      const client = createPromiseClient(ElizaService, transport);
+      const client = createClient(ElizaService, transport);
       const req = createWritableIterable<PartialMessage<ConverseRequest>>();
       try {
         const res = client.converse(req);

--- a/packages/connect-node/src/transport.spec.ts
+++ b/packages/connect-node/src/transport.spec.ts
@@ -17,7 +17,7 @@ import { Int32Value, StringValue, MethodKind } from "@bufbuild/protobuf";
 import { useNodeServer } from "./use-node-server-helper.spec.js";
 import * as http2 from "node:http2";
 import { connectNodeAdapter } from "./connect-node-adapter.js";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import type { Transport } from "@connectrpc/connect";
 import { createTransport as createGrpcTransport } from "@connectrpc/connect/protocol-grpc";
 import { createTransport as createGrpcWebTransport } from "@connectrpc/connect/protocol-grpc-web";
@@ -65,7 +65,7 @@ describe("Calls should fail with code internal on RST_STREAM no_error before tra
     }),
   );
   async function testRstStream(transport: Transport) {
-    const client = createPromiseClient(TestService, transport);
+    const client = createClient(TestService, transport);
     const it = client.server({ value: 1 })[Symbol.asyncIterator]();
     const first = await it.next();
     expect(first.done).toBeFalse();

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   152,706 b |  66,483 b |   16,394 b |
-| Connect-ES     |    4 |   168,148 b |  72,422 b |   16,888 b |
-| Connect-ES     |    8 |   193,461 b |  82,145 b |   17,496 b |
-| Connect-ES     |   16 |   227,100 b |  96,411 b |   18,258 b |
+| Connect-ES     |    1 |   152,692 b |  66,483 b |   16,385 b |
+| Connect-ES     |    4 |   168,120 b |  72,422 b |   16,893 b |
+| Connect-ES     |    8 |   193,426 b |  82,145 b |   17,484 b |
+| Connect-ES     |   16 |   227,051 b |  96,411 b |   18,238 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.5716796875 140,242.17265625 280,240.45078125 420,238.2927734375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,243.59716796875 140,242.15849609375 280,240.484765625 420,238.3494140625">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="243.5716796875" r="4" fill="#ffa600"><title>Connect-ES 16.01 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="242.17265625" r="4" fill="#ffa600"><title>Connect-ES 16.49 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="240.45078125" r="4" fill="#ffa600"><title>Connect-ES 17.09 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="238.2927734375" r="4" fill="#ffa600"><title>Connect-ES 17.83 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="243.59716796875" r="4" fill="#ffa600"><title>Connect-ES 16 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="242.15849609375" r="4" fill="#ffa600"><title>Connect-ES 16.5 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="240.484765625" r="4" fill="#ffa600"><title>Connect-ES 17.07 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="238.3494140625" r="4" fill="#ffa600"><title>Connect-ES 17.81 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect-web-bench/src/gen/connectweb/entry-1.ts
+++ b/packages/connect-web-bench/src/gen/connectweb/entry-1.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { CommitService } from "./buf/registry/module/v1/commit_service_connect.js";
 
 /* eslint-disable no-console */
@@ -25,6 +25,6 @@ export async function call() {
   const transport = createConnectTransport({
     baseUrl: "https://buf.build/",
   });
-  const commitClient = createPromiseClient(CommitService, transport);
+  const commitClient = createClient(CommitService, transport);
   console.log(await commitClient.getCommits({}));
 }

--- a/packages/connect-web-bench/src/gen/connectweb/entry-16.ts
+++ b/packages/connect-web-bench/src/gen/connectweb/entry-16.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { CommitService } from "./buf/registry/module/v1/commit_service_connect.js";
 import { DownloadService } from "./buf/registry/module/v1/download_service_connect.js";
 import { GraphService } from "./buf/registry/module/v1/graph_service_connect.js";
@@ -30,26 +30,26 @@ export async function call() {
   const transport = createConnectTransport({
     baseUrl: "https://buf.build/",
   });
-  const commitClient = createPromiseClient(CommitService, transport);
+  const commitClient = createClient(CommitService, transport);
   console.log(await commitClient.getCommits({}));
   console.log(await commitClient.listCommits({}));
-  const downloadClient = createPromiseClient(DownloadService, transport);
+  const downloadClient = createClient(DownloadService, transport);
   console.log(await downloadClient.download({}));
-  const graphClient = createPromiseClient(GraphService, transport);
+  const graphClient = createClient(GraphService, transport);
   console.log(await graphClient.getGraph({}));
-  const labelClient = createPromiseClient(LabelService, transport);
+  const labelClient = createClient(LabelService, transport);
   console.log(await labelClient.getLabels({}));
   console.log(await labelClient.listLabels({}));
   console.log(await labelClient.listLabelHistory({}));
   console.log(await labelClient.createOrUpdateLabels({}));
   console.log(await labelClient.archiveLabels({}));
   console.log(await labelClient.unarchiveLabels({}));
-  const moduleClient = createPromiseClient(ModuleService, transport);
+  const moduleClient = createClient(ModuleService, transport);
   console.log(await moduleClient.getModules({}));
   console.log(await moduleClient.listModules({}));
   console.log(await moduleClient.createModules({}));
   console.log(await moduleClient.updateModules({}));
   console.log(await moduleClient.deleteModules({}));
-  const resourceClient = createPromiseClient(ResourceService, transport);
+  const resourceClient = createClient(ResourceService, transport);
   console.log(await resourceClient.getResources({}));
 }

--- a/packages/connect-web-bench/src/gen/connectweb/entry-4.ts
+++ b/packages/connect-web-bench/src/gen/connectweb/entry-4.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { CommitService } from "./buf/registry/module/v1/commit_service_connect.js";
 import { DownloadService } from "./buf/registry/module/v1/download_service_connect.js";
 import { GraphService } from "./buf/registry/module/v1/graph_service_connect.js";
@@ -27,11 +27,11 @@ export async function call() {
   const transport = createConnectTransport({
     baseUrl: "https://buf.build/",
   });
-  const commitClient = createPromiseClient(CommitService, transport);
+  const commitClient = createClient(CommitService, transport);
   console.log(await commitClient.getCommits({}));
   console.log(await commitClient.listCommits({}));
-  const downloadClient = createPromiseClient(DownloadService, transport);
+  const downloadClient = createClient(DownloadService, transport);
   console.log(await downloadClient.download({}));
-  const graphClient = createPromiseClient(GraphService, transport);
+  const graphClient = createClient(GraphService, transport);
   console.log(await graphClient.getGraph({}));
 }

--- a/packages/connect-web-bench/src/gen/connectweb/entry-8.ts
+++ b/packages/connect-web-bench/src/gen/connectweb/entry-8.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { CommitService } from "./buf/registry/module/v1/commit_service_connect.js";
 import { DownloadService } from "./buf/registry/module/v1/download_service_connect.js";
 import { GraphService } from "./buf/registry/module/v1/graph_service_connect.js";
@@ -28,14 +28,14 @@ export async function call() {
   const transport = createConnectTransport({
     baseUrl: "https://buf.build/",
   });
-  const commitClient = createPromiseClient(CommitService, transport);
+  const commitClient = createClient(CommitService, transport);
   console.log(await commitClient.getCommits({}));
   console.log(await commitClient.listCommits({}));
-  const downloadClient = createPromiseClient(DownloadService, transport);
+  const downloadClient = createClient(DownloadService, transport);
   console.log(await downloadClient.download({}));
-  const graphClient = createPromiseClient(GraphService, transport);
+  const graphClient = createClient(GraphService, transport);
   console.log(await graphClient.getGraph({}));
-  const labelClient = createPromiseClient(LabelService, transport);
+  const labelClient = createClient(LabelService, transport);
   console.log(await labelClient.getLabels({}));
   console.log(await labelClient.listLabels({}));
   console.log(await labelClient.listLabelHistory({}));

--- a/packages/connect-web-bench/src/protoc-gen-entrypoints.ts
+++ b/packages/connect-web-bench/src/protoc-gen-entrypoints.ts
@@ -51,7 +51,7 @@ runNodeJs(
 function generateConnectWeb(f: GeneratedFile, methods: DescMethod[]) {
   f.print("/* eslint-disable no-console */");
   f.print();
-  const createPromiseClient = f.import("createPromiseClient", "@connectrpc/connect");
+  const createClient = f.import("createClient", "@connectrpc/connect");
   const createConnectTransport = f.import("createConnectTransport", "@connectrpc/connect-web");
   let lastService: DescService | undefined = undefined;
   f.print(f.jsDoc(`Calls ${methods.length} RPCs with Connect-Web`));
@@ -67,7 +67,7 @@ function generateConnectWeb(f: GeneratedFile, methods: DescMethod[]) {
         service.name,
         "./connectweb/" + service.file.name + "_connect.js",
       );
-      f.print("  const ", clientName, " = ", createPromiseClient, "(", serviceSchema, ", transport);");
+      f.print("  const ", clientName, " = ", createClient, "(", serviceSchema, ", transport);");
       lastService = method.parent;
     }
     f.print("  console.log(await ", clientName, ".", codegenInfo.localName(method), "({}));");

--- a/packages/connect-web/README.md
+++ b/packages/connect-web/README.md
@@ -12,7 +12,7 @@ the fetch API on board:
 Lets your clients running in the web browser talk to a server with the Connect protocol:
 
 ```diff
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 + import { createConnectTransport } from "@connectrpc/connect-web";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -21,7 +21,7 @@ import { ElizaService } from "./gen/eliza_connect.js";
 +   baseUrl: "https://demo.connectrpc.com",
 + });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence) // you said: I feel happy.
 ```
@@ -31,7 +31,7 @@ console.log(sentence) // you said: I feel happy.
 Lets your clients running in the web browser talk to a server with the gRPC-web protocol:
 
 ```diff
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 + import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -40,7 +40,7 @@ import { ElizaService } from "./gen/eliza_connect.js";
 +   baseUrl: "https://demo.connectrpc.com",
 + });
 
-const client = createPromiseClient(ElizaService, transport);
+const client = createClient(ElizaService, transport);
 const { sentence } = await client.say({ sentence: "I feel happy." });
 console.log(sentence) // you said: I feel happy.
 ```

--- a/packages/connect-web/browserstack/eliza.spec.ts
+++ b/packages/connect-web/browserstack/eliza.spec.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "../src/connect-transport.js";
 import { ElizaService } from "./gen/connectrpc/eliza/v1/eliza_connect.js";
 import { IntroduceRequest } from "./gen/connectrpc/eliza/v1/eliza_pb.js";
@@ -26,7 +26,7 @@ describe("eliza", () => {
   it(
     "say()",
     async () => {
-      const client = createPromiseClient(ElizaService, transport);
+      const client = createClient(ElizaService, transport);
       const res = await client.say({ sentence: "I feel happy." });
       expect(typeof res.sentence).toBe("string");
     },
@@ -35,7 +35,7 @@ describe("eliza", () => {
   it(
     "introduce()",
     async () => {
-      const client = createPromiseClient(ElizaService, transport);
+      const client = createClient(ElizaService, transport);
       const request = new IntroduceRequest({
         name: "Browser",
       });

--- a/packages/connect-web/conformance/README.md
+++ b/packages/connect-web/conformance/README.md
@@ -15,7 +15,7 @@ Tests run in the following environments:
 
 For every environment, two client flavors are available:
 
-- Promise (using `createPromiseClient`)
+- Promise (using `createClient`)
 - Callback (using `createCallbackClient`)
 
 For every combination, a task is available:

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -21,8 +21,8 @@ export {
 } from "./http-headers.js";
 export { createCallbackClient } from "./callback-client.js";
 export type { CallbackClient } from "./callback-client.js";
-export { createPromiseClient } from "./promise-client.js";
-export type { PromiseClient } from "./promise-client.js";
+export { createClient, createPromiseClient } from "./promise-client.js";
+export type { Client as PromiseClient } from "./promise-client.js";
 export type { CallOptions } from "./call-options.js";
 export type { Transport } from "./transport.js";
 export type {

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -22,7 +22,7 @@ export {
 export { createCallbackClient } from "./callback-client.js";
 export type { CallbackClient } from "./callback-client.js";
 export { createClient, createPromiseClient } from "./promise-client.js";
-export type { Client as PromiseClient } from "./promise-client.js";
+export type { Client, PromiseClient } from "./promise-client.js";
 export type { CallOptions } from "./call-options.js";
 export type { Transport } from "./transport.js";
 export type {

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -46,6 +46,11 @@ export type Client<T extends ServiceType> = {
 };
 
 /**
+ * @deprecated use Client
+ */
+export type PromiseClient<T extends ServiceType> = Client<T>;
+
+/**
  * Create a Client for the given service, invoking RPCs through the
  * given transport.
  */

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -32,11 +32,11 @@ import type { StreamResponse } from "./interceptor.js";
 
 // prettier-ignore
 /**
- * PromiseClient is a simple client that supports unary and server-streaming
+ * Client is a simple client that supports unary and server-streaming
  * methods. Methods will produce a promise for the response message,
  * or an asynchronous iterable of response messages.
  */
-export type PromiseClient<T extends ServiceType> = {
+export type Client<T extends ServiceType> = {
   [P in keyof T["methods"]]:
     T["methods"][P] extends MethodInfoUnary<infer I, infer O>           ? (request: PartialMessage<I>, options?: CallOptions) => Promise<O>
   : T["methods"][P] extends MethodInfoServerStreaming<infer I, infer O> ? (request: PartialMessage<I>, options?: CallOptions) => AsyncIterable<O>
@@ -46,10 +46,10 @@ export type PromiseClient<T extends ServiceType> = {
 };
 
 /**
- * Create a PromiseClient for the given service, invoking RPCs through the
+ * Create a Client for the given service, invoking RPCs through the
  * given transport.
  */
-export function createPromiseClient<T extends ServiceType>(
+export function createClient<T extends ServiceType>(
   service: T,
   transport: Transport,
 ) {
@@ -66,7 +66,17 @@ export function createPromiseClient<T extends ServiceType>(
       default:
         return null;
     }
-  }) as PromiseClient<T>;
+  }) as Client<T>;
+}
+
+/**
+ * @deprecated use createClient.
+ */
+export function createPromiseClient<T extends ServiceType>(
+  service: T,
+  transport: Transport,
+) {
+  return createClient(service, transport);
 }
 
 /**

--- a/packages/connect/src/router-transport.spec.ts
+++ b/packages/connect/src/router-transport.spec.ts
@@ -19,7 +19,7 @@ import {
   proto3,
   StringValue,
 } from "@bufbuild/protobuf";
-import { createPromiseClient } from "./promise-client.js";
+import { createClient } from "./promise-client.js";
 import { createAsyncIterable } from "./protocol/async-iterable.js";
 import { createRouterTransport } from "./router-transport.js";
 import { ConnectError } from "./connect-error.js";
@@ -80,7 +80,7 @@ describe("createRoutesTransport", function () {
       },
     });
   });
-  const client = createPromiseClient(testService, transport);
+  const client = createClient(testService, transport);
   it("should work for unary", async function () {
     const res = await client.unary({ value: 13 });
     expect(res.value).toBe("13");
@@ -114,7 +114,7 @@ describe("createRoutesTransport", function () {
     const transport = createRouterTransport(() => {
       // intentionally not registering any transports
     });
-    const client = createPromiseClient(testService, transport);
+    const client = createClient(testService, transport);
     try {
       await client.unary({});
       fail("expected error");
@@ -173,7 +173,7 @@ describe("createRoutesTransport", function () {
         });
       });
       it("returns mocked answer", async () => {
-        const client = createPromiseClient(ElizaService, mockTransport);
+        const client = createClient(ElizaService, mockTransport);
         const { sentence } = await client.say({ sentence: "how do you feel?" });
         expect(sentence).toEqual("I feel happy.");
       });
@@ -189,7 +189,7 @@ describe("createRoutesTransport", function () {
         });
       });
       it("expects a request", async () => {
-        const client = createPromiseClient(ElizaService, mockTransport);
+        const client = createClient(ElizaService, mockTransport);
         const { sentence } = await client.say({ sentence: "how do you feel?" });
         expect(sentence).toEqual("I feel happy.");
       });
@@ -214,7 +214,7 @@ describe("createRoutesTransport", function () {
         });
       });
       it("tests a simple client call", async () => {
-        const client = createPromiseClient(ElizaService, mockTransport);
+        const client = createClient(ElizaService, mockTransport);
         await client.say({ sentence: "1" });
         await client.say({ sentence: "2" });
         await client.say({ sentence: "3" });

--- a/packages/example/src/client.ts
+++ b/packages/example/src/client.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-node";
 import { ElizaService } from "./gen/eliza_connect.js";
 import { stdin, stdout, env } from "node:process";
@@ -38,7 +38,7 @@ const transport = createConnectTransport({
 });
 
 void (async () => {
-  const client = createPromiseClient(ElizaService, transport);
+  const client = createClient(ElizaService, transport);
 
   const name = await rl.question("What is your name?\n> ");
 

--- a/packages/example/src/webclient.ts
+++ b/packages/example/src/webclient.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { ElizaService } from "./gen/eliza_connect.js";
 
@@ -21,7 +21,7 @@ import { ElizaService } from "./gen/eliza_connect.js";
 const transport = createConnectTransport({ baseUrl: "/" });
 
 void (async () => {
-  const client = createPromiseClient(ElizaService, transport);
+  const client = createClient(ElizaService, transport);
 
   print("What is your name?");
   const name = await prompt();


### PR DESCRIPTION
Deprecate `createPromiseClient` in favor of `createClient`. Promises are more widely adopted than ever before, this change will mark the promise variant as the default.

This is effectively just a rename, but to keep backward compatibility we keep the existing signature and mark it as deprecated. `createPromiseClient` will be removed in v2.

