### PR TITLE
Ensure any error metadata is appended to target grpc response

### DIFF
--- a/packages/connect/src/protocol-grpc/trailer-status.spec.ts
+++ b/packages/connect/src/protocol-grpc/trailer-status.spec.ts
@@ -63,6 +63,36 @@ describe("setTrailerStatus()", function () {
       "CAgSDHNvaXLDqWUg8J+OiRo0Ci50eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5wcm90b2J1Zi5JbnQzMlZhbHVlEgIIew",
     );
   });
+  it("should append any error metadata", function () {
+    const t = new Headers();
+    setTrailerStatus(
+      t,
+      new ConnectError("soirée 🎉", Code.ResourceExhausted, { foo: "bar" }),
+    );
+    let count = 0;
+    t.forEach(() => count++);
+    expect(count).toBe(3);
+    expect(t.get("grpc-status")).toBe("8"); // resource_exhausted
+    expect(t.get("grpc-message")).toBe("soir%C3%A9e%20%F0%9F%8E%89");
+    expect(t.get("foo")).toBe("bar");
+  });
+  it("should overwrite error metadata that uses reserved protocol headers", function () {
+    const t = new Headers();
+    setTrailerStatus(
+      t,
+      new ConnectError("soirée 🎉", Code.ResourceExhausted, {
+        foo: "bar",
+        "grpc-status": "foo-status",
+        "grpc-message": "foo-message",
+      }),
+    );
+    let count = 0;
+    t.forEach(() => count++);
+    expect(count).toBe(3);
+    expect(t.get("grpc-status")).toBe("8"); // resource_exhausted
+    expect(t.get("grpc-message")).toBe("soir%C3%A9e%20%F0%9F%8E%89");
+    expect(t.get("foo")).toBe("bar");
+  });
 });
 
 describe("findTrailerError()", function () {

--- a/packages/connect/src/protocol-grpc/trailer-status.ts
+++ b/packages/connect/src/protocol-grpc/trailer-status.ts
@@ -46,6 +46,13 @@ export function setTrailerStatus(
   error: ConnectError | undefined,
 ): Headers {
   if (error) {
+    // Copy any metadata specified in the error into the target Headers
+    // Note that if a protocol header happens to be specified in metadata, it
+    // its value will be overridden below by the official protocol headers.
+    error.metadata.forEach((value, key) => {
+      target.append(key, value);
+    });
+
     target.set(headerGrpcStatus, error.code.toString(10));
     target.set(headerGrpcMessage, encodeURIComponent(error.rawMessage));
     if (error.details.length > 0) {


### PR DESCRIPTION
Fixes #1406 

This ensures that any error metadata set in the server is returned as part of the error metadata in the response for the gRPC transport.