### PR TITLE
Release 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12683,7 +12683,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.59.0",
@@ -12699,22 +12699,22 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0",
-        "@connectrpc/connect-node": "2.1.0"
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-node": "2.1.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250831.0",
-        "@connectrpc/connect-conformance": "^2.1.0",
+        "@connectrpc/connect-conformance": "^2.1.1",
         "tsx": "^4.20.6",
         "wrangler": "^4.40.3"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0",
+        "@connectrpc/connect": "2.1.1",
         "fflate": "^0.8.2",
         "tar-stream": "^3.1.7"
       },
@@ -12731,12 +12731,12 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.1.0",
-        "@connectrpc/connect-conformance": "^2.1.0",
-        "@connectrpc/connect-node": "2.1.0",
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-conformance": "^2.1.1",
+        "@connectrpc/connect-node": "2.1.1",
         "@types/express": "^5.0.5",
         "express": "^5.1.0",
         "tsx": "^4.20.6"
@@ -12746,33 +12746,33 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0",
-        "@connectrpc/connect-node": "2.1.0",
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-node": "2.1.1",
         "express": "^4.18.2 || ^5.0.1"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.1.0",
-        "@connectrpc/connect-conformance": "^2.1.0",
-        "@connectrpc/connect-node": "2.1.0"
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-conformance": "^2.1.1",
+        "@connectrpc/connect-node": "2.1.1"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0",
-        "@connectrpc/connect-node": "2.1.0",
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-node": "2.1.1",
         "fastify": "^4.22.1 || ^5.1.0"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.3",
@@ -12793,28 +12793,28 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.1.0",
-        "@connectrpc/connect-node": "2.1.0"
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-node": "2.1.1"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0",
-        "@connectrpc/connect-node": "2.1.0",
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-node": "2.1.1",
         "next": "^13.2.4 || ^14.2.5 || ^15.0.2"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.1.0",
+        "@connectrpc/connect-conformance": "^2.1.1",
         "@types/jasmine": "^5.1.12",
         "@types/node": "^24.10.1",
         "jasmine": "^5.12.0"
@@ -12824,17 +12824,17 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0"
+        "@connectrpc/connect": "2.1.1"
       }
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.59.0",
         "@bufbuild/protoc-gen-es": "^2.10.0",
-        "@connectrpc/connect-conformance": "^2.1.0",
+        "@connectrpc/connect-conformance": "^2.1.1",
         "@wdio/browserstack-service": "^9.19.2",
         "@wdio/cli": "^9.19.2",
         "@wdio/jasmine-framework": "^9.19.2",
@@ -12844,7 +12844,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0"
+        "@connectrpc/connect": "2.1.1"
       }
     },
     "packages/connect-web-bench": {
@@ -12853,7 +12853,7 @@
         "@bufbuild/buf": "^1.59.0",
         "@bufbuild/protobuf": "^2.7.0",
         "@bufbuild/protoc-gen-es": "^2.10.0",
-        "@connectrpc/connect-web": "2.1.0",
+        "@connectrpc/connect-web": "2.1.1",
         "@types/brotli": "^1.3.4",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
@@ -12865,8 +12865,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect-node": "^2.1.0",
-        "@connectrpc/connect-web": "^2.1.0",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@connectrpc/connect-web": "^2.1.1",
         "tsx": "^4.20.6"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.0",
-    "@connectrpc/connect-node": "2.1.0"
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-node": "2.1.1"
   },
   "devDependencies": {
     "wrangler": "^4.40.3",
     "@cloudflare/workers-types": "^4.20250831.0",
     "tsx": "^4.20.6",
-    "@connectrpc/connect-conformance": "^2.1.0"
+    "@connectrpc/connect-conformance": "^2.1.1"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.0",
+    "@connectrpc/connect": "2.1.1",
     "fflate": "^0.8.2",
     "tar-stream": "^3.1.7"
   },

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,9 +32,9 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.1.0",
-    "@connectrpc/connect": "2.1.0",
-    "@connectrpc/connect-node": "2.1.0",
+    "@connectrpc/connect-conformance": "^2.1.1",
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-node": "2.1.1",
     "@types/express": "^5.0.5",
     "express": "^5.1.0",
     "tsx": "^4.20.6"
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "express": "^4.18.2 || ^5.0.1",
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.0",
-    "@connectrpc/connect-node": "2.1.0"
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-node": "2.1.1"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,14 +31,14 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.1.0",
-    "@connectrpc/connect": "2.1.0",
-    "@connectrpc/connect-node": "2.1.0"
+    "@connectrpc/connect-conformance": "^2.1.1",
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-node": "2.1.1"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "fastify": "^4.22.1 || ^5.1.0",
-    "@connectrpc/connect": "2.1.0",
-    "@connectrpc/connect-node": "2.1.0"
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-node": "2.1.1"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "next": "^13.2.4 || ^14.2.5 || ^15.0.2",
-    "@connectrpc/connect": "2.1.0",
-    "@connectrpc/connect-node": "2.1.0"
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-node": "2.1.1"
   },
   "devDependencies": {
-    "@connectrpc/connect": "2.1.0",
-    "@connectrpc/connect-node": "2.1.0"
+    "@connectrpc/connect": "2.1.1",
+    "@connectrpc/connect-node": "2.1.1"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,11 +34,11 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.0"
+    "@connectrpc/connect": "2.1.1"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
-    "@connectrpc/connect-conformance": "^2.1.0",
+    "@connectrpc/connect-conformance": "^2.1.1",
     "@types/jasmine": "^5.1.12",
     "jasmine": "^5.12.0"
   }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   285,007 b | 180,536 b |   36,523 b |
