### PR TITLE
Release 2.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16343,7 +16343,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.39.0",
@@ -16359,22 +16359,22 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.2",
-        "@connectrpc/connect-node": "2.0.0-beta.2"
+        "@connectrpc/connect": "2.0.0-rc.1",
+        "@connectrpc/connect-node": "2.0.0-rc.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240821.1",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.1",
         "tsx": "^4.19.0",
         "wrangler": "^3.73.0"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.2",
+        "@connectrpc/connect": "2.0.0-rc.1",
         "fflate": "^0.8.1",
         "tar-stream": "^3.1.7"
       },
@@ -16391,12 +16391,12 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-beta.2",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
-        "@connectrpc/connect-node": "2.0.0-beta.2",
+        "@connectrpc/connect": "2.0.0-rc.1",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.1",
+        "@connectrpc/connect-node": "2.0.0-rc.1",
         "@types/express": "^4.17.18",
         "express": "^4.19.2",
         "tsx": "^4.19.0"
@@ -16406,32 +16406,32 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.2",
-        "@connectrpc/connect-node": "2.0.0-beta.2"
+        "@connectrpc/connect": "2.0.0-rc.1",
+        "@connectrpc/connect-node": "2.0.0-rc.1"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-beta.2",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
-        "@connectrpc/connect-node": "2.0.0-beta.2"
+        "@connectrpc/connect": "2.0.0-rc.1",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.1",
+        "@connectrpc/connect-node": "2.0.0-rc.1"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.2",
-        "@connectrpc/connect-node": "2.0.0-beta.2",
+        "@connectrpc/connect": "2.0.0-rc.1",
+        "@connectrpc/connect-node": "2.0.0-rc.1",
         "fastify": "^4.22.1"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.2",
@@ -16452,28 +16452,28 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-beta.2",
-        "@connectrpc/connect-node": "2.0.0-beta.2"
+        "@connectrpc/connect": "2.0.0-rc.1",
+        "@connectrpc/connect-node": "2.0.0-rc.1"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.2",
-        "@connectrpc/connect-node": "2.0.0-beta.2",
+        "@connectrpc/connect": "2.0.0-rc.1",
+        "@connectrpc/connect-node": "2.0.0-rc.1",
         "next": "^13.2.4 || ^14.2.5"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.1",
         "@types/jasmine": "^5.0.0",
         "jasmine": "^5.2.0"
       },
@@ -16482,17 +16482,17 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.2"
+        "@connectrpc/connect": "2.0.0-rc.1"
       }
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.39.0",
         "@bufbuild/protoc-gen-es": "^2.1.0",
-        "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.1",
         "@wdio/browserstack-service": "^9.0.9",
         "@wdio/cli": "^9.0.9",
         "@wdio/jasmine-framework": "^9.0.9",
@@ -16502,7 +16502,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-beta.2"
+        "@connectrpc/connect": "2.0.0-rc.1"
       }
     },
     "packages/connect-web-bench": {
@@ -16511,7 +16511,7 @@
         "@bufbuild/buf": "^1.39.0",
         "@bufbuild/protobuf": "^2.2.0",
         "@bufbuild/protoc-gen-es": "^2.1.0",
-        "@connectrpc/connect-web": "2.0.0-beta.2",
+        "@connectrpc/connect-web": "2.0.0-rc.1",
         "@types/brotli": "^1.3.4",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
@@ -16523,8 +16523,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect-node": "^2.0.0-beta.2",
-        "@connectrpc/connect-web": "^2.0.0-beta.2",
+        "@connectrpc/connect-node": "^2.0.0-rc.1",
+        "@connectrpc/connect-web": "^2.0.0-rc.1",
         "tsx": "^4.16.5"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.2",
-    "@connectrpc/connect-node": "2.0.0-beta.2"
+    "@connectrpc/connect": "2.0.0-rc.1",
+    "@connectrpc/connect-node": "2.0.0-rc.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240821.1",
     "wrangler": "^3.73.0",
     "tsx": "^4.19.0",
-    "@connectrpc/connect-conformance": "^2.0.0-beta.2"
+    "@connectrpc/connect-conformance": "^2.0.0-rc.1"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/src/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.2",
+    "@connectrpc/connect": "2.0.0-rc.1",
     "fflate": "^0.8.1",
     "tar-stream": "^3.1.7"
   },

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,16 +32,16 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
-    "@connectrpc/connect": "2.0.0-beta.2",
-    "@connectrpc/connect-node": "2.0.0-beta.2",
+    "@connectrpc/connect-conformance": "^2.0.0-rc.1",
+    "@connectrpc/connect": "2.0.0-rc.1",
+    "@connectrpc/connect-node": "2.0.0-rc.1",
     "@types/express": "^4.17.18",
     "express": "^4.19.2",
     "tsx": "^4.19.0"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.2",
