### PR TITLE
V2: Remove obsolete todo

### DIFF
--- a/packages/connect/src/router.ts
+++ b/packages/connect/src/router.ts
@@ -164,13 +164,13 @@ function whichProtocols(
   }
   const opt: ConnectRouterOptions = base
     ? {
-      ...validateUniversalHandlerOptions(base.options),
-      ...options,
-    }
+        ...validateUniversalHandlerOptions(base.options),
+        ...options,
+      }
     : {
-      ...options,
-      ...validateUniversalHandlerOptions(options ?? {}),
-    };
+        ...options,
+        ...validateUniversalHandlerOptions(options ?? {}),
+      };
 
   const protocols: ProtocolHandlerFactory[] = [];
   if (options?.grpc !== false) {

--- a/packages/connect/src/router.ts
+++ b/packages/connect/src/router.ts
@@ -72,7 +72,6 @@ export interface ConnectRouter {
     impl: MethodImpl<M>,
     options?: Partial<UniversalHandlerOptions>,
   ): this;
-  // TODO: Re-add the method type API.
 }
 
 /**
@@ -165,13 +164,13 @@ function whichProtocols(
   }
   const opt: ConnectRouterOptions = base
     ? {
-        ...validateUniversalHandlerOptions(base.options),
-        ...options,
-      }
+      ...validateUniversalHandlerOptions(base.options),
+      ...options,
+    }
     : {
-        ...options,
-        ...validateUniversalHandlerOptions(options ?? {}),
-      };
+      ...options,
+      ...validateUniversalHandlerOptions(options ?? {}),
+    };
 
   const protocols: ProtocolHandlerFactory[] = [];
   if (options?.grpc !== false) {


### PR DESCRIPTION
Remove obsolete todo. With v2 we have access to full method descriptors.  The `TODO` was added when v2 of protobuf was not yet finalized.