### PR TITLE
Avoid turbo warning when building example

### DIFF
--- a/packages/example/turbo.json
+++ b/packages/example/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build", "generate"],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
>  WARNING  no output files found for task @connectrpc/example#build. Please check your `outputs` key in `turbo.json`
