### PR TITLE
V2: Remove `createPromiseClient` and `PromiseClient`

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   276,503 b | 176,399 b |   35,752 b |
-| Connect-ES     |    4 |   280,755 b | 179,501 b |   36,598 b |
-| Connect-ES     |    8 |   285,618 b | 183,932 b |   37,485 b |
-| Connect-ES     |   16 |   294,746 b | 191,556 b |   38,999 b |
+| Connect-ES     |    1 |   276,503 b | 176,399 b |   35,786 b |
+| Connect-ES     |    4 |   280,755 b | 179,501 b |   36,562 b |
+| Connect-ES     |    8 |   285,618 b | 183,932 b |   37,491 b |
+| Connect-ES     |   16 |   294,746 b | 191,556 b |   38,985 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.74921875 140,186.3533203125 280,183.84130859375 420,179.55361328125">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.65292968749998 140,186.4552734375 280,183.82431640624998 420,179.59326171875">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="188.74921875" r="4" fill="#ffa600"><title>Connect-ES 34.91 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="186.3533203125" r="4" fill="#ffa600"><title>Connect-ES 35.74 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="183.84130859375" r="4" fill="#ffa600"><title>Connect-ES 36.61 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="179.55361328125" r="4" fill="#ffa600"><title>Connect-ES 38.08 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="188.65292968749998" r="4" fill="#ffa600"><title>Connect-ES 34.95 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="186.4552734375" r="4" fill="#ffa600"><title>Connect-ES 35.71 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="183.82431640624998" r="4" fill="#ffa600"><title>Connect-ES 36.61 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="179.59326171875" r="4" fill="#ffa600"><title>Connect-ES 38.07 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -21,8 +21,8 @@ export {
 } from "./http-headers.js";
 export { createCallbackClient } from "./callback-client.js";
 export type { CallbackClient } from "./callback-client.js";
-export { createClient, createPromiseClient } from "./promise-client.js";
-export type { Client, PromiseClient } from "./promise-client.js";
+export { createClient } from "./promise-client.js";
+export type { Client } from "./promise-client.js";
 export type { CallOptions } from "./call-options.js";
 export type { Transport } from "./transport.js";
 export type {

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -48,11 +48,6 @@ export type Client<Desc extends DescService> = {
 };
 
 /**
- * @deprecated use Client
- */
-export type PromiseClient<T extends DescService> = Client<T>;
-
-/**
  * Create a Client for the given service, invoking RPCs through the
  * given transport.
  */
@@ -74,16 +69,6 @@ export function createClient<T extends DescService>(
         return null;
     }
   }) as Client<T>;
-}
-
-/**
- * @deprecated use createClient.
- */
-export function createPromiseClient<T extends DescService>(
-  service: T,
-  transport: Transport,
-) {
-  return createClient(service, transport);
 }
 
 /**


### PR DESCRIPTION
Remove the deprecated `createPromiseClient` and `PromiseClient`.