### PR TITLE
Reduce the number of browser versions tested on Browserstack

### DIFF
--- a/packages/connect-web/browserstack/wdio.browserstack.conf.js
+++ b/packages/connect-web/browserstack/wdio.browserstack.conf.js
@@ -41,7 +41,7 @@ export const config = {
         args: ["--headless", "--disable-gpu"],
       },
     },
-     {
+    {
       browserName: "Safari",
       "bstack:options": {
         os: "OS X",


### PR DESCRIPTION
Our tests on Browserstack are flaky. The most common cause appears to be that we're frequently exceeding the permitted number of parallel tests. To mitigate, this disables 5 of 8 browser versions tested on Browserstack. This is a compromise, but we keep testing the oldest browser versions.