### PR TITLE
Update Node.js versions running in CI

### DIFF
--- a/.github/workflows/conformance-express.yaml
+++ b/.github/workflows/conformance-express.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.7.0, 20.17.0, 18.20.4, 18.14.1]
+        node-version: [24.x, 22.x, 20.x]
     name: "Node.js ${{ matrix.node-version }}"
     timeout-minutes: 10
     steps:

--- a/.github/workflows/conformance-fastify.yaml
+++ b/.github/workflows/conformance-fastify.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # Fastify v5 only supports Node.js v20+
-        node-version: [22.7.0, 20.17.0]
+        node-version: [24.x, 22.x, 20.x]
     name: "Node.js ${{ matrix.node-version }}"
     timeout-minutes: 10
     steps:

--- a/.github/workflows/conformance-node.yaml
+++ b/.github/workflows/conformance-node.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.7.0, 20.17.0, 18.20.4, 18.14.1]
+        node-version: [24.x, 22.x, 20.x]
         side: [client, server]
     name: "Node.js ${{ matrix.node-version }} ${{ matrix.side }}"
     timeout-minutes: 10

--- a/.github/workflows/conformance-web.yaml
+++ b/.github/workflows/conformance-web.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [22.7.0, 20.17.0, 18.20.4, 18.14.1]
+        node-version: [24.x, 22.x, 20.x]
         client: [promise, callback]
     name: "Node.js ${{ matrix.node-version }} ${{ matrix.client }}"
     timeout-minutes: 10


### PR DESCRIPTION
As a follow-up to https://github.com/connectrpc/connect-es/pull/1548 and https://github.com/connectrpc/connect-es/pull/1559, this updates more workflows to run in the same versions of Node.js as the main workflow "CI".