### PR TITLE
V2: Update makeAnyClient signature to carry type information to narrow down method kinds

### DIFF
--- a/packages/connect/src/any-client.ts
+++ b/packages/connect/src/any-client.ts
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescService, DescMethodUnary, DescMethodStreaming } from "@bufbuild/protobuf";
+import type {
+  DescService,
+  DescMethodUnary,
+  DescMethodStreaming,
+} from "@bufbuild/protobuf";
 
 /**
  * AnyClient is an arbitrary service client with any method signature.
@@ -24,7 +28,9 @@ export type AnyClient = Record<string, AnyClientMethod>;
 
 type AnyClientMethod = (...args: any[]) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-type CreateAnyClientMethod = (method: DescMethodUnary | DescMethodStreaming) => AnyClientMethod | null;
+type CreateAnyClientMethod = (
+  method: DescMethodUnary | DescMethodStreaming,
+) => AnyClientMethod | null;
 
 /**
  * Create any client for the given service.

--- a/packages/connect/src/any-client.ts
+++ b/packages/connect/src/any-client.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescMethod, DescService } from "@bufbuild/protobuf";
+import type { DescService, DescMethodUnary, DescMethodStreaming } from "@bufbuild/protobuf";
 
 /**
  * AnyClient is an arbitrary service client with any method signature.
@@ -24,7 +24,7 @@ export type AnyClient = Record<string, AnyClientMethod>;
 
 type AnyClientMethod = (...args: any[]) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-type CreateAnyClientMethod = (method: DescMethod) => AnyClientMethod | null;
+type CreateAnyClientMethod = (method: DescMethodUnary | DescMethodStreaming) => AnyClientMethod | null;
 
 /**
  * Create any client for the given service.

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -53,23 +53,20 @@ export function createClient<T extends DescService>(
   service: T,
   transport: Transport,
 ) {
-  return makeAnyClient(
-    service,
-    (method) => {
-      switch (method.methodKind) {
-        case "unary":
-          return createUnaryFn(transport, method);
-        case "server_streaming":
-          return createServerStreamingFn(transport, method);
-        case "client_streaming":
-          return createClientStreamingFn(transport, method);
-        case "bidi_streaming":
-          return createBiDiStreamingFn(transport, method);
-        default:
-          return null;
-      }
-    },
-  ) as Client<T>;
+  return makeAnyClient(service, (method) => {
+    switch (method.methodKind) {
+      case "unary":
+        return createUnaryFn(transport, method);
+      case "server_streaming":
+        return createServerStreamingFn(transport, method);
+      case "client_streaming":
+        return createClientStreamingFn(transport, method);
+      case "bidi_streaming":
+        return createBiDiStreamingFn(transport, method);
+      default:
+        return null;
+    }
+  }) as Client<T>;
 }
 
 /**

--- a/packages/connect/src/promise-client.ts
+++ b/packages/connect/src/promise-client.ts
@@ -20,7 +20,6 @@ import type {
   DescMethodBiDiStreaming,
   DescMethodClientStreaming,
   DescMethodServerStreaming,
-  DescMethodStreaming,
   DescMethodUnary,
 } from "@bufbuild/protobuf";
 import type { Transport } from "./transport.js";
@@ -56,7 +55,7 @@ export function createClient<T extends DescService>(
 ) {
   return makeAnyClient(
     service,
-    (method: DescMethodUnary | DescMethodStreaming) => {
+    (method) => {
       switch (method.methodKind) {
         case "unary":
           return createUnaryFn(transport, method);


### PR DESCRIPTION
Without this change, the `createMethod` argument to makeAnyClient does not have enough type information to narrow down the method kind, which is inconvenient when creating a client.

Also see https://github.com/connectrpc/examples-es/pull/1974#discussion_r1824666343
