### PR TITLE
Run conformance tests for @connectrpc/connect-web only on Node.js

### DIFF
--- a/.github/workflows/conformance-web.yaml
+++ b/.github/workflows/conformance-web.yaml
@@ -16,32 +16,7 @@ env:
   DO_NOT_TRACK: 1
 
 jobs:
-  browser:
-    strategy:
-      fail-fast: false
-      matrix:
-        browser: [chrome, safari, firefox]
-        client: [promise, callback]
-        include:
-          - os: ubuntu-22.04
-          - browser: safari
-            os: macos-13
-    runs-on: ${{ matrix.os }}
-    name: "${{ matrix.browser }} ${{ matrix.client }}"
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: "npm"
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}/web-conformance/${{ github.sha }}
-          restore-keys: ${{ runner.os }}/web-conformance
-      - run: npm ci
-      - run: npx turbo run conformance:${{matrix.browser}}:${{matrix.client}} --filter '@connectrpc/connect-web' --output-logs new-only --log-order stream
+  # Conformance tests for @connectrpc/connect-web clients run only on Node.js in CI
   node:
     runs-on: ubuntu-22.04
     strategy:

--- a/packages/connect-web/conformance/README.md
+++ b/packages/connect-web/conformance/README.md
@@ -6,12 +6,14 @@ It uses the [conformance runner](https://github.com/connectrpc/conformance/relea
 
 ## Running conformance tests
 
-Tests run in the following environments:
+Tests can run in the following environments:
 
 - Chrome
 - Firefox
 - Safari (only if running in OSX. Safari requires users to enable the "Allow Remote Automation" option in Safari's Develop menu)
 - Node.js
+
+Browsers are instrumented with [webdriverio](https://webdriver.io/).
 
 For every environment, two client flavors are available:
 
@@ -21,6 +23,8 @@ For every environment, two client flavors are available:
 For every combination, a task is available:
 
 `npx turbo run conformance:<chrome|firefox|safari|node>:<promise|callback>`
+
+Note tests only run on Node.js in CI, or with the `conformance` task.
 
 ## Using a local browser
 

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -12,7 +12,6 @@
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",
-    "conformance:safari": "npm run conformance:safari:promise && npm run conformance:client:safari:callback",
     "conformance:safari:promise": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser safari",
     "conformance:safari:callback": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser safari --useCallbackClient",
     "conformance:chrome:promise": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser chrome",

--- a/packages/connect-web/turbo.json
+++ b/packages/connect-web/turbo.json
@@ -13,10 +13,6 @@
     "conformance": {
       "dependsOn": ["conformance:node:promise", "conformance:node:callback"]
     },
-    "conformance:safari": {
-      "cache": false,
-      "dependsOn": ["^build"]
-    },
     "conformance:safari:promise": {
       "cache": false,
       "dependsOn": ["^build"]


### PR DESCRIPTION
We're using [webdriverio](https://webdriver.io/) to instrument browsers for Connect conformance tests. These tests have been flaky. 

Looking at workflow runs from the past two months, there have been timeouts with all browsers under tests (Chrome, Safari, Firefox). The timeouts are frequent enough to affect every other PR. The timeouts happen on browsers start-up or IPC with the browser, not while running tests. So it appears that there is a deficiency in webdriverio, or the way we're using it. 

As a practical solution, this PR proposes to run conformance tests for @connectrpc/connect-web exclusively on Node.js, where they have been running stable so far. Considering that the fetch implementation in Node.js is well tested, this seems acceptable.
