### PR TITLE
add details about underlying message types on input message protocol errors

### DIFF
--- a/packages/connect/src/protocol/invoke-implementation.ts
+++ b/packages/connect/src/protocol/invoke-implementation.ts
@@ -151,6 +151,14 @@ export function transformInvokeImplementation<
           throw new ConnectError(
             "protocol error: received extra input message for unary method",
             Code.Unimplemented,
+            {
+              methodName: spec.method.name,
+              serviceTypeName: spec.service.typeName,
+              inputTypeName: spec.method.I.typeName,
+              outputTypeName: spec.method.O.typeName,
+              url: context.url,
+              requestMethod: context.requestMethod,
+            }
           );
         }
       };
@@ -162,6 +170,14 @@ export function transformInvokeImplementation<
           throw new ConnectError(
             "protocol error: missing input message for server-streaming method",
             Code.Unimplemented,
+            {
+              methodName: spec.method.name,
+              serviceTypeName: spec.service.typeName,
+              inputTypeName: spec.method.I.typeName,
+              outputTypeName: spec.method.O.typeName,
+              url: context.url,
+              requestMethod: context.requestMethod,
+            }
           );
         }
         const anyFn = async (
@@ -209,6 +225,14 @@ export function transformInvokeImplementation<
           throw new ConnectError(
             "protocol error: received extra input message for server-streaming method",
             Code.Unimplemented,
+            {
+              methodName: spec.method.name,
+              serviceTypeName: spec.service.typeName,
+              inputTypeName: spec.method.I.typeName,
+              outputTypeName: spec.method.O.typeName,
+              url: context.url,
+              requestMethod: context.requestMethod,
+            }
           );
         }
       };

--- a/packages/connect/src/protocol/invoke-implementation.ts
+++ b/packages/connect/src/protocol/invoke-implementation.ts
@@ -149,7 +149,7 @@ export function transformInvokeImplementation<
         const input2 = await inputIt.next();
         if (input2.done !== true) {
           throw new ConnectError(
-            "protocol error: received extra input message for unary method",
+            `protocol error: received extra input message ${spec.method.I.typeName} for unary method ${spec.method.name}`,
             Code.Unimplemented,
             {
               methodName: spec.method.name,
@@ -168,7 +168,7 @@ export function transformInvokeImplementation<
         const input1 = await inputIt.next();
         if (input1.done === true) {
           throw new ConnectError(
-            "protocol error: missing input message for server-streaming method",
+            `protocol error: missing input message ${spec.method.I.typeName} for server-streaming method ${spec.method.name}`,
             Code.Unimplemented,
             {
               methodName: spec.method.name,
@@ -223,7 +223,7 @@ export function transformInvokeImplementation<
         const input2 = await inputIt.next();
         if (input2.done !== true) {
           throw new ConnectError(
-            "protocol error: received extra input message for server-streaming method",
+            `protocol error: received extra input message ${spec.method.I.typeName} for server-streaming method ${spec.method.name}`,
             Code.Unimplemented,
             {
               methodName: spec.method.name,


### PR DESCRIPTION
in general the protocol errors are all missing a lot of context
