### PR TITLE
Fix transform for `createPromiseClient` -> `createClient` in connect-migrate

### DIFF
--- a/packages/connect-migrate/src/migrations/v1.6.0-transform.spec.ts
+++ b/packages/connect-migrate/src/migrations/v1.6.0-transform.spec.ts
@@ -148,6 +148,19 @@ describe("rename symbols using", () => {
         `;
       expect(t(got)?.trim()).toBe(want.trim());
     });
+
+    it("handles other imports", () => {
+      const input = `
+        import { Code, ConnectError, createPromiseClient } from "@connectrpc/connect";
+        const promiseClient = createPromiseClient(ResourceService, transport);
+      `;
+      const want = `
+        import { Code, ConnectError, createClient } from "@connectrpc/connect";
+        const promiseClient = createClient(ResourceService, transport);
+      `;
+
+      expect(t(input)?.trim()).toBe(want.trim());
+    });
   });
   describe("'require' with", () => {
     it("const", () => {
@@ -184,6 +197,17 @@ describe("rename symbols using", () => {
     `;
       expect(t(got)?.trim()).toBe(want.trim());
     });
+
+    it("handles other imports", () => {
+      const got = `
+    const { Code, createPromiseClient } = require("@connectrpc/connect");
+    `;
+      const want = `
+    const { Code, createClient } = require("@connectrpc/connect");
+    `;
+      expect(t(got)?.trim()).toBe(want.trim());
+    });
+
     it("let", () => {
       const got = `
       let connect;

--- a/packages/connect-migrate/src/migrations/v1.6.0-transform.ts
+++ b/packages/connect-migrate/src/migrations/v1.6.0-transform.ts
@@ -32,13 +32,15 @@ const transform: j.Transform = (file, { j }, options) => {
       specifiers: [
         {
           type: "ImportSpecifier",
-          imported: { name: (name) => [fromFunction, fromType].includes(name) },
         },
       ],
     })
     .forEach((path) => {
       path.value.specifiers?.forEach((s) => {
         s = s as j.ImportSpecifier;
+        if (![fromFunction, fromType].includes(s.imported.name)) {
+          return;
+        }
         // import { createPromiseClient as <local> } from "@connectrpc/connect";
         //
         // We should just rename createPromiseClient here and user code will continue to use local.


### PR DESCRIPTION
In [v1.6.0](https://github.com/connectrpc/connect-es/releases/tag/v1.6.0), we're renaming `createPromiseClient` to `createClient`.

Running `npx @connectrpc/connect-migrate` updates imports for `createPromiseClient` or `PromiseClient` as expected, but only if the import statement doesn't import anything else.

This ports @paul-sachs' fix https://github.com/connectrpc/connect-es/pull/1268 from the v2 branch to v2.