### PR TITLE
Allow MSW to intercept connect-node client HTTP-requests

### DIFF
--- a/packages/connect-node/README.md
+++ b/packages/connect-node/README.md
@@ -84,7 +84,7 @@ export default function (router: ConnectRouter) {
 
 ```diff
 // server.ts
-import * as http2 from "http2";
+import http2 from "node:http2";
 + import routes from "connect";
 + import { connectNodeAdapter } from "@connectrpc/connect-node";
 

--- a/packages/connect-node/conformance/server.ts
+++ b/packages/connect-node/conformance/server.ts
@@ -18,9 +18,9 @@ import {
   compressionGzip,
   connectNodeAdapter,
 } from "../src/index.js";
-import * as http from "node:http";
-import * as http2 from "node:http2";
-import * as https from "node:https";
+import http from "node:http";
+import http2 from "node:http2";
+import https from "node:https";
 import * as net from "node:net";
 import { createRegistry } from "@bufbuild/protobuf";
 import {

--- a/packages/connect-node/conformance/transport.ts
+++ b/packages/connect-node/conformance/transport.ts
@@ -33,7 +33,7 @@ import {
   createGrpcWebTransport,
 } from "../src/index.js";
 import type { Compression } from "@connectrpc/connect/protocol";
-import * as http2 from "node:http2";
+import http2 from "node:http2";
 
 /**
  * Configure a transport for a client from @connectrpc/connect-node under test.

--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { useNodeServer } from "./use-node-server-helper.spec.js";
-import * as http2 from "http2";
+import http2 from "node:http2";
 import { Http2SessionManager } from "./http2-session-manager.js";
 import { ConnectError } from "@connectrpc/connect";
 import { Worker } from "worker_threads";

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as http2 from "http2";
+import http2 from "node:http2";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { connectErrorFromNodeReason } from "./node-error.js";
 

--- a/packages/connect-node/src/node-readme.spec.ts
+++ b/packages/connect-node/src/node-readme.spec.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as http2 from "http2";
+import http2 from "node:http2";
 import { Message, MethodKind, proto3 } from "@bufbuild/protobuf";
 import type { PartialMessage } from "@bufbuild/protobuf";
 import {

--- a/packages/connect-node/src/node-transport-options.ts
+++ b/packages/connect-node/src/node-transport-options.ts
@@ -22,9 +22,9 @@ import { createNodeHttpClient } from "./node-universal-client.js";
 import type { NodeHttp2ClientSessionManager } from "./node-universal-client.js";
 import { Http2SessionManager } from "./http2-session-manager.js";
 import type { Http2SessionOptions } from "./http2-session-manager.js";
-import * as http2 from "http2";
-import * as http from "http";
-import * as https from "https";
+import http2 from "node:http2";
+import http from "node:http";
+import https from "node:https";
 
 /**
  * Options specific to Node.js client transports.

--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as http2 from "http2";
-import * as http from "http";
+import http2 from "node:http2";
+import http from "node:http";
 import { ConnectError } from "@connectrpc/connect";
 import { createAsyncIterable } from "@connectrpc/connect/protocol";
 import { createNodeHttpClient } from "./node-universal-client.js";

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as http2 from "http2";
-import * as http from "http";
-import * as https from "https";
+import http2 from "node:http2";
+import http from "node:http";
+import https from "node:https";
 import type * as net from "net";
 import { Code, ConnectError } from "@connectrpc/connect";
 import {

--- a/packages/connect-node/src/node-universal-handler.spec.ts
+++ b/packages/connect-node/src/node-universal-handler.spec.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import { useNodeServer } from "./use-node-server-helper.spec.js";
-import * as http2 from "http2";
-import * as http from "http";
+import http2 from "node:http2";
+import http from "node:http";
 import { universalRequestFromNodeRequest } from "./node-universal-handler.js";
 import { ConnectError } from "@connectrpc/connect";
 import { getNodeErrorProps } from "./node-error.js";

--- a/packages/connect-node/src/node-universal-handler.ts
+++ b/packages/connect-node/src/node-universal-handler.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type * as http from "http";
-import type * as http2 from "http2";
+import type * as http from "node:http";
+import type * as http2 from "node:http2";
 import type * as stream from "stream";
 import type { JsonValue } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";

--- a/packages/connect-node/src/node-universal-header.spec.ts
+++ b/packages/connect-node/src/node-universal-header.spec.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as http from "http";
+import http from "node:http";
 import {
   nodeHeaderToWebHeader,
   webHeaderToNodeHeaders,

--- a/packages/connect-node/src/node-universal-header.ts
+++ b/packages/connect-node/src/node-universal-header.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type * as http from "http";
-import type * as http2 from "http2";
+import type * as http from "node:http";
+import type * as http2 from "node:http2";
 
 /**
  * Convert a Node.js header object to a fetch API Headers object.

--- a/packages/connect-node/src/testdata/http2-session-manager-verify-ping.ts
+++ b/packages/connect-node/src/testdata/http2-session-manager-verify-ping.ts
@@ -15,7 +15,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-floating-promises */
 
 import { Http2SessionManager } from "../http2-session-manager.js";
-import * as http2 from "http2";
+import http2 from "node:http2";
 import { parentPort, workerData } from "worker_threads";
 
 const sm = new Http2SessionManager(workerData, {

--- a/packages/connect-node/src/transport.spec.ts
+++ b/packages/connect-node/src/transport.spec.ts
@@ -15,7 +15,7 @@
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
 import { Int32Value, StringValue, MethodKind } from "@bufbuild/protobuf";
 import { useNodeServer } from "./use-node-server-helper.spec.js";
-import * as http2 from "node:http2";
+import http2 from "node:http2";
 import { connectNodeAdapter } from "./connect-node-adapter.js";
 import { createClient } from "@connectrpc/connect";
 import type { Transport } from "@connectrpc/connect";

--- a/packages/connect-node/src/use-node-server-helper.spec.ts
+++ b/packages/connect-node/src/use-node-server-helper.spec.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as http2 from "http2";
-import * as http from "http";
-import * as https from "https";
+import http2 from "node:http2";
+import http from "node:http";
+import https from "node:https";
 import type { UniversalClientFn } from "@connectrpc/connect/protocol";
 import { Http2SessionManager } from "./http2-session-manager.js";
 import { createNodeHttpClient } from "./node-universal-client.js";


### PR DESCRIPTION
MSW library can't patch `node:http`, `https` and `http2` modules if they are imported with `* as` or named import syntax (https://github.com/mswjs/msw/issues/2049)

To allow mocking `connect-node` HTTP requests, we can use default imports.

So this PR replaces:
```js
import * as http from "http";
import * as https from "https";
import * as http2 from "http2";
```
with
```js
import http from "node:http";
import https from "node:https";
import http2 from "node:http2";
```
