### PR TITLE
Fix gRPC-Web trailers-only response handling for server-streaming RPCs

### DIFF
--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -274,7 +274,6 @@ export function createGrpcWebTransport(
         foundStatus: boolean,
         trailerTarget: Headers,
         header: Headers,
-        headerError: ConnectError | undefined,
         signal: AbortSignal,
       ) {
         const reader = createEnvelopeReadableStream(body).getReader();
@@ -313,7 +312,6 @@ export function createGrpcWebTransport(
             throw "extra message";
           }
           yield parse(data);
-          continue;
         }
         // Node wil not throw an AbortError on `read` if the
         // signal is aborted before `getReader` is called.
@@ -326,9 +324,6 @@ export function createGrpcWebTransport(
           signal.throwIfAborted();
         }
         if (!trailerReceived) {
-          if (headerError) {
-            throw headerError;
-          }
           throw "missing trailer";
         }
       }
@@ -398,7 +393,6 @@ export function createGrpcWebTransport(
               foundStatus,
               trailer,
               fRes.headers,
-              headerError,
               req.signal,
             ),
           };

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -382,10 +382,10 @@ export function createGrpcWebTransport(
             fRes.status,
             fRes.headers,
           );
+          if (headerError != undefined) {
+            throw headerError;
+          }
           if (!fRes.body) {
-            if (headerError != undefined) {
-              throw headerError;
-            }
             throw "missing response body";
           }
           const trailer = new Headers();


### PR DESCRIPTION
gRPC-Web supports "trailers-only" responses - error responses with an empty body, that have all trailer fields in the response headers. 

The gRPC-Web transport from `@connectrpc/connect-web` has a bug handling these responses: It raises an error as expected for unary RPCs, but it does not raise an error for server-streaming RPCs. 

The next release of the conformance test suite will include tests for this case (added in https://github.com/connectrpc/conformance/pull/935). 
