### PR TITLE
Release `2.0.0-rc.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14662,7 +14662,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.46.0",
@@ -14678,22 +14678,22 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-node": "2.0.0-rc.2"
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-node": "2.0.0-rc.3"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241022.0",
-        "@connectrpc/connect-conformance": "^2.0.0-rc.2",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.3",
         "tsx": "^4.19.2",
         "wrangler": "^3.84.1"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
         "fflate": "^0.8.1",
         "tar-stream": "^3.1.7"
       },
@@ -14710,12 +14710,12 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-conformance": "^2.0.0-rc.2",
-        "@connectrpc/connect-node": "2.0.0-rc.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.3",
+        "@connectrpc/connect-node": "2.0.0-rc.3",
         "@types/express": "^5.0.0",
         "express": "^5.0.1",
         "tsx": "^4.19.2"
@@ -14725,33 +14725,33 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-node": "2.0.0-rc.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-node": "2.0.0-rc.3",
         "express": "^4.18.2 || ^5.0.1"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-conformance": "^2.0.0-rc.2",
-        "@connectrpc/connect-node": "2.0.0-rc.2"
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.3",
+        "@connectrpc/connect-node": "2.0.0-rc.3"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-node": "2.0.0-rc.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-node": "2.0.0-rc.3",
         "fastify": "^4.22.1 || ^5.1.0"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.2",
@@ -14772,28 +14772,28 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-node": "2.0.0-rc.2"
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-node": "2.0.0-rc.3"
       },
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-node": "2.0.0-rc.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-node": "2.0.0-rc.3",
         "next": "^13.2.4 || ^14.2.5 || ^15.0.2"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.0.0-rc.2",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.3",
         "@types/jasmine": "^5.0.0",
         "jasmine": "^5.2.0"
       },
@@ -14802,17 +14802,17 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2"
+        "@connectrpc/connect": "2.0.0-rc.3"
       }
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.46.0",
         "@bufbuild/protoc-gen-es": "^2.2.2",
-        "@connectrpc/connect-conformance": "^2.0.0-rc.2",
+        "@connectrpc/connect-conformance": "^2.0.0-rc.3",
         "@wdio/browserstack-service": "^9.2.8",
         "@wdio/cli": "^9.2.8",
         "@wdio/jasmine-framework": "^9.2.8",
@@ -14822,7 +14822,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2"
+        "@connectrpc/connect": "2.0.0-rc.3"
       }
     },
     "packages/connect-web-bench": {
@@ -14831,7 +14831,7 @@
         "@bufbuild/buf": "^1.46.0",
         "@bufbuild/protobuf": "^2.2.0",
         "@bufbuild/protoc-gen-es": "^2.2.2",
-        "@connectrpc/connect-web": "2.0.0-rc.2",
+        "@connectrpc/connect-web": "2.0.0-rc.3",
         "@types/brotli": "^1.3.4",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
@@ -14843,8 +14843,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect-node": "^2.0.0-rc.2",
-        "@connectrpc/connect-web": "^2.0.0-rc.2",
+        "@connectrpc/connect-node": "^2.0.0-rc.3",
+        "@connectrpc/connect-web": "^2.0.0-rc.3",
         "tsx": "^4.19.2"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-node": "2.0.0-rc.2"
+    "@connectrpc/connect": "2.0.0-rc.3",
+    "@connectrpc/connect-node": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241022.0",
     "wrangler": "^3.84.1",
     "tsx": "^4.19.2",
-    "@connectrpc/connect-conformance": "^2.0.0-rc.2"
+    "@connectrpc/connect-conformance": "^2.0.0-rc.3"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/src/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-rc.2",
+    "@connectrpc/connect": "2.0.0-rc.3",
     "fflate": "^0.8.1",
     "tar-stream": "^3.1.7"
   },

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,9 +32,9 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-rc.2",
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-node": "2.0.0-rc.2",
+    "@connectrpc/connect-conformance": "^2.0.0-rc.3",
+    "@connectrpc/connect": "2.0.0-rc.3",
+    "@connectrpc/connect-node": "2.0.0-rc.3",
     "@types/express": "^5.0.0",
     "express": "^5.0.1",
     "tsx": "^4.19.2"
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "express": "^4.18.2 || ^5.0.1",
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-node": "2.0.0-rc.2"
+    "@connectrpc/connect": "2.0.0-rc.3",
+    "@connectrpc/connect-node": "2.0.0-rc.3"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,14 +31,14 @@
     "node": ">=18.14.1"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-rc.2",
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-node": "2.0.0-rc.2"
+    "@connectrpc/connect-conformance": "^2.0.0-rc.3",
+    "@connectrpc/connect": "2.0.0-rc.3",
+    "@connectrpc/connect-node": "2.0.0-rc.3"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
     "fastify": "^4.22.1 || ^5.1.0",
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-node": "2.0.0-rc.2"
+    "@connectrpc/connect": "2.0.0-rc.3",
+    "@connectrpc/connect-node": "2.0.0-rc.3"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.spec.ts
@@ -118,7 +118,7 @@ plugins:
       expect(bufGenYamlWritten.length).toBe(1);
       expect(bufGenYamlWritten[0]?.yaml).toEqual(`version: v2
 plugins:
-  - remote: buf.build/bufbuild/es:v2.2.0
+  - remote: buf.build/bufbuild/es:v${targetVersionProtobufEs}
     out: src/gen
 `);
     });
@@ -244,7 +244,7 @@ plugins:
       expect(bufGenYamlWritten.length).toBe(1);
       expect(bufGenYamlWritten[0]?.yaml).toEqual(`version: v2
 plugins:
