### PR TITLE
Optimize envelope decoding

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   279,002 b | 177,602 b |   35,928 b |
-| Connect-ES     |    4 |   283,254 b | 180,704 b |   36,717 b |
-| Connect-ES     |    8 |   288,117 b | 185,135 b |   37,672 b |
-| Connect-ES     |   16 |   297,245 b | 192,762 b |   39,185 b |
+| Connect-ES     |    1 |   280,662 b | 178,362 b |   36,175 b |
+| Connect-ES     |    4 |   284,914 b | 181,464 b |   36,913 b |
+| Connect-ES     |    8 |   289,777 b | 185,895 b |   37,860 b |
+| Connect-ES     |   16 |   298,905 b | 193,522 b |   39,382 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,188.25078125 140,186.01630859375 280,183.31171875 420,179.02685546875">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,187.55126953125 140,185.46123046875 280,182.779296875 420,178.4689453125">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="188.25078125" r="4" fill="#ffa600"><title>Connect-ES 35.09 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="186.01630859375" r="4" fill="#ffa600"><title>Connect-ES 35.86 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="183.31171875" r="4" fill="#ffa600"><title>Connect-ES 36.79 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="179.02685546875" r="4" fill="#ffa600"><title>Connect-ES 38.27 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="187.55126953125" r="4" fill="#ffa600"><title>Connect-ES 35.33 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="185.46123046875" r="4" fill="#ffa600"><title>Connect-ES 36.05 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="182.779296875" r="4" fill="#ffa600"><title>Connect-ES 36.97 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="178.4689453125" r="4" fill="#ffa600"><title>Connect-ES 38.46 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">


### PR DESCRIPTION
This adds the internal type `EnvelopeDecoder`. It decodes a stream of raw byte chunks into enveloped messages. 

It allocates a single ArrayBuffer for envelope headers (always 5 bytes), and allocates an ArrayBuffer with the size of the enveloped message as soon as the size is known. Incoming chunks are buffered in a regular array, and copied to the allocated ArrayBuffer once complete.

This new type is used in `transformSplitEnvelope()` (Node.js) and `createEnvelopeReadableStream()` (Web), consolidating the logic.

Compared to the current approach, this avoids allocating a new buffer each time a chunk comes in, noticeably increasing envelope decoding performance.

Closes https://github.com/connectrpc/connect-es/issues/1333