-    "@connectrpc/connect-node": "2.0.0-beta.2"
+    "@connectrpc/connect": "2.0.0-rc.1",
+    "@connectrpc/connect-node": "2.0.0-rc.1"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,14 +31,14 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
-    "@connectrpc/connect": "2.0.0-beta.2",
-    "@connectrpc/connect-node": "2.0.0-beta.2"
+    "@connectrpc/connect-conformance": "^2.0.0-rc.1",
+    "@connectrpc/connect": "2.0.0-rc.1",
+    "@connectrpc/connect-node": "2.0.0-rc.1"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
     "fastify": "^4.22.1",
-    "@connectrpc/connect": "2.0.0-beta.2",
-    "@connectrpc/connect-node": "2.0.0-beta.2"
+    "@connectrpc/connect": "2.0.0-rc.1",
+    "@connectrpc/connect-node": "2.0.0-rc.1"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
@@ -244,7 +244,7 @@ plugins:
       expect(bufGenYamlWritten.length).toBe(1);
       expect(bufGenYamlWritten[0]?.yaml).toEqual(`version: v2
 plugins:
-  - remote: buf.build/connectrpc/query-es:v2.0.0-beta.1
+  - remote: buf.build/connectrpc/query-es:v2.0.0-rc.1
     out: src/gen
 `);
     });