-  - remote: buf.build/connectrpc/query-es:v2.0.0-rc.1
+  - remote: buf.build/connectrpc/query-es:v${targetVersionConnectQuery}
     out: src/gen
 `);
     });

--- a/packages/connect-migrate/src/migrations/v2.0.0.ts
+++ b/packages/connect-migrate/src/migrations/v2.0.0.ts
@@ -34,9 +34,9 @@ import {
 } from "../lib/migrate-bufgenyaml";
 import { writeBufGenYamlFile } from "../lib/bufgenyaml";
 
-export const targetVersionProtobufEs = "2.2.0";
-export const targetVersionConnectEs = "2.0.0-rc.1"; // TODO
-export const targetVersionConnectQuery = "2.0.0-rc.1"; // TODO
+export const targetVersionProtobufEs = "2.2.2";
+export const targetVersionConnectEs = "2.0.0-rc.3"; // TODO
+export const targetVersionConnectQuery = "2.0.0-rc.3"; // TODO
 export const targetVersionConnectPlaywright = "0.5.0"; // TODO
 
 const dependencyMigrations: DependencyMigration[] = [

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
     "next": "^13.2.4 || ^14.2.5 || ^15.0.2",
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-node": "2.0.0-rc.2"
+    "@connectrpc/connect": "2.0.0-rc.3",
+    "@connectrpc/connect-node": "2.0.0-rc.3"
   },
   "devDependencies": {
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-node": "2.0.0-rc.2"
+    "@connectrpc/connect": "2.0.0-rc.3",
+    "@connectrpc/connect-node": "2.0.0-rc.3"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,10 +34,10 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-rc.2"
+    "@connectrpc/connect": "2.0.0-rc.3"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.0-rc.2",
+    "@connectrpc/connect-conformance": "^2.0.0-rc.3",
     "@types/jasmine": "^5.0.0",
     "jasmine": "^5.2.0"
   }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   276,498 b | 176,488 b |   35,716 b |
-| Connect-ES     |    4 |   280,750 b | 179,590 b |   36,547 b |
-| Connect-ES     |    8 |   285,613 b | 184,021 b |   37,458 b |
-| Connect-ES     |   16 |   294,741 b | 191,645 b |   38,978 b |
+| Connect-ES     |    1 |   276,498 b | 176,488 b |   35,800 b |
+| Connect-ES     |    4 |   280,750 b | 179,590 b |   36,545 b |
+| Connect-ES     |    8 |   285,613 b | 184,021 b |   37,486 b |
+| Connect-ES     |   16 |   294,741 b | 191,645 b |   38,989 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.85117187499998 140,186.49775390625 280,183.9177734375 420,179.6130859375">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.61328125 140,186.50341796875 280,183.83847656249998 420,179.58193359375002">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="188.85117187499998" r="4" fill="#ffa600"><title>Connect-ES 34.88 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="186.49775390625" r="4" fill="#ffa600"><title>Connect-ES 35.69 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="183.9177734375" r="4" fill="#ffa600"><title>Connect-ES 36.58 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="179.6130859375" r="4" fill="#ffa600"><title>Connect-ES 38.06 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="188.61328125" r="4" fill="#ffa600"><title>Connect-ES 34.96 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="186.50341796875" r="4" fill="#ffa600"><title>Connect-ES 35.69 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="183.83847656249998" r="4" fill="#ffa600"><title>Connect-ES 36.61 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="179.58193359375002" r="4" fill="#ffa600"><title>Connect-ES 38.08 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -13,7 +13,7 @@
     "@bufbuild/buf": "^1.46.0",
     "@bufbuild/protobuf": "^2.2.0",
     "@bufbuild/protoc-gen-es": "^2.2.2",
-    "@connectrpc/connect-web": "2.0.0-rc.2",
+    "@connectrpc/connect-web": "2.0.0-rc.3",
     "@types/brotli": "^1.3.4",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.46.0",
     "@bufbuild/protoc-gen-es": "^2.2.2",
-    "@connectrpc/connect-conformance": "^2.0.0-rc.2",
+    "@connectrpc/connect-conformance": "^2.0.0-rc.3",
     "@wdio/browserstack-service": "^9.2.8",
     "@wdio/cli": "^9.2.8",
     "@wdio/jasmine-framework": "^9.2.8",
@@ -52,6 +52,6 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect": "2.0.0-rc.2"
+    "@connectrpc/connect": "2.0.0-rc.3"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.0",
-    "@connectrpc/connect-node": "^2.0.0-rc.2",
-    "@connectrpc/connect-web": "^2.0.0-rc.2",
+    "@connectrpc/connect-node": "^2.0.0-rc.3",
+    "@connectrpc/connect-web": "^2.0.0-rc.3",
     "tsx": "^4.19.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's Changed

This is a release candidate for version 2. See [here](https://github.com/connectrpc/connect-es/releases/tag/v2.0.0-alpha.1) for an introduction. 

* Update makeAnyClient signature to carry type information to narrow down method kinds by @timostamm in https://github.com/connectrpc/connect-es/pull/1292
* Support Express v5 in @connectrpc/connect-fastify by @timostamm in https://github.com/connectrpc/connect-es/pull/1297
* Support Fastify v5 in @connectrpc/connect-fastify by @timostamm in https://github.com/connectrpc/connect-es/pull/1296


**Full Changelog**: https://github.com/connectrpc/connect-es/compare/v2.0.0-rc.2...v2.0.0-rc.3