### PR TITLE
Special case TimeoutError in ConnectError.from

### DIFF
--- a/packages/connect/src/connect-error.spec.ts
+++ b/packages/connect/src/connect-error.spec.ts
@@ -155,6 +155,20 @@ describe("ConnectError", () => {
       expect(got.rawMessage).toBe("Not permitted");
       expect(got.cause).toBe(error);
     });
+    it("wraps AbortError with code canceled", () => {
+      // abort() on AbortSignal aborts with a AbortError
+      const error: unknown = new DOMException("foo", "AbortError");
+      const got = ConnectError.from(error);
+      expect(got.code).toBe(Code.Canceled);
+      expect(got.rawMessage).toBe("foo");
+    });
+    it("wraps TimeoutError with code canceled", () => {
+      // AbortSignal.timeout() aborts with a TimeoutError
+      const error: unknown = new DOMException("foo", "TimeoutError");
+      const got = ConnectError.from(error);
+      expect(got.code).toBe(Code.Canceled);
+      expect(got.rawMessage).toBe("foo");
+    });
   });
   describe("instanceof", () => {
     it("works for the actual ConnectError", () => {

--- a/packages/connect/src/connect-error.ts
+++ b/packages/connect/src/connect-error.ts
@@ -102,8 +102,8 @@ export class ConnectError extends Error {
    * Convert any value - typically a caught error into a ConnectError,
    * following these rules:
    * - If the value is already a ConnectError, return it as is.
-   * - If the value is an AbortError from the fetch API, return the message
-   *   of the AbortError with code Canceled.
+   * - If the value is an AbortError or TimeoutError from the fetch API, return
+   *   the message of the error with code Canceled.
    * - For other Errors, return the error message with code Unknown by default.
    * - For other values, return the values String representation as a message,
    *   with the code Unknown by default.
@@ -115,10 +115,9 @@ export class ConnectError extends Error {
       return reason;
     }
     if (reason instanceof Error) {
-      if (reason.name == "AbortError") {
-        // Fetch requests can only be canceled with an AbortController.
-        // We detect that condition by looking at the name of the raised
-        // error object, and translate to the appropriate status code.
+      if (reason.name == "AbortError" || reason.name == "TimeoutError") {
+        // Fetch requests can only be canceled with an AbortController,
+        // or with AbortSignal.timeout().
         return new ConnectError(reason.message, Code.Canceled);
       }
       return new ConnectError(


### PR DESCRIPTION
To abort an RPC, you pass an AbortSignal in the call options. 

Usually, this is done by creating an AbortController, passing the controller's signal to the call options, and calling AbortController.abort() when necessary. The raised AbortError is automatically converted to the Connect error code `canceled`. 

Alternatively it is also possible to create an AbortSignal via AbortSignal.timeout(). The signal will automatically abort after a specified time, with a TimeoutError. This error is currently converted to the Connect error code `unknown`, but it should be code `canceled`, same as with an AbortController.

This PR updates the behavior, closing https://github.com/connectrpc/connect-es/issues/1453.

Note that it is not recommended to use AbortSignal.timeout() with RPCs, because the timeout cannot be propagated to the server. Instead, use the `timeoutMs` option ([documentation](https://connectrpc.com/docs/web/cancellation-and-timeouts#timeouts)).
