### PR TITLE
Use node version from .nvmrc in cloudflare-conformance

### DIFF
--- a/.github/workflows/conformance-cloudflare.yaml
+++ b/.github/workflows/conformance-cloudflare.yaml
@@ -23,6 +23,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
       - uses: actions/cache@v5
         with:
           path: .turbo


### PR DESCRIPTION
We are currently using the system version of Node, which is breaking on the latest version of wrangler.
