### PR TITLE
Do not hold on to HTTP/2 connections after receiving GOAWAY without open streams

### DIFF
--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -418,6 +418,11 @@ describe("Http2SessionManager", () => {
           .withContext("connection state after receiving GOAWAY")
           .toBe("closed");
 
+        // manager should not hold on to connection without streams
+        expect(
+          (sm as unknown as { shuttingDown: unknown[] }).shuttingDown.length,
+        ).toBe(0);
+
         // second request should open a new session
         const req2 = await sm.request("POST", "/", {}, {});
         expect(sm.state())


### PR DESCRIPTION
If a HTTP/2 client receives a GOAWAY frame, it must not open new streams on the connection. Existing streams can finish, but new streams must use a new connection.

The `Http2SessionManager` from `@connectrpc/connect-node` implements this logic. It automatically opens a new connection for new requests, and holds on to the current current, waiting for existing streams to finish. The new connection can also receive a GOAWAY frame, so all such connections are kept in a list of connections that are "shutting down".

So far, so good. But if a connection without any open streams receives a GOAWAY frame, it's also put into the list of shutting down connections, and it's never vacated. This PR changes the behavior for connections without open streams: If they receive a GOAWAY frame, they are not added to the list of shutting down connections.

Fixes https://github.com/connectrpc/connect-es/issues/1545.