### PR TITLE
Upgrade to macos-13

### DIFF
--- a/.github/workflows/conformance-web.yaml
+++ b/.github/workflows/conformance-web.yaml
@@ -25,7 +25,7 @@ jobs:
         include:
           - os: ubuntu-22.04
           - browser: safari
-            os: macos-12
+            os: macos-13
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.browser }} ${{ matrix.client }}"
     timeout-minutes: 10


### PR DESCRIPTION
Fixes https://github.com/connectrpc/connect-es/issues/1298.

The macos-12 image is deprecated for Github Actions. This upgrades to the lowest supported version.