### PR TITLE
Bump browser versions tested on Browserstack

### DIFF
--- a/packages/connect-web/browserstack/wdio.browserstack.conf.js
+++ b/packages/connect-web/browserstack/wdio.browserstack.conf.js
@@ -42,14 +42,14 @@ export const config = {
       },
     },
     {
-      browserName: "Safari iOS 13, iPhone 11",
+      browserName: "Safari",
       "bstack:options": {
         osVersion: "13",
         deviceName: "iPhone 11",
       },
     },
     {
-      browserName: "Safari 14.1, Big Sur",
+      browserName: "Safari",
       "bstack:options": {
         os: "OS X",
         osVersion: "Big Sur",
@@ -57,7 +57,7 @@ export const config = {
       },
     },
     {
-      browserName: "Safari 13.1, Catalina",
+      browserName: "Safari",
       "bstack:options": {
         os: "OS X",
         osVersion: "Catalina",
@@ -65,7 +65,7 @@ export const config = {
       },
     },
     {
-      browserName: "Safari 12.1, Mojave",
+      browserName: "Safari",
       "bstack:options": {
         os: "OS X",
         osVersion: "Mojave",
@@ -73,7 +73,7 @@ export const config = {
       },
     },
     {
-      browserName: "Safari 11.1, High Sierra",
+      browserName: "Safari",
       "bstack:options": {
         os: "OS X",
         osVersion: "High Sierra",
@@ -81,7 +81,7 @@ export const config = {
       },
     },
     {
-      browserName: "Chrome 66.0, Win 10",
+      browserName: "Chrome",
       "bstack:options": {
         os: "Windows",
         osVersion: "10",
@@ -89,7 +89,7 @@ export const config = {
       },
     },
     {
-      browserName: "Firefox 67.0, Win 10",
+      browserName: "Firefox",
       "bstack:options": {
         os: "Windows",
         osVersion: "10",

--- a/packages/connect-web/browserstack/wdio.browserstack.conf.js
+++ b/packages/connect-web/browserstack/wdio.browserstack.conf.js
@@ -85,7 +85,7 @@ export const config = {
       "bstack:options": {
         os: "Windows",
         osVersion: "10",
-        browserVersion: "60.0",
+        browserVersion: "66.0",
       },
     },
     {

--- a/packages/connect-web/browserstack/wdio.browserstack.conf.js
+++ b/packages/connect-web/browserstack/wdio.browserstack.conf.js
@@ -42,14 +42,14 @@ export const config = {
       },
     },
     {
-      browserName: "Safari",
+      browserName: "Safari iOS 13, iPhone 11",
       "bstack:options": {
         osVersion: "13",
         deviceName: "iPhone 11",
       },
     },
     {
-      browserName: "Safari",
+      browserName: "Safari 14.1, Big Sur",
       "bstack:options": {
         os: "OS X",
         osVersion: "Big Sur",
@@ -57,7 +57,7 @@ export const config = {
       },
     },
     {
-      browserName: "Safari",
+      browserName: "Safari 13.1, Catalina",
       "bstack:options": {
         os: "OS X",
         osVersion: "Catalina",
@@ -65,7 +65,7 @@ export const config = {
       },
     },
     {
-      browserName: "Safari",
+      browserName: "Safari 12.1, Mojave",
       "bstack:options": {
         os: "OS X",
         osVersion: "Mojave",
@@ -73,7 +73,7 @@ export const config = {
       },
     },
     {
-      browserName: "Safari",
+      browserName: "Safari 11.1, High Sierra",
       "bstack:options": {
         os: "OS X",
         osVersion: "High Sierra",
@@ -81,7 +81,7 @@ export const config = {
       },
     },
     {
-      browserName: "Chrome",
+      browserName: "Chrome 66.0, Win 10",
       "bstack:options": {
         os: "Windows",
         osVersion: "10",
@@ -89,7 +89,7 @@ export const config = {
       },
     },
     {
-      browserName: "Firefox",
+      browserName: "Firefox 67.0, Win 10",
       "bstack:options": {
         os: "Windows",
         osVersion: "10",


### PR DESCRIPTION
This bumps the version of Chrome tested on Browserstack from 60 to 66 (released 2018-04-17). This is the first version to support AbortSignal with `fetch` according the the [compatibility data on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility).