### PR TITLE
Release 2.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14213,7 +14213,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.39.0",
@@ -14229,22 +14229,22 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect": "2.0.0-alpha.1",
-        "@connectrpc/connect-node": "2.0.0-alpha.1"
+        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect-node": "2.0.0-beta.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240821.1",
-        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
         "tsx": "^4.19.0",
         "wrangler": "^3.73.0"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "dependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect": "2.0.0-alpha.1",
+        "@connectrpc/connect": "2.0.0-beta.1",
         "fflate": "^0.8.1",
         "tar-stream": "^3.1.7"
       },
@@ -14261,12 +14261,12 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-alpha.1",
-        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
-        "@connectrpc/connect-node": "2.0.0-alpha.1",
+        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+        "@connectrpc/connect-node": "2.0.0-beta.1",
         "@types/express": "^4.17.18",
         "express": "^4.19.2",
         "tsx": "^4.19.0"
@@ -14276,32 +14276,32 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect": "2.0.0-alpha.1",
-        "@connectrpc/connect-node": "2.0.0-alpha.1"
+        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect-node": "2.0.0-beta.1"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-alpha.1",
-        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
-        "@connectrpc/connect-node": "2.0.0-alpha.1"
+        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+        "@connectrpc/connect-node": "2.0.0-beta.1"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect": "2.0.0-alpha.1",
-        "@connectrpc/connect-node": "2.0.0-alpha.1",
+        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect-node": "2.0.0-beta.1",
         "fastify": "^4.22.1"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.2",
@@ -14322,28 +14322,28 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-alpha.1",
-        "@connectrpc/connect-node": "2.0.0-alpha.1"
+        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect-node": "2.0.0-beta.1"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect": "2.0.0-alpha.1",
-        "@connectrpc/connect-node": "2.0.0-alpha.1",
+        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect-node": "2.0.0-beta.1",
         "next": "^13.2.4 || ^14.2.5"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
         "@types/jasmine": "^5.0.0",
         "jasmine": "^5.2.0"
       },
@@ -14352,17 +14352,17 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect": "2.0.0-alpha.1"
+        "@connectrpc/connect": "2.0.0-beta.1"
       }
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.39.0",
         "@bufbuild/protoc-gen-es": "^2.1.0",
-        "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
         "@wdio/browserstack-service": "^9.0.9",
         "@wdio/cli": "^9.0.9",
         "@wdio/jasmine-framework": "^9.0.9",
@@ -14372,7 +14372,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect": "2.0.0-alpha.1"
+        "@connectrpc/connect": "2.0.0-beta.1"
       }
     },
     "packages/connect-web-bench": {
@@ -14381,7 +14381,7 @@
         "@bufbuild/buf": "^1.39.0",
         "@bufbuild/protobuf": "^2.1.0",
         "@bufbuild/protoc-gen-es": "^2.1.0",
-        "@connectrpc/connect-web": "2.0.0-alpha.1",
+        "@connectrpc/connect-web": "2.0.0-beta.1",
         "@types/brotli": "^1.3.4",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
@@ -14393,8 +14393,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.1.0",
-        "@connectrpc/connect-node": "^2.0.0-alpha.1",
-        "@connectrpc/connect-web": "^2.0.0-alpha.1",
+        "@connectrpc/connect-node": "^2.0.0-beta.1",
+        "@connectrpc/connect-web": "^2.0.0-beta.1",
         "tsx": "^4.16.5"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.1.0",
-    "@connectrpc/connect": "2.0.0-alpha.1",
-    "@connectrpc/connect-node": "2.0.0-alpha.1"
+    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect-node": "2.0.0-beta.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240821.1",
     "wrangler": "^3.73.0",
     "tsx": "^4.19.0",
-    "@connectrpc/connect-conformance": "^2.0.0-alpha.1"
+    "@connectrpc/connect-conformance": "^2.0.0-beta.1"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/src/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.1.0",
-    "@connectrpc/connect": "2.0.0-alpha.1",
+    "@connectrpc/connect": "2.0.0-beta.1",
     "fflate": "^0.8.1",
     "tar-stream": "^3.1.7"
   },

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,16 +32,16 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
-    "@connectrpc/connect": "2.0.0-alpha.1",
-    "@connectrpc/connect-node": "2.0.0-alpha.1",
+    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect-node": "2.0.0-beta.1",
     "@types/express": "^4.17.18",
     "express": "^4.19.2",
     "tsx": "^4.19.0"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.1.0",
-    "@connectrpc/connect": "2.0.0-alpha.1",
-    "@connectrpc/connect-node": "2.0.0-alpha.1"
+    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect-node": "2.0.0-beta.1"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,14 +31,14 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
-    "@connectrpc/connect": "2.0.0-alpha.1",
-    "@connectrpc/connect-node": "2.0.0-alpha.1"
+    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect-node": "2.0.0-beta.1"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.1.0",
     "fastify": "^4.22.1",
-    "@connectrpc/connect": "2.0.0-alpha.1",
-    "@connectrpc/connect-node": "2.0.0-alpha.1"
+    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect-node": "2.0.0-beta.1"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-migrate/src/migrations/v2.0.0.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.ts
@@ -35,7 +35,7 @@ import {
 import { writeBufGenYamlFile } from "../lib/bufgenyaml";
 
 export const targetVersionProtobufEs = "2.1.0";
-export const targetVersionConnectEs = "2.0.0-alpha.1"; // TODO
+export const targetVersionConnectEs = "2.0.0-beta.1"; // TODO
 export const targetVersionConnectQuery = "2.0.0"; // TODO
 export const targetVersionConnectPlaywright = "0.4.0"; // TODO
 

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.1.0",
     "next": "^13.2.4 || ^14.2.5",
-    "@connectrpc/connect": "2.0.0-alpha.1",
-    "@connectrpc/connect-node": "2.0.0-alpha.1"
+    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect-node": "2.0.0-beta.1"
   },
   "devDependencies": {
-    "@connectrpc/connect": "2.0.0-alpha.1",
-    "@connectrpc/connect-node": "2.0.0-alpha.1"
+    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect-node": "2.0.0-beta.1"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,10 +34,10 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.1.0",
-    "@connectrpc/connect": "2.0.0-alpha.1"
+    "@connectrpc/connect": "2.0.0-beta.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
+    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
     "@types/jasmine": "^5.0.0",
     "jasmine": "^5.2.0"
   }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   276,158 b | 176,214 b |   35,709 b |
-| Connect-ES     |    4 |   280,410 b | 179,316 b |   36,533 b |
-| Connect-ES     |    8 |   285,273 b | 183,747 b |   37,477 b |
-| Connect-ES     |   16 |   294,401 b | 191,371 b |   38,966 b |
+| Connect-ES     |    1 |   276,157 b | 176,213 b |   35,724 b |
+| Connect-ES     |    4 |   280,409 b | 179,315 b |   36,525 b |
+| Connect-ES     |    8 |   285,272 b | 183,746 b |   37,426 b |
+| Connect-ES     |   16 |   294,400 b | 191,370 b |   38,944 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.87099609375002 140,186.53740234375 280,183.86396484375 420,179.64707031249998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.828515625 140,186.56005859375 280,184.0083984375 420,179.709375">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="188.87099609375002" r="4" fill="#ffa600"><title>Connect-ES 34.87 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="186.53740234375" r="4" fill="#ffa600"><title>Connect-ES 35.68 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="183.86396484375" r="4" fill="#ffa600"><title>Connect-ES 36.6 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="179.64707031249998" r="4" fill="#ffa600"><title>Connect-ES 38.05 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="188.828515625" r="4" fill="#ffa600"><title>Connect-ES 34.89 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="186.56005859375" r="4" fill="#ffa600"><title>Connect-ES 35.67 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="184.0083984375" r="4" fill="#ffa600"><title>Connect-ES 36.55 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="179.709375" r="4" fill="#ffa600"><title>Connect-ES 38.03 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -13,7 +13,7 @@
     "@bufbuild/buf": "^1.39.0",
     "@bufbuild/protobuf": "^2.1.0",
     "@bufbuild/protoc-gen-es": "^2.1.0",
-    "@connectrpc/connect-web": "2.0.0-alpha.1",
+    "@connectrpc/connect-web": "2.0.0-beta.1",
     "@types/brotli": "^1.3.4",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.39.0",
     "@bufbuild/protoc-gen-es": "^2.1.0",
-    "@connectrpc/connect-conformance": "^2.0.0-alpha.1",
+    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
     "@wdio/browserstack-service": "^9.0.9",
     "@wdio/cli": "^9.0.9",
     "@wdio/jasmine-framework": "^9.0.9",
@@ -52,6 +52,6 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.1.0",
-    "@connectrpc/connect": "2.0.0-alpha.1"
+    "@connectrpc/connect": "2.0.0-beta.1"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.1.0",
-    "@connectrpc/connect-node": "^2.0.0-alpha.1",
-    "@connectrpc/connect-web": "^2.0.0-alpha.1",
+    "@connectrpc/connect-node": "^2.0.0-beta.1",
+    "@connectrpc/connect-web": "^2.0.0-beta.1",
     "tsx": "^4.16.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's changed

This is a beta release for version 2. See [here](https://github.com/connectrpc/connect-es/releases/tag/v2.0.0-alpha.1) for an introduction. 

To give this version a try, run `npx @connectrpc/connect-migrate@beta`. Note that [connect-query](https://github.com/connectrpc/connect-query-es) has not been updated yet.

* Correct type inference for ConnectError#findDetails by @bhollis in https://github.com/connectrpc/connect-es/pull/1188
* Remove Node10 subpath fallbacks by @timostamm in https://github.com/connectrpc/connect-es/pull/1227
* Remove support for Node.js v16 by @timostamm in https://github.com/connectrpc/connect-es/pull/1225
* Use `Stream{Request|Response}` types in interceptors for all streaming rpcs by @srikrsna-buf in https://github.com/connectrpc/connect-es/pull/1230
* Bump minimum supported TypeScript version to 4.9.5 by @timostamm in https://github.com/connectrpc/connect-es/pull/1231
* Don't trigger handler signal on success by @srikrsna-buf in https://github.com/connectrpc/connect-es/pull/1234
* Add migration to v2 by @timostamm in https://github.com/connectrpc/connect-es/pull/1142
* Add a transform for `createPromiseClient` -> `createClient` by @srikrsna-buf in https://github.com/connectrpc/connect-es/pull/1236
* Remove `createPromiseClient` and `PromiseClient` by @srikrsna-buf in https://github.com/connectrpc/connect-es/pull/1240
* Bump browser versions tested on Browserstack by @timostamm in https://github.com/connectrpc/connect-es/pull/1241
* Remove "credentials" option from transports by @timostamm in https://github.com/connectrpc/connect-es/pull/1242

## New Contributors
* @bhollis made their first contribution in https://github.com/connectrpc/connect-es/pull/1188

**Full Changelog**: https://github.com/connectrpc/connect-es/compare/v2.0.0-alpha.1...v2.0.0-beta.1