### PR TITLE
Release 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12703,7 +12703,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.56.0",
@@ -12719,22 +12719,22 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.0.4",
-        "@connectrpc/connect-node": "2.0.4"
+        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect-node": "2.1.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250801.0",
-        "@connectrpc/connect-conformance": "^2.0.4",
+        "@connectrpc/connect-conformance": "^2.1.0",
         "tsx": "^4.20.4",
         "wrangler": "^4.29.1"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.0.4",
+        "@connectrpc/connect": "2.1.0",
         "fflate": "^0.8.2",
         "tar-stream": "^3.1.7"
       },
@@ -12751,12 +12751,12 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.4",
-        "@connectrpc/connect-conformance": "^2.0.4",
-        "@connectrpc/connect-node": "2.0.4",
+        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect-conformance": "^2.1.0",
+        "@connectrpc/connect-node": "2.1.0",
         "@types/express": "^5.0.3",
         "express": "^5.1.0",
         "tsx": "^4.20.4"
@@ -12766,33 +12766,33 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.0.4",
-        "@connectrpc/connect-node": "2.0.4",
+        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect-node": "2.1.0",
         "express": "^4.18.2 || ^5.0.1"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.4",
-        "@connectrpc/connect-conformance": "^2.0.4",
-        "@connectrpc/connect-node": "2.0.4"
+        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect-conformance": "^2.1.0",
+        "@connectrpc/connect-node": "2.1.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.0.4",
-        "@connectrpc/connect-node": "2.0.4",
+        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect-node": "2.1.0",
         "fastify": "^4.22.1 || ^5.1.0"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.3",
@@ -12813,28 +12813,28 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.0.4",
-        "@connectrpc/connect-node": "2.0.4"
+        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect-node": "2.1.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.0.4",
-        "@connectrpc/connect-node": "2.0.4",
+        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect-node": "2.1.0",
         "next": "^13.2.4 || ^14.2.5 || ^15.0.2"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.0.4",
+        "@connectrpc/connect-conformance": "^2.1.0",
         "@types/jasmine": "^5.1.8",
         "@types/node": "^24.2.1",
         "jasmine": "^5.9.0"
@@ -12844,7 +12844,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.0.4"
+        "@connectrpc/connect": "2.1.0"
       }
     },
     "packages/connect-node/node_modules/@types/node": {
@@ -12866,12 +12866,12 @@
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.56.0",
         "@bufbuild/protoc-gen-es": "^2.7.0",
-        "@connectrpc/connect-conformance": "^2.0.4",
+        "@connectrpc/connect-conformance": "^2.1.0",
         "@wdio/browserstack-service": "^9.19.1",
         "@wdio/cli": "^9.19.1",
         "@wdio/jasmine-framework": "^9.19.1",
@@ -12881,7 +12881,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.0.4"
+        "@connectrpc/connect": "2.1.0"
       }
     },
     "packages/connect-web-bench": {
@@ -12890,7 +12890,7 @@
         "@bufbuild/buf": "^1.56.0",
         "@bufbuild/protobuf": "^2.7.0",
         "@bufbuild/protoc-gen-es": "^2.7.0",
-        "@connectrpc/connect-web": "2.0.4",
+        "@connectrpc/connect-web": "2.1.0",
         "@types/brotli": "^1.3.4",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
@@ -12902,8 +12902,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect-node": "^2.0.4",
-        "@connectrpc/connect-web": "^2.0.4",
+        "@connectrpc/connect-node": "^2.1.0",
+        "@connectrpc/connect-web": "^2.1.0",
         "tsx": "^4.20.4"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.0.4",
-    "@connectrpc/connect-node": "2.0.4"
+    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect-node": "2.1.0"
   },
   "devDependencies": {
     "wrangler": "^4.29.1",
     "@cloudflare/workers-types": "^4.20250801.0",
     "tsx": "^4.20.4",
-    "@connectrpc/connect-conformance": "^2.0.4"
+    "@connectrpc/connect-conformance": "^2.1.0"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.0.4",
+    "@connectrpc/connect": "2.1.0",
     "fflate": "^0.8.2",
     "tar-stream": "^3.1.7"
   },

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,9 +32,9 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.4",
-    "@connectrpc/connect": "2.0.4",
-    "@connectrpc/connect-node": "2.0.4",
+    "@connectrpc/connect-conformance": "^2.1.0",
+    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect-node": "2.1.0",
     "@types/express": "^5.0.3",
     "express": "^5.1.0",
     "tsx": "^4.20.4"
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "express": "^4.18.2 || ^5.0.1",
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.0.4",
-    "@connectrpc/connect-node": "2.0.4"
+    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect-node": "2.1.0"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,14 +31,14 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.0.4",
-    "@connectrpc/connect": "2.0.4",
-    "@connectrpc/connect-node": "2.0.4"
+    "@connectrpc/connect-conformance": "^2.1.0",
+    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect-node": "2.1.0"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "fastify": "^4.22.1 || ^5.1.0",
-    "@connectrpc/connect": "2.0.4",
-    "@connectrpc/connect-node": "2.0.4"
+    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect-node": "2.1.0"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "next": "^13.2.4 || ^14.2.5 || ^15.0.2",
-    "@connectrpc/connect": "2.0.4",
-    "@connectrpc/connect-node": "2.0.4"
+    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect-node": "2.1.0"
   },
   "devDependencies": {
-    "@connectrpc/connect": "2.0.4",
-    "@connectrpc/connect-node": "2.0.4"
+    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect-node": "2.1.0"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,11 +34,11 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.0.4"
+    "@connectrpc/connect": "2.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",
-    "@connectrpc/connect-conformance": "^2.0.4",
+    "@connectrpc/connect-conformance": "^2.1.0",
     "@types/jasmine": "^5.1.8",
     "jasmine": "^5.9.0"
   }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   284,162 b | 180,111 b |   36,441 b |
