### PR TITLE
Update connect-next docs for Turbopack compatibility

### DIFF
--- a/packages/connect-next/README.md
+++ b/packages/connect-next/README.md
@@ -20,9 +20,8 @@ add two files to your project:
         └── [[...connect]].ts
 ```
 
-> **Note:** Next.js 13 introduced the new App Router. Your Connect API routes
-> need to be placed in `pages/`, but you can use the `app/` directory for the
-> App Router at the same time.
+> **Note:** Your Connect API routes need to be placed in `pages/`, but you
+> can use the `app/` directory for the App Router at the same time.
 
 The new file `connect.ts` is where you register your RPCs:
 
@@ -46,11 +45,19 @@ import { nextJsApiRouter } from "@connectrpc/connect-next";
 import { createValidateInterceptor } from "@connectrpc/validate";
 import routes from "../../connect";
 
-const { handler, config } = nextJsApiRouter({
+const { handler } = nextJsApiRouter({
   interceptors: [createValidateInterceptor()],
-  routes 
+  routes,
 });
-export { handler as default, config };
+export default handler;
+
+// Required: Connect parses request bodies itself, so the Next.js body
+// parser must be disabled. Without this, RPCs will fail.
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
 ```
 
 With that server running, you can make requests with any Connect or gRPC-Web client.
@@ -88,7 +95,7 @@ simply use `createConnectTransport` from [@connectrpc/connect-web](https://www.n
 instead.
 
 Note that support for gRPC is limited, since many gRPC clients require HTTP/2,
-and Express does not support the Node.js `http2` module.
+and Next.js does not support the Node.js `http2` module.
 
 ### Deploying to Vercel
 

--- a/packages/connect-next/src/connect-nextjs-adapter.ts
+++ b/packages/connect-next/src/connect-nextjs-adapter.ts
@@ -68,6 +68,24 @@ interface NextJsApiRouterOptions extends ConnectRouterOptions {
 
 /**
  * Provide your Connect RPCs via Next.js API routes.
+ *
+ * Usage in `pages/api/[[...connect]].ts`:
+ *
+ * ```ts
+ * import { nextJsApiRouter } from "@connectrpc/connect-next";
+ * import routes from "../../connect";
+ *
+ * const { handler } = nextJsApiRouter({ routes });
+ * export default handler;
+ *
+ * // Required: Connect parses request bodies itself, so the Next.js
+ * // body parser must be disabled. Without this, RPCs will fail.
+ * export const config = {
+ *   api: {
+ *     bodyParser: false,
+ *   },
+ * };
+ * ```
  */
 export function nextJsApiRouter(options: NextJsApiRouterOptions): ApiRoute {
   if (options.acceptCompression === undefined) {
@@ -120,5 +138,18 @@ export function nextJsApiRouter(options: NextJsApiRouterOptions): ApiRoute {
 
 interface ApiRoute {
   handler: NextApiHandler;
+  /**
+   * @deprecated Export the config directly in your API route file
+   * instead. Turbopack requires config exports to be statically analyzable at
+   * compile time, which means re-exporting this value will fail:
+   *
+   * ```ts
+   * export const config = {
+   *   api: {
+   *     bodyParser: false,
+   *   },
+   * };
+   * ```
+   */
   config: PageConfig;
 }


### PR DESCRIPTION
This updates the docs to better support Next.js v16.  Update the recommended usage pattern for `nextJsApiRouter()` to export `config` as a static literal. Deprecate the `config` property on the `ApiRoute` return type.

Next.js 16 uses Turbopack as the default bundler. Turbopack reads the AST of route files at compile time to extract config values like `api.bodyParser`. It only recognizes inline export declarations (`export const config = ...`) and does not trace references from export specifiers (`export { config }`) back to their declarations. See the [custom config examples](https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config).

The previously recommended pattern re-exported `config` from the `nextJsApiRouter()` return value, which produces an AST node with no inline initializer. Turbopack treats this as a fatal error (upgraded from warning in vercel/next.js#83297).

Contributes towards https://github.com/connectrpc/connect-es/issues/1645