### PR TITLE
Release 2.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14219,7 +14219,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.39.0",
@@ -14235,22 +14235,22 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.1",
-        "@connectrpc/connect-node": "2.0.0-beta.1"
+        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect-node": "2.0.0-beta.2"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240821.1",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
         "tsx": "^4.19.0",
         "wrangler": "^3.73.0"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.1",
+        "@connectrpc/connect": "2.0.0-beta.2",
         "fflate": "^0.8.1",
         "tar-stream": "^3.1.7"
       },
@@ -14267,12 +14267,12 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-beta.1",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
-        "@connectrpc/connect-node": "2.0.0-beta.1",
+        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+        "@connectrpc/connect-node": "2.0.0-beta.2",
         "@types/express": "^4.17.18",
         "express": "^4.19.2",
         "tsx": "^4.19.0"
@@ -14282,32 +14282,32 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.1",
-        "@connectrpc/connect-node": "2.0.0-beta.1"
+        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect-node": "2.0.0-beta.2"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-beta.1",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
-        "@connectrpc/connect-node": "2.0.0-beta.1"
+        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+        "@connectrpc/connect-node": "2.0.0-beta.2"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.1",
-        "@connectrpc/connect-node": "2.0.0-beta.1",
+        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect-node": "2.0.0-beta.2",
         "fastify": "^4.22.1"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.2",
@@ -14328,28 +14328,28 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-beta.1",
-        "@connectrpc/connect-node": "2.0.0-beta.1"
+        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect-node": "2.0.0-beta.2"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.1",
-        "@connectrpc/connect-node": "2.0.0-beta.1",
+        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect-node": "2.0.0-beta.2",
         "next": "^13.2.4 || ^14.2.5"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
         "@types/jasmine": "^5.0.0",
         "jasmine": "^5.2.0"
       },
@@ -14358,17 +14358,17 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.1"
+        "@connectrpc/connect": "2.0.0-beta.2"
       }
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.39.0",
         "@bufbuild/protoc-gen-es": "^2.1.0",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
         "@wdio/browserstack-service": "^9.0.9",
         "@wdio/cli": "^9.0.9",
         "@wdio/jasmine-framework": "^9.0.9",
@@ -14378,7 +14378,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.1"
+        "@connectrpc/connect": "2.0.0-beta.2"
       }
     },
     "packages/connect-web-bench": {
@@ -14387,7 +14387,7 @@
         "@bufbuild/buf": "^1.39.0",
         "@bufbuild/protobuf": "^2.2.0",
         "@bufbuild/protoc-gen-es": "^2.1.0",
-        "@connectrpc/connect-web": "2.0.0-beta.1",
+        "@connectrpc/connect-web": "2.0.0-beta.2",
         "@types/brotli": "^1.3.4",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
@@ -14399,8 +14399,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect-node": "^2.0.0-beta.1",
-        "@connectrpc/connect-web": "^2.0.0-beta.1",
+        "@connectrpc/connect-node": "^2.0.0-beta.2",
+        "@connectrpc/connect-web": "^2.0.0-beta.2",
         "tsx": "^4.16.5"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.1",
-    "@connectrpc/connect-node": "2.0.0-beta.1"
+    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect-node": "2.0.0-beta.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240821.1",
     "wrangler": "^3.73.0",
     "tsx": "^4.19.0",
-    "@connectrpc/connect-conformance": "^2.0.0-beta.1"
+    "@connectrpc/connect-conformance": "^2.0.0-beta.2"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/src/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.1",
+    "@connectrpc/connect": "2.0.0-beta.2",
     "fflate": "^0.8.1",
     "tar-stream": "^3.1.7"
   },

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,16 +32,16 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
-    "@connectrpc/connect": "2.0.0-beta.1",
-    "@connectrpc/connect-node": "2.0.0-beta.1",
+    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect-node": "2.0.0-beta.2",
     "@types/express": "^4.17.18",
     "express": "^4.19.2",
     "tsx": "^4.19.0"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.1",
-    "@connectrpc/connect-node": "2.0.0-beta.1"
+    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect-node": "2.0.0-beta.2"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,14 +31,14 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
-    "@connectrpc/connect": "2.0.0-beta.1",
-    "@connectrpc/connect-node": "2.0.0-beta.1"
+    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect-node": "2.0.0-beta.2"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
     "fastify": "^4.22.1",
-    "@connectrpc/connect": "2.0.0-beta.1",
-    "@connectrpc/connect-node": "2.0.0-beta.1"
+    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect-node": "2.0.0-beta.2"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
@@ -118,7 +118,7 @@ plugins:
       expect(bufGenYamlWritten.length).toBe(1);
       expect(bufGenYamlWritten[0]?.yaml).toEqual(`version: v2
 plugins:
-  - remote: buf.build/bufbuild/es:v2.1.0
+  - remote: buf.build/bufbuild/es:v2.2.0
     out: src/gen
 `);
     });

