### PR TITLE
export functions in normalize.ts

### DIFF
--- a/packages/connect/src/protocol/index.ts
+++ b/packages/connect/src/protocol/index.ts
@@ -114,3 +114,4 @@ export {
 export type { UniversalHandlerOptions } from "./universal-handler.js";
 export type { ProtocolHandlerFactory } from "./protocol-handler-factory.js";
 export type { CommonTransportOptions } from "./transport-options.js";
+export { normalize, normalizeIterable } from "./normalize.js";


### PR DESCRIPTION
export functions in normalize.ts for third-party developer

Hi. Team. I am developing a [connect client for Weixin Miniprogram](https://github.com/wangcheng/connect-miniprogram). It uses a special JS runtime that doesn't support `fetch` and and `AbortSignal`. I have to port the logic to adapt to its own fetching function. 

Since I don't have `AbortSignal` I decided to drop signal support and not use functions in `run-call`. That means I need to use functions in `normalize` directly. Now I just copied the code to my repo like [this](https://github.com/wangcheng/connect-miniprogram/blob/main/packages/connect-miniprogram/src/connect-wx/grpc-web-transport-wx.ts#L243).

I think it will be convenient to export them for third-party developer like me. Or do the team have a better suggestions for how to implement a client on runtimes that don't support `fetch` and `AbortSignal`?