### PR TITLE
Run CI on all branches to support stacked PRs

### DIFF
--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, "v*"]
     tags: ["v*"]
   pull_request:
-    branches: [main, "v*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, "v*"]
     tags: ["v*"]
   pull_request:
-    branches: [main, "v*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/conformance-cloudflare.yaml
+++ b/.github/workflows/conformance-cloudflare.yaml
@@ -6,7 +6,6 @@ on:
   push:
     tags: ["v*"]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/conformance-express.yaml
+++ b/.github/workflows/conformance-express.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, "v*"]
     tags: ["v*"]
   pull_request:
-    branches: [main, "v*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/conformance-fastify.yaml
+++ b/.github/workflows/conformance-fastify.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, "v*"]
     tags: ["v*"]
   pull_request:
-    branches: [main, "v*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/conformance-node.yaml
+++ b/.github/workflows/conformance-node.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, "v*"]
     tags: ["v*"]
   pull_request:
-    branches: [main, "v*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/conformance-web.yaml
+++ b/.github/workflows/conformance-web.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, "v*"]
     tags: ["v*"]
   pull_request:
-    branches: [main, "v*"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Removes the `branches: [main, \"v*\"]` filter from the `pull_request` trigger in all GitHub Actions workflows. With the filter in place, PRs whose base branch is anything other than `main` or `v*` (i.e. stacked PRs targeting another feature branch) do not trigger CI, leaving them unverified until they are eventually retargeted at `main`.

After this change, CI runs for PRs against any base branch, which makes stacked PR workflows usable while still keeping the narrower `push` filter so we don't double-run CI on every push to a feature branch.

## Affected workflows

- `ci.yaml`
- `browserstack.yaml`
- `conformance-cloudflare.yaml`
- `conformance-express.yaml`
- `conformance-fastify.yaml`
- `conformance-node.yaml`
- `conformance-web.yaml`