### PR TITLE
Only run browserstack tests if credentials are present

### DIFF
--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Check credentials
         id: credentials
         shell: bash
-        run: (test -n "${BROWSERSTACK_USERNAME}" && echo present=1 || echo present=0) >> $GITHUB_OUTPUT
+        run: (test -n "${BROWSERSTACK_USERNAME_XXX}" && echo present=1 || echo present=0) >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: (steps.credentials.outputs.present == '1')
       - uses: actions/setup-node@v4

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -17,9 +17,10 @@ env:
 
 jobs:
   browserstack:
-    name: "Test @connectrpc/connect-web"
+    name: "Test @connectrpc/connect-web on Browserstack"
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: ${{ secrets.BROWSERSTACK_USERNAME != '' && secrets.BROWSERSTACK_ACCESS_KEY != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Check credentials
         id: credentials
         shell: bash
-        run: (test -n "${BROWSERSTACK_USERNAME_XXX}" && echo present=1 || echo present=0) >> $GITHUB_OUTPUT
+        run: (test -n "${BROWSERSTACK_USERNAME}" && echo present=1 || echo present=0) >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: (steps.credentials.outputs.present == '1')
       - uses: actions/setup-node@v4

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Check credentials
         id: credentials
         shell: bash
-        run: (test -n "${BROWSERSTACK_USERNAME}" && echo present=1 || echo present=0) >> >> $GITHUB_OUTPUT
+        run: (test -n "${BROWSERSTACK_USERNAME}" && echo present=1 || echo present=0) >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: (steps.credentials.outputs.present == '1')
       - uses: actions/setup-node@v4

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -20,7 +20,7 @@ jobs:
     name: "Test @connectrpc/connect-web on Browserstack"
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    if: ${{ secrets.BROWSERSTACK_USERNAME != '' && secrets.BROWSERSTACK_ACCESS_KEY != '' }}
+    if: secrets.BROWSERSTACK_USERNAME != '' && secrets.BROWSERSTACK_ACCESS_KEY != ''
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Check credentials
         id: credentials
         shell: bash
+        # Job and step conditions do not have access to secrets or the environment.
+        # This step makes presence of the browserstack credentials available as a step output.
         run: (test -n "${BROWSERSTACK_USERNAME}" && echo present=1 || echo present=0) >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: (steps.credentials.outputs.present == '1')

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -20,21 +20,29 @@ jobs:
     name: "Test @connectrpc/connect-web on Browserstack"
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    if: secrets.BROWSERSTACK_USERNAME != '' && secrets.BROWSERSTACK_ACCESS_KEY != ''
+    env:
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
+      - name: Check credentials
+        id: credentials
+        shell: bash
+        run: (test -n "${BROWSERSTACK_USERNAME}" && echo present=1 || echo present=0) >> >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
+        if: (steps.credentials.outputs.present == '1')
       - uses: actions/setup-node@v4
+        if: (steps.credentials.outputs.present == '1')
         with:
           node-version-file: .nvmrc
       - uses: actions/cache@v4
+        if: (steps.credentials.outputs.present == '1')
         with:
           path: .turbo
           key: ${{ runner.os }}/browserstack/${{ github.sha }}
           restore-keys: ${{ runner.os }}/browserstack
       - name: NPM Install
+        if: (steps.credentials.outputs.present == '1')
         run: npm ci
       - name: Browserstack
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        if: (steps.credentials.outputs.present == '1')
         run: npx turbo run test-browserstack --output-logs new-only --log-order stream


### PR DESCRIPTION
This disables the Browserstack workflow if Browserstack credentials are not present.

The credentials are never present in contributor PRs, the workflow will always fail, and potentially shadow other issues. 

Skipping the tests is clearly not ideal. The tests will run when merging to main and before release, so this seems like a viable compromise.