-| Connect-ES     |    4 |   289,259 b | 183,638 b |   37,365 b |
-| Connect-ES     |    8 |   294,122 b | 188,069 b |   38,271 b |
-| Connect-ES     |   16 |   303,250 b | 195,696 b |   39,724 b |
+| Connect-ES     |    1 |   285,007 b | 180,536 b |   36,540 b |
+| Connect-ES     |    4 |   289,259 b | 183,638 b |   37,322 b |
+| Connect-ES     |    8 |   294,122 b | 188,069 b |   38,215 b |
+| Connect-ES     |   16 |   303,250 b | 195,696 b |   39,726 b |
 | gRPC-Web       |    1 | 1,070,505 b | 707,341 b |   70,184 b |
 | gRPC-Web       |    4 | 1,121,879 b | 738,633 b |   72,562 b |
 | gRPC-Web       |    8 | 1,197,272 b | 786,157 b |   75,059 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.56572265625 140,184.18115234375 280,181.61533203125 420,177.500390625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.517578125 140,184.3029296875 280,181.77392578125 420,177.4947265625">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="186.56572265625" r="4" fill="#ffa600"><title>Connect-ES 35.67 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="184.18115234375" r="4" fill="#ffa600"><title>Connect-ES 36.49 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="181.61533203125" r="4" fill="#ffa600"><title>Connect-ES 37.37 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="177.500390625" r="4" fill="#ffa600"><title>Connect-ES 38.79 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="186.517578125" r="4" fill="#ffa600"><title>Connect-ES 35.68 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="184.3029296875" r="4" fill="#ffa600"><title>Connect-ES 36.45 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="181.77392578125" r="4" fill="#ffa600"><title>Connect-ES 37.32 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="177.4947265625" r="4" fill="#ffa600"><title>Connect-ES 38.79 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,91.23671875 140,84.50214843750001 280,77.43056640625 420,66.39697265625">

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -13,7 +13,7 @@
     "@bufbuild/buf": "^1.59.0",
     "@bufbuild/protobuf": "^2.7.0",
     "@bufbuild/protoc-gen-es": "^2.10.0",
-    "@connectrpc/connect-web": "2.1.0",
+    "@connectrpc/connect-web": "2.1.1",
     "@types/brotli": "^1.3.4",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.59.0",
     "@bufbuild/protoc-gen-es": "^2.10.0",
-    "@connectrpc/connect-conformance": "^2.1.0",
+    "@connectrpc/connect-conformance": "^2.1.1",
     "@wdio/jasmine-framework": "^9.19.2",
     "@wdio/cli": "^9.19.2",
     "@wdio/local-runner": "^9.19.2",
@@ -51,6 +51,6 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.0"
+    "@connectrpc/connect": "2.1.1"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect-node": "^2.1.0",
-    "@connectrpc/connect-web": "^2.1.0",
+    "@connectrpc/connect-node": "^2.1.1",
+    "@connectrpc/connect-web": "^2.1.1",
     "tsx": "^4.20.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's Changed
* Do not hold on to HTTP/2 connections after receiving GOAWAY without open streams by @timostamm in https://github.com/connectrpc/connect-es/pull/1566
* Add Protovalidate (@connectrpc/validate) to README by @jrinehart-buf in https://github.com/connectrpc/connect-es/pull/1595
* Fix memory leak in Http2SessionManager's verify step by @ttyniwa in https://github.com/connectrpc/connect-es/pull/1616

## New Contributors
* @jrinehart-buf made their first contribution in https://github.com/connectrpc/connect-es/pull/1595
* @ttyniwa made their first contribution in https://github.com/connectrpc/connect-es/pull/1616

**Full Changelog**: https://github.com/connectrpc/connect-es/compare/v2.1.0...v2.1.1