### PR TITLE
Fix cloudflare conformance tests

### DIFF
--- a/packages/connect-cloudflare/conformance/known-failing-client.txt
+++ b/packages/connect-cloudflare/conformance/known-failing-client.txt
@@ -1,1 +1,3 @@
 Connect Compressed Error and End-Stream/*/TLS:true/error/compressed
+# On receiving 504, cloudflare is returning a static response back instead of the actual body.
+Errors/*/Protocol:PROTOCOL_CONNECT/*/*/TLS:true/unary/deadline-exceeded

--- a/packages/connect-cloudflare/conformance/known-failing-client.txt
+++ b/packages/connect-cloudflare/conformance/known-failing-client.txt
@@ -1,3 +1,2 @@
-Connect Compressed Error and End-Stream/*/TLS:true/error/compressed
 # On receiving 504, cloudflare is returning a static response back instead of the actual body.
 Errors/*/Protocol:PROTOCOL_CONNECT/*/*/TLS:true/unary/deadline-exceeded

--- a/packages/connect-cloudflare/conformance/transport.ts
+++ b/packages/connect-cloudflare/conformance/transport.ts
@@ -88,7 +88,11 @@ export function createTransport(req: ClientCompatRequest) {
         const headers = new Headers(res.headers);
         headers.delete("content-encoding");
         headers.delete("content-length");
-        return new Response(res.body, { ...res, headers });
+        return new Response(res.body, {
+          headers,
+          status: res.status,
+          statusText: res.statusText,
+        });
       }
       return res;
     }),


### PR DESCRIPTION
There are 16 failing cases in the most recent conformance [run](https://github.com/connectrpc/connect-es/actions/runs/24753259450/job/72420835527). 

All of them are for the clients. Half of them are because the workers don't see the actual body in the case of HTTP 504 status, instead they see a static text of 504. The other half is due to spread inconsistently working on the `Response` type. It should not work at all because of them being getters, so we update the fetch wrapper to explicitly set `status` and `statusText`. 

This fix also resulted in 2 failing test cases to pass.

Successful run of the latest commit: https://github.com/connectrpc/connect-es/actions/runs/24794910215