### PR TITLE
Support Next.js v16 and drop v13 and v14

### DIFF
--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "next": "^13.2.4 || ^14.2.5 || ^15.0.2",
+    "next": "^15.0.2 || ^16.0.0",
     "@connectrpc/connect": "2.1.1",
     "@connectrpc/connect-node": "2.1.1"
   },


### PR DESCRIPTION
This updates the peer dependency for connect-next to support the latest two version: v15 and v16. Versions v13 and v14 are dropped, replicating [Vercels supported versions](https://nextjs.org/support-policy#supported-versions). 

Tested using the [examples-es/nextjs](https://github.com/connectrpc/examples-es/compare/main...emcfarlane:examples-es:ed/nextjsv16) packages. This includes the static config fix described in https://github.com/connectrpc/connect-es/pull/1665 plus an updated "Server Action" example with use of the next/cache API. Example will be updated on a release of connect-next supporting the peer dependency.

Fixes https://github.com/connectrpc/connect-es/issues/1645