--- a/packages/connect-migrate/src/migrations/v2.0.0.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.ts
@@ -35,7 +35,7 @@ import {
 import { writeBufGenYamlFile } from "../lib/bufgenyaml";
 
 export const targetVersionProtobufEs = "2.2.0";
-export const targetVersionConnectEs = "2.0.0-beta.1"; // TODO
+export const targetVersionConnectEs = "2.0.0-beta.2"; // TODO
 export const targetVersionConnectQuery = "2.0.0-beta.1"; // TODO
 export const targetVersionConnectPlaywright = "0.4.0"; // TODO
 

--- a/packages/connect-migrate/src/migrations/v2.0.0.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.ts
@@ -34,9 +34,9 @@ import {
 } from "../lib/migrate-bufgenyaml";
 import { writeBufGenYamlFile } from "../lib/bufgenyaml";
 
-export const targetVersionProtobufEs = "2.1.0";
-export const targetVersionConnectEs = "2.0.0-beta.1"; // TODO
-export const targetVersionConnectQuery = "2.0.0"; // TODO
+export const targetVersionProtobufEs = "2.2.0";
+export const targetVersionConnectEs = "2.0.0-beta.2"; // TODO
+export const targetVersionConnectQuery = "2.0.0-beta.1"; // TODO
 export const targetVersionConnectPlaywright = "0.4.0"; // TODO
 
 const dependencyMigrations: DependencyMigration[] = [

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
     "next": "^13.2.4 || ^14.2.5",
-    "@connectrpc/connect": "2.0.0-beta.1",
-    "@connectrpc/connect-node": "2.0.0-beta.1"
+    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect-node": "2.0.0-beta.2"
   },
   "devDependencies": {
-    "@connectrpc/connect": "2.0.0-beta.1",
-    "@connectrpc/connect-node": "2.0.0-beta.1"
+    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect-node": "2.0.0-beta.2"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,10 +34,10 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.1"
+    "@connectrpc/connect": "2.0.0-beta.2"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
     "@types/jasmine": "^5.0.0",
     "jasmine": "^5.2.0"
   }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   276,213 b | 176,244 b |   35,700 b |
-| Connect-ES     |    4 |   280,465 b | 179,346 b |   36,533 b |
-| Connect-ES     |    8 |   285,328 b | 183,777 b |   37,458 b |
-| Connect-ES     |   16 |   294,456 b | 191,401 b |   38,966 b |
+| Connect-ES     |    1 |   276,213 b | 176,244 b |   35,693 b |
+| Connect-ES     |    4 |   280,465 b | 179,346 b |   36,574 b |
+| Connect-ES     |    8 |   285,328 b | 183,777 b |   37,434 b |
+| Connect-ES     |   16 |   294,456 b | 191,401 b |   38,933 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.896484375 140,186.53740234375 280,183.9177734375 420,179.64707031249998">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.91630859375 140,186.4212890625 280,183.98574218750002 420,179.74052734375">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="188.896484375" r="4" fill="#ffa600"><title>Connect-ES 34.86 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="186.53740234375" r="4" fill="#ffa600"><title>Connect-ES 35.68 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="183.9177734375" r="4" fill="#ffa600"><title>Connect-ES 36.58 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="179.64707031249998" r="4" fill="#ffa600"><title>Connect-ES 38.05 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="188.91630859375" r="4" fill="#ffa600"><title>Connect-ES 34.86 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="186.4212890625" r="4" fill="#ffa600"><title>Connect-ES 35.72 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="183.98574218750002" r="4" fill="#ffa600"><title>Connect-ES 36.56 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="179.74052734375" r="4" fill="#ffa600"><title>Connect-ES 38.02 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -13,7 +13,7 @@
     "@bufbuild/buf": "^1.39.0",
     "@bufbuild/protobuf": "^2.2.0",
     "@bufbuild/protoc-gen-es": "^2.1.0",
-    "@connectrpc/connect-web": "2.0.0-beta.1",
+    "@connectrpc/connect-web": "2.0.0-beta.2",
     "@types/brotli": "^1.3.4",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.39.0",
     "@bufbuild/protoc-gen-es": "^2.1.0",
-    "@connectrpc/connect-conformance": "^2.0.0-beta.1",
+    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
     "@wdio/browserstack-service": "^9.0.9",
     "@wdio/cli": "^9.0.9",
     "@wdio/jasmine-framework": "^9.0.9",
@@ -52,6 +52,6 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.1"
+    "@connectrpc/connect": "2.0.0-beta.2"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect-node": "^2.0.0-beta.1",
-    "@connectrpc/connect-web": "^2.0.0-beta.1",
+    "@connectrpc/connect-node": "^2.0.0-beta.2",
+    "@connectrpc/connect-web": "^2.0.0-beta.2",
     "tsx": "^4.16.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's Changed

This is a beta release for version 2. See [here](https://github.com/connectrpc/connect-es/releases/tag/v2.0.0-alpha.1) for an introduction. 

To give this version a try, run `npx @connectrpc/connect-migrate@beta`. 

* Fix gRPC-Web trailers-only response handling for server-streaming RPCs by @timostamm in https://github.com/connectrpc/connect-es/pull/1261
* Add Connect-Query v2.0.0-beta.1 to connect-migrate by @timostamm in https://github.com/connectrpc/connect-es/pull/1264

**Full Changelog**: https://github.com/connectrpc/connect-es/compare/v2.0.0-beta.1...v2.0.0-beta.2