### PR TITLE
Support Fastify v5 in @connectrpc/connect-fastify

### DIFF
--- a/.github/workflows/conformance-fastify.yaml
+++ b/.github/workflows/conformance-fastify.yaml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.7.0, 20.17.0, 18.20.4, 18.14.1]
+        # Fastify v5 only supports Node.js v20+
+        node-version: [22.7.0, 20.17.0]
     name: "Node.js ${{ matrix.node-version }}"
     timeout-minutes: 10
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16426,7 +16426,7 @@
         "@bufbuild/protobuf": "^2.2.0",
         "@connectrpc/connect": "2.0.0-rc.2",
         "@connectrpc/connect-node": "2.0.0-rc.2",
-        "fastify": "^4.22.1"
+        "fastify": "^4.22.1 || ^5.1.0"
       }
     },
     "packages/connect-migrate": {
@@ -16465,7 +16465,7 @@
         "@bufbuild/protobuf": "^2.2.0",
         "@connectrpc/connect": "2.0.0-rc.2",
         "@connectrpc/connect-node": "2.0.0-rc.2",
-        "next": "^13.2.4 || ^14.2.5"
+        "next": "^13.2.4 || ^14.2.5 || ^15.0.2"
       }
     },
     "packages/connect-node": {

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "fastify": "^4.22.1",
+    "fastify": "^4.22.1 || ^5.1.0",
     "@connectrpc/connect": "2.0.0-rc.2",
     "@connectrpc/connect-node": "2.0.0-rc.2"
   }


### PR DESCRIPTION
This relaxes the peer dependency constraint on `fastify` to include `^5.1.0`.

Closes https://github.com/connectrpc/connect-es/issues/1250.