### PR TITLE
V2: Replace MethodInfo with Descriptor Types

### DIFF
--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -30,7 +30,8 @@ import type {
   UnaryRequest,
   UnaryResponse,
   ContextValues,
-  MethodInfo,
+  DescMethodUnary,
+  DescMethodStreaming,
 } from "@connectrpc/connect";
 import {
   Code,
@@ -140,7 +141,7 @@ export function createConnectTransport(
   const useBinaryFormat = options.useBinaryFormat ?? false;
   return {
     async unary<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodUnary<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
@@ -238,7 +239,7 @@ export function createConnectTransport(
     },
 
     async stream<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodStreaming<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -28,7 +28,8 @@ import type {
   UnaryRequest,
   UnaryResponse,
   ContextValues,
-  MethodInfo,
+  DescMethodUnary,
+  DescMethodStreaming,
 } from "@connectrpc/connect";
 import { createContextValues, ConnectError, Code } from "@connectrpc/connect";
 import {
@@ -130,7 +131,7 @@ export function createGrpcWebTransport(
   const useBinaryFormat = options.useBinaryFormat ?? true;
   return {
     async unary<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodUnary<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: Headers,
@@ -241,7 +242,7 @@ export function createGrpcWebTransport(
     },
 
     async stream<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodStreaming<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,

--- a/packages/connect/src/any-client.ts
+++ b/packages/connect/src/any-client.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescService } from "@bufbuild/protobuf";
-import type { MethodInfo } from "./types.js";
+import type { DescMethod, DescService } from "@bufbuild/protobuf";
 
 /**
  * AnyClient is an arbitrary service client with any method signature.
@@ -25,7 +24,7 @@ export type AnyClient = Record<string, AnyClientMethod>;
 
 type AnyClientMethod = (...args: any[]) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-type CreateAnyClientMethod = (method: MethodInfo) => AnyClientMethod | null;
+type CreateAnyClientMethod = (method: DescMethod) => AnyClientMethod | null;
 
 /**
  * Create any client for the given service.

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -56,5 +56,4 @@ export {
 } from "./implementation.js";
 export type { ServiceImplSpec, MethodImplSpec } from "./implementation.js";
 export { createRouterTransport } from "./router-transport.js";
-
-export type { MethodInfo } from "./types.js";
+export type { DescMethodUnary, DescMethodStreaming } from "./types.js"; // TODO: Remove once exported from @bufbuild/protobuf

--- a/packages/connect/src/interceptor.ts
+++ b/packages/connect/src/interceptor.ts
@@ -14,12 +14,11 @@
 
 import type {
   DescMessage,
-  DescMethod,
   DescService,
   MessageShape,
 } from "@bufbuild/protobuf";
 import type { ContextValues } from "./context-values.js";
-import type { MethodInfo } from "./types.js";
+import type { DescMethodStreaming, DescMethodUnary } from "./types.js";
 
 /**
  * An interceptor can add logic to clients or servers, similar to the decorators
@@ -67,7 +66,7 @@ type AnyFn = (
 export interface UnaryRequest<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> extends RequestCommon<I, O> {
+> extends RequestCommon {
   /**
    * The `stream` property discriminates between UnaryRequest and
    * StreamingRequest.
@@ -78,6 +77,11 @@ export interface UnaryRequest<
    * The input message that will be transmitted.
    */
   readonly message: MessageShape<I>;
+
+  /**
+   * Metadata related to the service method that is being called.
+   */
+  readonly method: DescMethodUnary<I, O>;
 }
 
 /**
@@ -87,7 +91,7 @@ export interface UnaryRequest<
 export interface UnaryResponse<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> extends ResponseCommon<I, O> {
+> extends ResponseCommon {
   /**
    * The `stream` property discriminates between UnaryResponse and
    * StreamingConn.
@@ -98,6 +102,11 @@ export interface UnaryResponse<
    * The received output message.
    */
   readonly message: MessageShape<O>;
+
+  /**
+   * Metadata related to the service method that is being called.
+   */
+  readonly method: DescMethodUnary<I, O>;
 }
 
 /**
@@ -107,7 +116,7 @@ export interface UnaryResponse<
 export interface StreamRequest<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> extends RequestCommon<I, O> {
+> extends RequestCommon {
   /**
    * The `stream` property discriminates between UnaryRequest and
    * StreamingRequest.
@@ -118,6 +127,11 @@ export interface StreamRequest<
    * The input messages that will be transmitted.
    */
   readonly message: AsyncIterable<MessageShape<I>>;
+
+  /**
+   * Metadata related to the service method that is being called.
+   */
+  readonly method: DescMethodStreaming<I, O>;
 }
 
 /**
@@ -127,7 +141,7 @@ export interface StreamRequest<
 export interface StreamResponse<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> extends ResponseCommon<I, O> {
+> extends ResponseCommon {
   /**
    * The `stream` property discriminates between UnaryResponse and
    * StreamingConn.
@@ -138,12 +152,17 @@ export interface StreamResponse<
    * The output messages.
    */
   readonly message: AsyncIterable<MessageShape<O>>;
+
+  /**
+   * Metadata related to the service method that is being called.
+   */
+  readonly method: DescMethodStreaming<I, O>;
 }
 
 /**
  * @private
  */
-export interface RequestCommon<I extends DescMessage, O extends DescMessage> {
+export interface RequestCommon {
   /**
    * Metadata related to the service that is being called.
    */
@@ -154,11 +173,6 @@ export interface RequestCommon<I extends DescMessage, O extends DescMessage> {
    * to identify Connect GET requests.
    */
   readonly requestMethod: string;
-
-  /**
-   * Metadata related to the service method that is being called.
-   */
-  readonly method: MethodInfo<I, O>;
 
   /**
    * The URL the request is going to hit for the clients or the
@@ -185,16 +199,11 @@ export interface RequestCommon<I extends DescMessage, O extends DescMessage> {
 /**
  * @private
  */
-export interface ResponseCommon<I extends DescMessage, O extends DescMessage> {
+export interface ResponseCommon {
   /**
    * Metadata related to the service that is being called.
    */
   readonly service: DescService;
-
-  /**
-   * Metadata related to the service method that is being called.
-   */
-  readonly method: DescMethod & { readonly input: I; readonly output: O };
 
   /**
    * Headers received from the response.

--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { create, isMessage, toBinary } from "@bufbuild/protobuf";
+import {
+  create,
+  isMessage,
+  toBinary,
+  type DescMethod,
+} from "@bufbuild/protobuf";
 import { createHandlerFactory } from "./handler-factory.js";
 import type { MethodImpl } from "../implementation.js";
 import { createMethodImplSpec } from "../implementation.js";
@@ -44,7 +49,6 @@ import {
   MethodSchema,
   StringValueSchema,
 } from "@bufbuild/protobuf/wkt";
-import type { MethodInfo } from "../types.js";
 
 describe("createHandlerFactory()", function () {
   const testService = createServiceDesc({
@@ -69,7 +73,7 @@ describe("createHandlerFactory()", function () {
     },
   });
 
-  function setupTestHandler<M extends MethodInfo>(
+  function setupTestHandler<M extends DescMethod>(
     method: M,
     opt: Partial<UniversalHandlerOptions>,
     impl: MethodImpl<M>,

--- a/packages/connect/src/protocol-connect/request-header.ts
+++ b/packages/connect/src/protocol-connect/request-header.ts
@@ -30,7 +30,7 @@ import {
   contentTypeUnaryProto,
 } from "./content-type.js";
 import type { Compression } from "../protocol/compression.js";
-import type { MethodKind } from "../types.js";
+import type { DescMethod } from "@bufbuild/protobuf";
 
 /**
  * Creates headers for a Connect request.
@@ -38,7 +38,7 @@ import type { MethodKind } from "../types.js";
  * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeader(
-  methodKind: MethodKind,
+  methodKind: DescMethod["methodKind"],
   useBinaryFormat: boolean,
   timeoutMs: number | undefined,
   userProvidedHeaders: HeadersInit | undefined,
@@ -76,7 +76,7 @@ export function requestHeader(
  * @private Internal code, does not follow semantic versioning.
  */
 export function requestHeaderWithCompression(
-  methodKind: MethodKind,
+  methodKind: DescMethod["methodKind"],
   useBinaryFormat: boolean,
   timeoutMs: number | undefined,
   userProvidedHeaders: HeadersInit | undefined,

--- a/packages/connect/src/protocol-connect/transport.ts
+++ b/packages/connect/src/protocol-connect/transport.ts
@@ -48,7 +48,7 @@ import { createMethodSerializationLookup } from "../protocol/serialization.js";
 import type { Transport } from "../transport.js";
 import type { ContextValues } from "../context-values.js";
 import { createContextValues } from "../context-values.js";
-import type { MethodInfo } from "../types.js";
+import type { DescMethodUnary, DescMethodStreaming } from "../types.js";
 import { MethodOptions_IdempotencyLevel } from "@bufbuild/protobuf/wkt";
 
 /**
@@ -57,7 +57,7 @@ import { MethodOptions_IdempotencyLevel } from "@bufbuild/protobuf/wkt";
 export function createTransport(opt: CommonTransportOptions): Transport {
   return {
     async unary<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodUnary<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
@@ -177,7 +177,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
     },
 
     async stream<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodStreaming<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,

--- a/packages/connect/src/protocol-connect/validate-response.ts
+++ b/packages/connect/src/protocol-connect/validate-response.ts
@@ -22,7 +22,7 @@ import {
   headerUnaryEncoding,
 } from "./headers.js";
 import type { Compression } from "../protocol/compression.js";
-import type { MethodKind } from "../types.js";
+import type { DescMethod } from "@bufbuild/protobuf";
 
 /**
  * Validates response status and header for the Connect protocol.
@@ -35,7 +35,7 @@ import type { MethodKind } from "../types.js";
  * @private Internal code, does not follow semantic versioning.
  */
 export function validateResponse(
-  methodKind: MethodKind,
+  methodKind: DescMethod["methodKind"],
   useBinaryFormat: boolean,
   status: number,
   headers: Headers,
@@ -81,7 +81,7 @@ export function validateResponse(
  * @private
  */
 export function validateResponseWithCompression(
-  methodKind: MethodKind,
+  methodKind: DescMethod["methodKind"],
   acceptCompression: Compression[],
   useBinaryFormat: boolean,
   status: number,

--- a/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { create, toBinary } from "@bufbuild/protobuf";
+import { create, toBinary, type DescMethod } from "@bufbuild/protobuf";
 import type { MethodImpl } from "../implementation.js";
 import { createMethodImplSpec } from "../implementation.js";
 import { Code } from "../code.js";
 import { ConnectError } from "../connect-error.js";
-import type { MethodInfo } from "../types.js";
 import type { UniversalHandlerOptions } from "../protocol/index.js";
 import {
   createAsyncIterable,
@@ -50,7 +49,7 @@ describe("createHandlerFactory()", function () {
     },
   });
 
-  function setupTestHandler<M extends MethodInfo>(
+  function setupTestHandler<M extends DescMethod>(
     method: M,
     opt: Partial<UniversalHandlerOptions>,
     impl: MethodImpl<M>,

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -48,7 +48,7 @@ import type { Transport } from "../transport.js";
 import { createContextValues } from "../context-values.js";
 import type { ContextValues } from "../context-values.js";
 import { headerGrpcStatus } from "./headers.js";
-import type { MethodInfo } from "../types.js";
+import type { DescMethodStreaming, DescMethodUnary } from "../types.js";
 
 /**
  * Create a Transport for the gRPC-web protocol.
@@ -56,7 +56,7 @@ import type { MethodInfo } from "../types.js";
 export function createTransport(opt: CommonTransportOptions): Transport {
   return {
     async unary<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodUnary<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
@@ -189,7 +189,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       });
     },
     async stream<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodStreaming<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,

--- a/packages/connect/src/protocol-grpc/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.spec.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { MethodInfo } from "../types.js";
-import { create, toBinary } from "@bufbuild/protobuf";
+import { create, toBinary, type DescMethod } from "@bufbuild/protobuf";
 import type { MethodImpl } from "../implementation.js";
 import { createMethodImplSpec } from "../implementation.js";
 import type { UniversalHandlerOptions } from "../protocol/index.js";
@@ -49,7 +48,7 @@ describe("createHandlerFactory()", function () {
     },
   });
 
-  function setupTestHandler<M extends MethodInfo>(
+  function setupTestHandler<M extends DescMethod>(
     method: M,
     opt: Partial<UniversalHandlerOptions>,
     impl: MethodImpl<M>,

--- a/packages/connect/src/protocol-grpc/transport.ts
+++ b/packages/connect/src/protocol-grpc/transport.ts
@@ -47,7 +47,7 @@ import type { Transport } from "../transport.js";
 import { createContextValues } from "../context-values.js";
 import type { ContextValues } from "../context-values.js";
 import { headerGrpcStatus } from "./headers.js";
-import type { MethodInfo } from "../types.js";
+import type { DescMethodStreaming, DescMethodUnary } from "../types.js";
 
 /**
  * Create a Transport for the gRPC protocol.
@@ -55,7 +55,7 @@ import type { MethodInfo } from "../types.js";
 export function createTransport(opt: CommonTransportOptions): Transport {
   return {
     async unary<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodUnary<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,
@@ -173,7 +173,7 @@ export function createTransport(opt: CommonTransportOptions): Transport {
       });
     },
     async stream<I extends DescMessage, O extends DescMessage>(
-      method: MethodInfo<I, O>,
+      method: DescMethodStreaming<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,
       header: HeadersInit | undefined,

--- a/packages/connect/src/protocol/serialization.ts
+++ b/packages/connect/src/protocol/serialization.ts
@@ -29,7 +29,7 @@ import type {
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";
 import { assertReadMaxBytes, assertWriteMaxBytes } from "./limit-io.js";
-import type { MethodInfo } from "../types.js";
+import type { DescMethodStreaming, DescMethodUnary } from "../types.js";
 
 /**
  * Serialization provides methods to serialize or parse data with a certain
@@ -74,7 +74,7 @@ export function createMethodSerializationLookup<
   I extends DescMessage,
   O extends DescMessage,
 >(
-  method: MethodInfo<I, O>,
+  method: DescMethodUnary<I, O> | DescMethodStreaming<I, O>,
   binaryOptions: Partial<BinaryReadOptions & BinaryWriteOptions> | undefined,
   jsonOptions: Partial<JsonReadOptions & JsonWriteOptions> | undefined,
   limitOptions: {
@@ -138,7 +138,7 @@ export function createClientMethodSerializers<
   I extends DescMessage,
   O extends DescMessage,
 >(
-  method: MethodInfo<I, O>,
+  method: DescMethodUnary<I, O> | DescMethodStreaming<I, O>,
   useBinaryFormat: boolean,
   jsonOptions?: JsonSerializationOptions,
   binaryOptions?: BinarySerializationOptions,

--- a/packages/connect/src/transport.ts
+++ b/packages/connect/src/transport.ts
@@ -15,7 +15,7 @@
 import type { DescMessage, MessageInitShape } from "@bufbuild/protobuf";
 import type { StreamResponse, UnaryResponse } from "./interceptor.js";
 import type { ContextValues } from "./context-values.js";
-import type { MethodInfo } from "./types.js";
+import type { DescMethodStreaming, DescMethodUnary } from "./types.js";
 
 /**
  * Transport represents the underlying transport for a client.
@@ -28,7 +28,7 @@ export interface Transport {
    * responds with a single output message.
    */
   unary<I extends DescMessage, O extends DescMessage>(
-    method: MethodInfo<I, O>,
+    method: DescMethodUnary<I, O>,
     signal: AbortSignal | undefined,
     timeoutMs: number | undefined,
     header: HeadersInit | undefined,
@@ -41,7 +41,7 @@ export interface Transport {
    * and responds with zero or more output messages.
    */
   stream<I extends DescMessage, O extends DescMessage>(
-    method: MethodInfo<I, O>,
+    method: DescMethodStreaming<I, O>,
     signal: AbortSignal | undefined,
     timeoutMs: number | undefined,
     header: HeadersInit | undefined,

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -14,49 +14,45 @@
 
 import type { DescMessage, DescMethod } from "@bufbuild/protobuf";
 
-// TODO: Maybe move this to protobuf and export from root?
-
-export type MethodKind = MethodInfo["methodKind"];
-
-export type MethodInfo<
+// TODO: Delete these once exported from `@bufbuild/protobuf`
+export type DescMethodStreaming<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
 > =
-  | MethodInfoUnary<I, O>
-  | MethodInfoServerStreaming<I, O>
-  | MethodInfoClientStreaming<I, O>
-  | MethodInfoBiDiStreaming<I, O>;
+  | DescMethodClientStreaming<I, O>
+  | DescMethodServerStreaming<I, O>
+  | DescMethodBiDiStreaming<I, O>;
 
-export type MethodInfoUnary<
-  I extends DescMessage,
-  O extends DescMessage,
+export type DescMethodUnary<
+  I extends DescMessage = DescMessage,
+  O extends DescMessage = DescMessage,
 > = DescMethod & {
   methodKind: "unary";
   input: I;
   output: O;
 };
 
-export type MethodInfoServerStreaming<
-  I extends DescMessage,
-  O extends DescMessage,
+export type DescMethodServerStreaming<
+  I extends DescMessage = DescMessage,
+  O extends DescMessage = DescMessage,
 > = DescMethod & {
   methodKind: "server_streaming";
   input: I;
   output: O;
 };
 
-export type MethodInfoClientStreaming<
-  I extends DescMessage,
-  O extends DescMessage,
+export type DescMethodClientStreaming<
+  I extends DescMessage = DescMessage,
+  O extends DescMessage = DescMessage,
 > = DescMethod & {
   methodKind: "client_streaming";
   input: I;
   output: O;
 };
 
-export type MethodInfoBiDiStreaming<
-  I extends DescMessage,
-  O extends DescMessage,
+export type DescMethodBiDiStreaming<
+  I extends DescMessage = DescMessage,
+  O extends DescMessage = DescMessage,
 > = DescMethod & {
   methodKind: "bidi_streaming";
   input: I;

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -26,7 +26,7 @@ export type DescMethodStreaming<
 export type DescMethodUnary<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> = DescMethod & {
+> = Omit<DescMethod, "methodKind" | "input" | "output"> & {
   methodKind: "unary";
   input: I;
   output: O;
@@ -35,7 +35,7 @@ export type DescMethodUnary<
 export type DescMethodServerStreaming<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> = DescMethod & {
+> = Omit<DescMethod, "methodKind" | "input" | "output"> & {
   methodKind: "server_streaming";
   input: I;
   output: O;
@@ -44,7 +44,7 @@ export type DescMethodServerStreaming<
 export type DescMethodClientStreaming<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> = DescMethod & {
+> = Omit<DescMethod, "methodKind" | "input" | "output"> & {
   methodKind: "client_streaming";
   input: I;
   output: O;
@@ -53,7 +53,7 @@ export type DescMethodClientStreaming<
 export type DescMethodBiDiStreaming<
   I extends DescMessage = DescMessage,
   O extends DescMessage = DescMessage,
-> = DescMethod & {
+> = Omit<DescMethod, "methodKind" | "input" | "output"> & {
   methodKind: "bidi_streaming";
   input: I;
   output: O;


### PR DESCRIPTION
Replace MethodInfo with Descriptor Types. We plan on adding these types to `@bufbuild/protobuf`. We can remove the types once that is done.

This also makes the types stricter, transport will now only accept unary descriptors for `unary` and streaming descriptors for `stream` methods. Likewise the interceptor types are also stricter.