### PR TITLE
Fix missing types in webstorm for jsdoc

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -27,22 +27,27 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "types": "./dist/cjs/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./protocol": {
+      "types": "./dist/cjs/protocol/index.d.ts",
       "import": "./dist/esm/protocol/index.js",
       "require": "./dist/cjs/protocol/index.js"
     },
     "./protocol-connect": {
+      "types": "./dist/cjs/protocol-connect/index.d.ts",
       "import": "./dist/esm/protocol-connect/index.js",
       "require": "./dist/cjs/protocol-connect/index.js"
     },
     "./protocol-grpc": {
+      "types": "./dist/cjs/protocol-grpc/index.d.ts",
       "import": "./dist/esm/protocol-grpc/index.js",
       "require": "./dist/cjs/protocol-grpc/index.js"
     },
     "./protocol-grpc-web": {
+      "types": "./dist/cjs/protocol-grpc-web/index.d.ts",
       "import": "./dist/esm/protocol-grpc-web/index.js",
       "require": "./dist/cjs/protocol-grpc-web/index.js"
     }


### PR DESCRIPTION
## Describe the bug

Webstorm does not highlight connectrpc types (e.g., ConnectError, Code) in js. This problem does not occur in vs code.

When manually adding to package.json:
```js
  "exports": {
    ".": {
      "types": "./dist/cjs/index.d.ts", // <- this is line
      "import": "./dist/esm/index.js",
      "require": "./dist/cjs/index.js"
    },
...
```
- The problem is solved.

## To Reproduce

1. Open webstorm
2. Download `@connectrpc/connect`
3.  Add line `import { Code as ConnectCode, ConnectError } from "@connectrpc/connect";`
4. Check types

## Environment:

- @connectrpc/connect-web version: 2.1.0
- @connectrpc/connect-node version: 2.1.0
- Node.js version: v23.6.0
- Webstorm: 2025.2.3

## Additional context
### With package.json modify:
#### 1. Webstorm
<img width="627" height="481" alt="Image" src="https://github.com/user-attachments/assets/c01ee0e7-d5d8-4217-894b-b54caf9c0779" />

#### 2. VScode
<img width="1168" height="178" alt="Image" src="https://github.com/user-attachments/assets/a6c40ba2-6eee-439a-8edc-d12158bc6376" />

### Withoud package.json modify:
#### 1. Webstorm
<img width="666" height="118" alt="Image" src="https://github.com/user-attachments/assets/d1186241-88bf-4eae-bf1a-c16d854cb415" />

<img width="666" height="118" alt="Image" src="https://github.com/user-attachments/assets/c8286942-1bf9-4bbe-b74d-8307d861c17d" />

#### 2. VScode

<img width="1230" height="173" alt="Image" src="https://github.com/user-attachments/assets/517b7f39-c089-4bc2-926a-4aae7773d325" />

## Issue
#1597 