-| Connect-ES     |    4 |   288,414 b | 183,213 b |   37,244 b |
-| Connect-ES     |    8 |   293,277 b | 187,644 b |   38,156 b |
-| Connect-ES     |   16 |   302,405 b | 195,271 b |   39,672 b |
+| Connect-ES     |    1 |   284,162 b | 180,111 b |   36,473 b |
+| Connect-ES     |    4 |   288,414 b | 183,213 b |   37,242 b |
+| Connect-ES     |    8 |   293,277 b | 187,644 b |   38,174 b |
+| Connect-ES     |   16 |   302,405 b | 195,271 b |   39,685 b |
 | gRPC-Web       |    1 |   876,563 b | 548,495 b |   52,300 b |
 | gRPC-Web       |    4 |   928,964 b | 580,477 b |   54,673 b |
 | gRPC-Web       |    8 | 1,004,833 b | 628,223 b |   57,118 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.79794921874998 140,184.523828125 280,181.941015625 420,177.64765625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.70732421875 140,184.5294921875 280,181.8900390625 420,177.61083984375">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="186.79794921874998" r="4" fill="#ffa600"><title>Connect-ES 35.59 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="184.523828125" r="4" fill="#ffa600"><title>Connect-ES 36.37 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="181.941015625" r="4" fill="#ffa600"><title>Connect-ES 37.26 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="177.64765625" r="4" fill="#ffa600"><title>Connect-ES 38.74 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="186.70732421875" r="4" fill="#ffa600"><title>Connect-ES 35.62 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="184.5294921875" r="4" fill="#ffa600"><title>Connect-ES 36.37 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="181.8900390625" r="4" fill="#ffa600"><title>Connect-ES 37.28 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="177.61083984375" r="4" fill="#ffa600"><title>Connect-ES 38.75 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,141.884765625 140,135.16435546875 280,128.24003906250002 420,116.54374999999999">

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -13,7 +13,7 @@
     "@bufbuild/buf": "^1.56.0",
     "@bufbuild/protobuf": "^2.7.0",
     "@bufbuild/protoc-gen-es": "^2.7.0",
-    "@connectrpc/connect-web": "2.0.4",
+    "@connectrpc/connect-web": "2.1.0",
     "@types/brotli": "^1.3.4",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.56.0",
     "@bufbuild/protoc-gen-es": "^2.7.0",
-    "@connectrpc/connect-conformance": "^2.0.4",
+    "@connectrpc/connect-conformance": "^2.1.0",
     "@wdio/jasmine-framework": "^9.19.1",
     "@wdio/cli": "^9.19.1",
     "@wdio/local-runner": "^9.19.1",
@@ -51,6 +51,6 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.0.4"
+    "@connectrpc/connect": "2.1.0"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect-node": "^2.0.4",
-    "@connectrpc/connect-web": "^2.0.4",
+    "@connectrpc/connect-node": "^2.1.0",
+    "@connectrpc/connect-web": "^2.1.0",
     "tsx": "^4.20.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's Changed

> [!IMPORTANT]
> 
> TypeScript 5.9 includes breaking changes to lib.d.ts, forcing us to change return types for some functions from `Uint8Array` to `Uint8Array<ArrayBuffer>`. This is unlikely to affect you, but if it does, see #1560 for details.

* Update to TypeScript 5.9 and change return types from `Uint8Array` to `Uint8Array<ArrayBuffer>` by @timostamm in https://github.com/connectrpc/connect-es/pull/1560
* Drop support for Node.js 18 by @timostamm in https://github.com/connectrpc/connect-es/pull/1559

**Full Changelog**: https://github.com/connectrpc/connect-es/compare/v2.0.4...v2.1.0
