### PR TITLE
Support Node.js http.ClientRequestArgs["headers"] array

### DIFF
--- a/packages/connect-node/src/node-universal-header.spec.ts
+++ b/packages/connect-node/src/node-universal-header.spec.ts
@@ -145,6 +145,7 @@ describe("webHeaderToNodeHeaders()", () => {
     });
   });
   it("should accept default node headers array", () => {
+    // biome-ignore format: headers array is contiguous
     const nodeDefaults: string[] = [
       "a", "a",
       "b", "b1",

--- a/packages/connect-node/src/node-universal-header.spec.ts
+++ b/packages/connect-node/src/node-universal-header.spec.ts
@@ -144,4 +144,25 @@ describe("webHeaderToNodeHeaders()", () => {
       d: ["d1", "d2"],
     });
   });
+  it("should accept default node headers array", () => {
+    const nodeDefaults: string[] = [
+      "a", "a",
+      "b", "b1",
+      "b", "b2",
+      "c", "123",
+    ];
+    const webHeaders: HeadersInit = [
+      ["b", "web"],
+      ["c", "456"],
+      ["d", "d1"],
+      ["d", "d2"],
+    ];
+    const h = webHeaderToNodeHeaders(webHeaders, nodeDefaults);
+    expect(h).toEqual({
+      a: "a",
+      b: ["b1", "b2", "web"],
+      c: ["123", "456"],
+      d: ["d1", "d2"],
+    });
+  });
 });


### PR DESCRIPTION
With the latest `@types/node`, the `headers` property of `http.ClientRequestArgs` is changing from  `http.OutgoingHttpHeaders` to `http.OutgoingHttpHeaders | string[]`. 

Because we're accepting `http.ClientRequestArgs` in client transport options, and pass them to our function `webHeaderToNodeHeaders()`, we have to support the `string[]` variant in this function. 

This PR implements the support. It should fix CI failures in https://github.com/connectrpc/connect-es/pull/1499.