### PR TITLE
Add additional options for generating imports

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -162,7 +162,7 @@ way your project is configured. For example, `npx buf generate` or `npm run gene
 >
 > - `include_imports: true`
 
-See the [Gotchas](#missing-imports) section for an explanation.
+See the [Gotchas](#the-new-plugins-generates-missing-imports) section for an explanation.
 
 ## Update your application code
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -73,6 +73,8 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: src/gen
+    include_wkt: true
+    include_imports: true
     opt: target=ts
 - - local: protoc-gen-connect-es
 -   out: src/gen
@@ -88,6 +90,8 @@ plugins:
 - - remote: buf.build/bufbuild/es:v1.10.0
 + - remote: buf.build/bufbuild/es:v2.2.0
     out: src/gen
+    include_wkt: true
+    include_imports: true
     opt: target=ts
 - - remote: buf.build/connectrpc/es
 -   out: src/gen
@@ -108,6 +112,8 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: src/gen
+    include_wkt: true
+    include_imports: true
 ```
 
 With this option, `buf generate` will delete the contents of `src/gen` before generating code.
@@ -123,6 +129,8 @@ version: v2
 plugins:
  - local: protoc-gen-es
    out: src/gen
+   include_wkt: true
+   include_imports: true
    opt:
      - target=ts
 +    - import_extension=js
@@ -137,6 +145,8 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: src/gen
+    include_wkt: true
+    include_imports: true
     opt:
       - target=ts
 -     - import_extension=none
@@ -150,6 +160,15 @@ as well - it's the default behavior now.
 Now that dependencies and `buf.gen.yaml` are updated, the next step is to re-generate code. The
 migration tool does not handle code generation, so be sure to do so in whatever
 way your project is configured. For example, `npx buf generate` or `npm run generate`.
+
+> [!NOTE]
+> Ensure that your `buf.gen.yaml` includes the following options to generate
+> code for well-known types and imports.
+> `include_wkt: true`
+> `include_imports: true`
+
+See the [Gotchas](#missing-imports) section for an explanation.
+
 
 ## Update your application code
 
@@ -709,7 +728,7 @@ Make sure to update your imports to the new package name and file names:
 
 ## Gotchas
 
-### The new plugins generates missing imports
+### The new plugins generates missing imports <a id="missing-imports"></a>
 
 Because Protobuf-ES supports custom options and other reflection-based features now, generated code includes more
 information than in the previous version, and will generate additional imports in some situations.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -159,7 +159,8 @@ way your project is configured. For example, `npx buf generate` or `npm run gene
 > [!NOTE]
 > Ensure that your `buf.gen.yaml` includes the following options to generate
 > code for imports.
-> * `include_imports: true`
+>
+> - `include_imports: true`
 
 See the [Gotchas](#missing-imports) section for an explanation.
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -722,7 +722,7 @@ Make sure to update your imports to the new package name and file names:
 
 ## Gotchas
 
-### The new plugins generates missing imports <a id="missing-imports"></a>
+### The new plugins generates missing imports
 
 Because Protobuf-ES supports custom options and other reflection-based features now, generated code includes more
 information than in the previous version, and will generate additional imports in some situations.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -73,7 +73,6 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: src/gen
-    include_wkt: true
     include_imports: true
     opt: target=ts
 - - local: protoc-gen-connect-es
@@ -90,7 +89,6 @@ plugins:
 - - remote: buf.build/bufbuild/es:v1.10.0
 + - remote: buf.build/bufbuild/es:v2.2.0
     out: src/gen
-    include_wkt: true
     include_imports: true
     opt: target=ts
 - - remote: buf.build/connectrpc/es
@@ -112,7 +110,6 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: src/gen
-    include_wkt: true
     include_imports: true
 ```
 
@@ -129,7 +126,6 @@ version: v2
 plugins:
  - local: protoc-gen-es
    out: src/gen
-   include_wkt: true
    include_imports: true
    opt:
      - target=ts
@@ -145,7 +141,6 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: src/gen
-    include_wkt: true
     include_imports: true
     opt:
       - target=ts
@@ -163,12 +158,10 @@ way your project is configured. For example, `npx buf generate` or `npm run gene
 
 > [!NOTE]
 > Ensure that your `buf.gen.yaml` includes the following options to generate
-> code for well-known types and imports.
-> `include_wkt: true`
-> `include_imports: true`
+> code for imports.
+> * `include_imports: true`
 
 See the [Gotchas](#missing-imports) section for an explanation.
-
 
 ## Update your application code
 


### PR DESCRIPTION
Including imports is not enabled by default in the Buf CLI. As a result, users have been getting tripped up on generating code when they have dependencies on protovalidate.

This adds some additional guidance in our generating code docs to make sure they include imports since these should essentially always be included when generating with Protobuf-ES.