### PR TITLE
Fix toBinary example in MIGRATING.md

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -203,7 +203,7 @@ import { toBinary } from "@bufbuild/protobuf";
 import { SayRequestSchema } from "./gen/eliza_pb";
 
 - sayRequest.toBinary();
-+ toBinary(sayRequest, SayRequestSchema);
++ toBinary(SayRequestSchema, sayRequest);
 ```
 
 The same applies to the methods `equals`, `clone`, `toJson`, and `toJsonString`,


### PR DESCRIPTION
toBinary is declared as 
```typescript
export declare function toBinary<Desc extends DescMessage>(schema: Desc, message: MessageShape<Desc>, options?: Partial<BinaryWriteOptions>): Uint8Array;
```