--- a/packages/connect-migrate/src/migrations/v2.0.0.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.ts
@@ -35,8 +35,8 @@ import {
 import { writeBufGenYamlFile } from "../lib/bufgenyaml";
 
 export const targetVersionProtobufEs = "2.2.0";
-export const targetVersionConnectEs = "2.0.0-beta.2"; // TODO
-export const targetVersionConnectQuery = "2.0.0-beta.1"; // TODO
+export const targetVersionConnectEs = "2.0.0-rc.1"; // TODO
+export const targetVersionConnectQuery = "2.0.0-rc.1"; // TODO
 export const targetVersionConnectPlaywright = "0.4.0"; // TODO
 
 const dependencyMigrations: DependencyMigration[] = [

--- a/packages/connect-migrate/src/migrations/v2.0.0.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.ts
@@ -37,7 +37,7 @@ import { writeBufGenYamlFile } from "../lib/bufgenyaml";
 export const targetVersionProtobufEs = "2.2.0";
 export const targetVersionConnectEs = "2.0.0-rc.1"; // TODO
 export const targetVersionConnectQuery = "2.0.0-rc.1"; // TODO
-export const targetVersionConnectPlaywright = "0.4.0"; // TODO
+export const targetVersionConnectPlaywright = "0.5.0"; // TODO
 
 const dependencyMigrations: DependencyMigration[] = [
   // https://github.com/bufbuild/protobuf-es

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
     "next": "^13.2.4 || ^14.2.5",
-    "@connectrpc/connect": "2.0.0-beta.2",
-    "@connectrpc/connect-node": "2.0.0-beta.2"
+    "@connectrpc/connect": "2.0.0-rc.1",
+    "@connectrpc/connect-node": "2.0.0-rc.1"
   },
   "devDependencies": {
-    "@connectrpc/connect": "2.0.0-beta.2",
-    "@connectrpc/connect-node": "2.0.0-beta.2"
+    "@connectrpc/connect": "2.0.0-rc.1",
+    "@connectrpc/connect-node": "2.0.0-rc.1"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,10 +34,10 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.2"
+    "@connectrpc/connect": "2.0.0-rc.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+    "@connectrpc/connect-conformance": "^2.0.0-rc.1",
     "@types/jasmine": "^5.0.0",
     "jasmine": "^5.2.0"
   }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   276,213 b | 176,244 b |   35,693 b |
-| Connect-ES     |    4 |   280,465 b | 179,346 b |   36,574 b |
-| Connect-ES     |    8 |   285,328 b | 183,777 b |   37,434 b |
-| Connect-ES     |   16 |   294,456 b | 191,401 b |   38,933 b |
+| Connect-ES     |    1 |   276,211 b | 176,242 b |   35,720 b |
+| Connect-ES     |    4 |   280,463 b | 179,344 b |   36,504 b |
+| Connect-ES     |    8 |   285,326 b | 183,775 b |   37,426 b |
+| Connect-ES     |   16 |   294,454 b | 191,399 b |   38,961 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.91630859375 140,186.4212890625 280,183.98574218750002 420,179.74052734375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.83984375 140,186.61953125 280,184.0083984375 420,179.66123046874998">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="188.91630859375" r="4" fill="#ffa600"><title>Connect-ES 34.86 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="186.4212890625" r="4" fill="#ffa600"><title>Connect-ES 35.72 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="183.98574218750002" r="4" fill="#ffa600"><title>Connect-ES 36.56 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="179.74052734375" r="4" fill="#ffa600"><title>Connect-ES 38.02 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="188.83984375" r="4" fill="#ffa600"><title>Connect-ES 34.88 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="186.61953125" r="4" fill="#ffa600"><title>Connect-ES 35.65 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="184.0083984375" r="4" fill="#ffa600"><title>Connect-ES 36.55 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="179.66123046874998" r="4" fill="#ffa600"><title>Connect-ES 38.05 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -13,7 +13,7 @@
     "@bufbuild/buf": "^1.39.0",
     "@bufbuild/protobuf": "^2.2.0",
     "@bufbuild/protoc-gen-es": "^2.1.0",
-    "@connectrpc/connect-web": "2.0.0-beta.2",
+    "@connectrpc/connect-web": "2.0.0-rc.1",
     "@types/brotli": "^1.3.4",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.39.0",
     "@bufbuild/protoc-gen-es": "^2.1.0",
-    "@connectrpc/connect-conformance": "^2.0.0-beta.2",
+    "@connectrpc/connect-conformance": "^2.0.0-rc.1",
     "@wdio/browserstack-service": "^9.0.9",
     "@wdio/cli": "^9.0.9",
     "@wdio/jasmine-framework": "^9.0.9",
@@ -52,6 +52,6 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-beta.2"
+    "@connectrpc/connect": "2.0.0-rc.1"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-rc.1",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect-node": "^2.0.0-beta.2",
-    "@connectrpc/connect-web": "^2.0.0-beta.2",
+    "@connectrpc/connect-node": "^2.0.0-rc.1",
+    "@connectrpc/connect-web": "^2.0.0-rc.1",
     "tsx": "^4.16.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's Changed

This is a release candidate for version 2. See [here](https://github.com/connectrpc/connect-es/releases/tag/v2.0.0-alpha.1) for an introduction. 

To give this version a try, run `npx @connectrpc/connect-migrate@rc`. 

* Fix transform for `createPromiseClient` -> `createClient` in connect-migrate by @paul-sachs in https://github.com/connectrpc/connect-es/pull/1268
* Require HTTP/2 for the gRPC transport by @timostamm in https://github.com/connectrpc/connect-es/pull/1279
* Ensure that a signal exists for a completed RPC by @timostamm in https://github.com/connectrpc/connect-es/pull/1282


**Full Changelog**: https://github.com/connectrpc/connect-es/compare/v2.0.0-beta.2...v2.0.0-rc.1