### PR TITLE
V2: Run `createPromiseClient` -> `createClient` codemod on all v1 versions

### DIFF
--- a/packages/connect-migrate/src/migrations/v1.16.0.spec.ts
+++ b/packages/connect-migrate/src/migrations/v1.16.0.spec.ts
@@ -81,8 +81,6 @@ describe("migration", function () {
       ];
       expect(v1_16_0.applicable(opt.scanned)).toBeTrue();
     });
-  });
-  describe("should not be applicable", function () {
     it("before 1.16.0", () => {
       opt.scanned.packageFiles = [
         {
@@ -94,8 +92,10 @@ describe("migration", function () {
           },
         },
       ];
-      expect(v1_16_0.applicable(opt.scanned)).toBeFalse();
+      expect(v1_16_0.applicable(opt.scanned)).toBeTrue();
     });
+  });
+  describe("should not be applicable", function () {
     it("from 2.0.0", () => {
       opt.scanned.packageFiles = [
         {

--- a/packages/connect-migrate/src/migrations/v1.16.0.ts
+++ b/packages/connect-migrate/src/migrations/v1.16.0.ts
@@ -79,7 +79,8 @@ function getMatchingPackages(packageFiles: Scanned["packageFiles"]) {
           if (minVersion === null) {
             return false;
           }
-          return semver.satisfies(minVersion, "^1.16.0");
+          // v2 migration will run next so we update all v1 versions.
+          return semver.satisfies(minVersion, "^1.0.0");
         })
     ) {
       matched.push(packageFile);


### PR DESCRIPTION
V2: Run `createPromiseClient` -> `createClient` codemod on all v1 versions. This is safe because we know v2 codemod will run right after this.