### PR TITLE
Migrate dual-build packages to tshy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .turbo
+.tshy
+.tshy-build
 .wrangler
 node_modules
 /packages/*/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -3808,6 +3808,147 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-+rghVK/GENODCBed03PMAbHAo885P6Hw6HeW5daICel80OmAM49QeTmdcI7oii/9WMqX2UhM0sfNMH0Y5LeO+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260612.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260612.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260612.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260612.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260612.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260612.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260612.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-4GXIs4Z/4E0E1fRXmt1XE7mKRiwghkoNHstbqSHFl6Z7PeWBdTiSFR5j4JGo3Zp8RzZ+N6zZoVZOfG3HNqjWtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-YCXzMiUYnkOpg1Hh+TgYL5MZ190eia4LE8qpEti+j4QnZyARhQEbPWSUzXfQjinAy3Qcx7njamydSHpuBnODLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-ylu0HtI0NS90souTPje6j1iTqhIPIYaZ12yLO1n8lxHkDXKjggm6w9l4BL/uRWqWc4iVHWt8JUAC/my7X1/EDQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-F4dPFLmRRPc2XeqQy45bDKQqbg4M4HoF7ybXae+D1LV8F44KR4ktUlXhp5pQBhwoQxZaLhA2D+NKwV/2UpILcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-F/k8oic3wyq0WD5v7PQFPBlXaajbgzMnG9fkCWMwLYh2BUtD1VUjQ78dwDEz06AmOY+hsFrDuCtIZUyauBBU7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-6/F10rOev8Wb2LM2F8C2ymuwcu+jrr06pcLR4AD8gy0YmTBjPvEZpKyBjCfdaJtIFH8S20dAVAK9HhYlw0JwnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260612.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260612.1.tgz",
+      "integrity": "sha512-8eRyhATm1dqo0PhAuyC908xlDUS9Onvm0BLvm81rAHRO6n3JhnzrwXL8s4jdvyDBiGK40R4d6JvY55edthg/rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/@typescript/vfs": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.2.tgz",
@@ -8214,6 +8355,15 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/jsonc-simple-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-simple-parser/-/jsonc-simple-parser-3.0.0.tgz",
+      "integrity": "sha512-0qi9Kuj4JPar4/3b9wZteuPZrTeFzXsQyOZj7hksnReCZN3Vr17Doz7w/i3E9XH7vRkVTHhHES+r1h97I+hfww==",
+      "dev": true,
+      "dependencies": {
+        "reghex": "^3.0.2"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -8744,11 +8894,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -8759,6 +8909,22 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -9947,6 +10113,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/polite-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/polite-json/-/polite-json-5.0.0.tgz",
+      "integrity": "sha512-OLS/0XeUAcE8a2fdwemNja+udKgXNnY6yKVIXqAD2zVRx1KvY6Ato/rZ2vdzbxqYwPW0u6SCNC/bAMPNzpzxbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -10541,6 +10720,13 @@
         "node": "*"
       }
     },
+    "node_modules/reghex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/reghex/-/reghex-3.0.2.tgz",
+      "integrity": "sha512-Zb9DJ5u6GhgqRSBnxV2QSnLqEwcKxHWFA1N2yUa4ZUAO1P8jlWKYtWZ6/ooV6yylspGXJX0O/uNzEv0xrCtwaA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10559,6 +10745,107 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-import": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/resolve-import/-/resolve-import-2.4.0.tgz",
+      "integrity": "sha512-gLWKdA5tiv5j/D7ipR47u3ovbVfzFPrctTdw2Ulnpmr6PPVVSvPKGNWu09jXVNlOSLLAeD6CA13bjIelpWttSw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/resolve-import/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/resolve-import/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/resolve-import/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/resolve-import/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/resolve-import/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/resolve-import/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -10619,6 +10906,110 @@
       "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -11456,6 +11847,112 @@
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
+    "node_modules/sync-content": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sync-content/-/sync-content-2.0.4.tgz",
+      "integrity": "sha512-w3ioiBmbaogob33WdLnuwFk+8tpePI58CTWKqtdAgEqc2hfGuSwP02gPETqNX/3PLS5skv5a1wQR0gbaa2W0XQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "mkdirp": "^3.0.1",
+        "path-scurry": "^2.0.0",
+        "rimraf": "^6.0.0"
+      },
+      "bin": {
+        "sync-content": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sync-content/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/sync-content/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/sync-content/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sync-content/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/sync-content/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sync-content/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
@@ -11673,6 +12170,102 @@
     "node_modules/ts6.0": {
       "resolved": "packages/typescript-compat/v6.0.x",
       "link": true
+    },
+    "node_modules/tshy": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tshy/-/tshy-4.1.3.tgz",
+      "integrity": "sha512-uEaLO1lFhu5X58KZxS5gKCabh+xd72MfXDOHhAIvnoreBAP1F4HNpbK2m0DUmrrzpcgxvXbsdXn1A0OaQxFYqw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@typescript/native-preview": "^7.0.0-dev.20260218.1",
+        "chalk": "^5.6.2",
+        "chokidar": "^4.0.3",
+        "foreground-child": "^4.0.0",
+        "jsonc-simple-parser": "^3.0.0",
+        "minimatch": "^10.0.3",
+        "mkdirp": "^3.0.1",
+        "polite-json": "^5.0.0",
+        "resolve-import": "^2.4.0",
+        "rimraf": "^6.1.2",
+        "sync-content": "^2.0.3",
+        "typescript": "^6.0.2",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "tshy": "dist/esm/bin-min.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/tshy/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/tshy/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/tshy/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tshy/node_modules/foreground-child": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-4.0.3.tgz",
+      "integrity": "sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tshy/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -12357,6 +12950,16 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -13361,7 +13964,8 @@
         "@bufbuild/buf": "^1.66.1",
         "@bufbuild/protoc-gen-es": "^2.10.0",
         "@types/jasmine": "^5.1.13",
-        "jasmine": "^5.13.0"
+        "jasmine": "^5.13.0",
+        "tshy": "^4.1.3"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14002,7 +14002,8 @@
         "@bufbuild/protoc-gen-es": "^2.10.0",
         "@types/debug": "^4.1.13",
         "@types/node-forge": "^1.3.14",
-        "@types/tar-stream": "^3.1.4"
+        "@types/tar-stream": "^3.1.4",
+        "tshy": "^4.1.3"
       }
     },
     "packages/connect-express": {
@@ -14015,6 +14016,7 @@
         "@connectrpc/connect-node": "2.1.2",
         "@types/express": "^5.0.6",
         "express": "^5.2.1",
+        "tshy": "^4.1.3",
         "tsx": "^4.20.6"
       },
       "engines": {
@@ -14034,7 +14036,8 @@
       "devDependencies": {
         "@connectrpc/connect": "2.1.2",
         "@connectrpc/connect-conformance": "^2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect-node": "2.1.2",
+        "tshy": "^4.1.3"
       },
       "engines": {
         "node": ">=20"
@@ -14073,7 +14076,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect-node": "2.1.2",
+        "tshy": "^4.1.3"
       },
       "engines": {
         "node": ">=20"
@@ -14093,7 +14097,8 @@
         "@connectrpc/connect-conformance": "^2.1.2",
         "@types/jasmine": "^5.1.13",
         "@types/node": "^24.10.1",
-        "jasmine": "^5.13.0"
+        "jasmine": "^5.13.0",
+        "tshy": "^4.1.3"
       },
       "engines": {
         "node": ">=20"
@@ -14116,6 +14121,7 @@
         "@wdio/jasmine-framework": "^9.19.2",
         "@wdio/local-runner": "^9.19.2",
         "jasmine": "^5.13.0",
+        "tshy": "^4.1.3",
         "webdriverio": "^9.7.2"
       },
       "peerDependencies": {

--- a/packages/connect-conformance/bin/connectconformance.cjs
+++ b/packages/connect-conformance/bin/connectconformance.cjs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const { run } = require("../dist/cjs/conformance.js");
+const { run } = require("../dist/commonjs/conformance.js");
 const { scripts } = require("../package.json");
 
 // Extract conformance runner version from the `generate` script

--- a/packages/connect-conformance/biome.json
+++ b/packages/connect-conformance/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["src/gen"]
+    "ignore": ["src/gen", "package.json"]
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -3,11 +3,10 @@
   "version": "2.1.2",
   "private": true,
   "type": "module",
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "bin": {
@@ -16,11 +15,8 @@
   "scripts": {
     "generate": "buf generate buf.build/connectrpc/conformance:v1.0.4",
     "postgenerate": "license-header src/gen",
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
+    "build": "tshy",
     "postbuild": "connectconformance --version",
-    "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.json --outDir ./dist/esm",
     "format": "biome format --write",
     "license-header": "license-header",
     "lint": "biome lint --error-on-warnings",
@@ -37,6 +33,23 @@
     "@bufbuild/protoc-gen-es": "^2.10.0",
     "@types/debug": "^4.1.13",
     "@types/node-forge": "^1.3.14",
-    "@types/tar-stream": "^3.1.4"
-  }
+    "@types/tar-stream": "^3.1.4",
+    "tshy": "^4.1.3"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "tshy": {
     "exports": {
-      ".": "./src/index.ts",
-      "./package.json": "./package.json"
+      ".": "./src/index.ts"
     }
   },
   "bin": {
@@ -46,8 +45,7 @@
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "tshy": {
+    "selfLink": false,
     "exports": {
       ".": "./src/index.ts"
     }

--- a/packages/connect-conformance/tsconfig.json
+++ b/packages/connect-conformance/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "include": ["src/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "verbatimModuleSyntax": false,
     "resolveJsonModule": true
   }
 }

--- a/packages/connect-express/.npmignore
+++ b/packages/connect-express/.npmignore
@@ -1,5 +1,0 @@
-/src
-/*.json
-/conformance
-/dist/**/*.spec.js
-/dist/**/*.spec.d.ts

--- a/packages/connect-express/biome.json
+++ b/packages/connect-express/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["src/testdata/gen"]
+    "ignore": ["src/testdata/gen", "package.json"]
   }
 }

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -19,6 +19,7 @@
   "type": "module",
   "sideEffects": false,
   "tshy": {
+    "selfLink": false,
     "exports": {
       ".": "./src/index.ts"
     }

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -45,7 +45,8 @@
   "files": [
     "dist/**",
     "!dist/**/*.spec.js",
-    "!dist/**/*.spec.d.ts"
+    "!dist/**/*.spec.d.ts",
+    "!dist/**/testdata/**"
   ],
   "exports": {
     ".": {

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-express"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",
+    "build": "tshy",
     "test": "jasmine --config=jasmine.json",
     "conformance": "tsc --noEmit && connectconformance --mode server --conf ./conformance/conformance-express.yaml -v -- tsx ./conformance/server.ts",
     "format": "biome format --write",
@@ -21,11 +18,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "engines": {
@@ -37,6 +33,7 @@
     "@connectrpc/connect-node": "2.1.2",
     "@types/express": "^5.0.6",
     "express": "^5.2.1",
+    "tshy": "^4.1.3",
     "tsx": "^4.20.6"
   },
   "peerDependencies": {
@@ -44,5 +41,26 @@
     "@bufbuild/protobuf": "^2.7.0",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-node": "2.1.2"
-  }
+  },
+  "files": [
+    "dist/**",
+    "!dist/**/*.spec.js",
+    "!dist/**/*.spec.d.ts"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -20,8 +20,7 @@
   "sideEffects": false,
   "tshy": {
     "exports": {
-      ".": "./src/index.ts",
-      "./package.json": "./package.json"
+      ".": "./src/index.ts"
     }
   },
   "engines": {
@@ -57,8 +56,7 @@
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",

--- a/packages/connect-express/tsconfig.build.json
+++ b/packages/connect-express/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "include": ["src/**/*.ts", "src/**/*.spec.ts"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "types": ["jasmine", "node"],
-    "allowSyntheticDefaultImports": true
-  }
-}

--- a/packages/connect-express/tsconfig.json
+++ b/packages/connect-express/tsconfig.json
@@ -2,6 +2,7 @@
   "include": ["src/**/*.ts", "src/**/*.spec.ts", "conformance/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": false,
     "types": ["jasmine", "node"],
     "allowSyntheticDefaultImports": true
   }

--- a/packages/connect-fastify/.npmignore
+++ b/packages/connect-fastify/.npmignore
@@ -1,5 +1,0 @@
-/src
-/*.json
-/conformance
-/dist/**/*.spec.js
-/dist/**/*.spec.d.ts

--- a/packages/connect-fastify/biome.json
+++ b/packages/connect-fastify/biome.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "extends": ["../../biome.base.json"]
+  "extends": ["../../biome.base.json"],
+  "files": {
+    "ignore": ["package.json"]
+  }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "sideEffects": false,
   "tshy": {
+    "selfLink": false,
     "exports": {
       ".": "./src/index.ts"
     }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-fastify"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",
+    "build": "tshy",
     "conformance": "tsc --noEmit && connectconformance --mode server --conf ./conformance/conformance-fastify.yaml -v -- tsx ./conformance/server.ts",
     "format": "biome format --write",
     "license-header": "license-header",
@@ -20,11 +17,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "engines": {
@@ -33,12 +29,32 @@
   "devDependencies": {
     "@connectrpc/connect-conformance": "^2.1.2",
     "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect-node": "2.1.2",
+    "tshy": "^4.1.3"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "fastify": "^4.22.1 || ^5.1.0",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-node": "2.1.2"
-  }
+  },
+  "files": [
+    "dist/**"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -19,8 +19,7 @@
   "sideEffects": false,
   "tshy": {
     "exports": {
-      ".": "./src/index.ts",
-      "./package.json": "./package.json"
+      ".": "./src/index.ts"
     }
   },
   "engines": {
@@ -51,8 +50,7 @@
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",

--- a/packages/connect-fastify/tsconfig.build.json
+++ b/packages/connect-fastify/tsconfig.build.json
@@ -1,7 +1,0 @@
-{
-  "files": ["src/index.ts"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "./src"
-  }
-}

--- a/packages/connect-fastify/tsconfig.json
+++ b/packages/connect-fastify/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "files": ["src/index.ts", "conformance/server.ts"],
-  "extends": "../../tsconfig.base.json"
+  "include": ["src/**/*.ts", "conformance/**/*.ts"],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  }
 }

--- a/packages/connect-next/.npmignore
+++ b/packages/connect-next/.npmignore
@@ -1,4 +1,0 @@
-/src
-/*.json
-/dist/**/*.spec.js
-/dist/**/*.spec.d.ts

--- a/packages/connect-next/biome.json
+++ b/packages/connect-next/biome.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "extends": ["../../biome.base.json"]
+  "extends": ["../../biome.base.json"],
+  "files": {
+    "ignore": ["package.json"]
+  }
 }

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -18,8 +18,7 @@
   "sideEffects": false,
   "tshy": {
     "exports": {
-      ".": "./src/index.ts",
-      "./package.json": "./package.json"
+      ".": "./src/index.ts"
     }
   },
   "engines": {
@@ -49,8 +48,7 @@
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-next"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.json --outDir ./dist/esm",
+    "build": "tshy",
     "format": "biome format --write",
     "license-header": "license-header",
     "lint": "biome lint --error-on-warnings",
@@ -19,11 +16,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "engines": {
@@ -37,6 +33,26 @@
   },
   "devDependencies": {
     "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
-  }
+    "@connectrpc/connect-node": "2.1.2",
+    "tshy": "^4.1.3"
+  },
+  "files": [
+    "dist/**"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "sideEffects": false,
   "tshy": {
+    "selfLink": false,
     "exports": {
       ".": "./src/index.ts"
     }

--- a/packages/connect-next/tsconfig.json
+++ b/packages/connect-next/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "files": ["src/index.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "verbatimModuleSyntax": false,
     // We see a row of errors from Next.js typings here, most likely simply
     // because of dependencies we do not install. For simplicity, we are
     // ignoring them, because we do not want to check Next.js typings.

--- a/packages/connect-node/.npmignore
+++ b/packages/connect-node/.npmignore
@@ -1,6 +1,0 @@
-/src
-/*.json
-/dist/*/**/*.spec.js
-/dist/*/**/*.spec.d.ts
-/dist/*/testdata/
-/conformance

--- a/packages/connect-node/biome.json
+++ b/packages/connect-node/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["src/testdata/gen"]
+    "ignore": ["src/testdata/gen", "package.json"]
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "sideEffects": false,
   "tshy": {
+    "selfLink": false,
     "exports": {
       ".": "./src/index.ts"
     }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-node"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node10 --verbatimModuleSyntax false --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",
+    "build": "tshy",
     "test": "jasmine --config=jasmine.json",
     "conformance:server": "tsc --noEmit && connectconformance --mode server --conf ./conformance/conformance-node.yaml -v -- tsx ./conformance/server.ts",
     "conformance:client": "tsc --noEmit && connectconformance --mode client --conf ./conformance/conformance-node.yaml -v -- tsx ./conformance/client.ts",
@@ -22,11 +19,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "engines": {
@@ -40,6 +36,29 @@
     "@types/node": "^24.10.1",
     "@connectrpc/connect-conformance": "^2.1.2",
     "@types/jasmine": "^5.1.13",
-    "jasmine": "^5.13.0"
-  }
+    "jasmine": "^5.13.0",
+    "tshy": "^4.1.3"
+  },
+  "files": [
+    "dist/**",
+    "!dist/**/*.spec.js",
+    "!dist/**/*.spec.d.ts",
+    "!dist/**/testdata/**"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -21,8 +21,7 @@
   "sideEffects": false,
   "tshy": {
     "exports": {
-      ".": "./src/index.ts",
-      "./package.json": "./package.json"
+      ".": "./src/index.ts"
     }
   },
   "engines": {
@@ -55,8 +54,7 @@
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",

--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -170,7 +170,7 @@ describe("Http2SessionManager", () => {
     });
     it("verify should keep the process alive", async () => {
       const worker = new Worker(
-        "./dist/cjs/testdata/http2-session-manager-verify-ping.js",
+        "./dist/commonjs/testdata/http2-session-manager-verify-ping.js",
         {
           workerData: server.getUrl(),
         },

--- a/packages/connect-node/tsconfig.build.json
+++ b/packages/connect-node/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.spec.ts", "src/testdata/*.ts"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "types": ["jasmine", "node"]
-  }
-}

--- a/packages/connect-node/tsconfig.json
+++ b/packages/connect-node/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.spec.ts", "src/testdata/*.ts", "conformance/**/*.ts"],
+  "include": ["src/**/*.ts", "conformance/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": false,
     "types": ["jasmine", "node"]
   }
 }

--- a/packages/connect-web/.npmignore
+++ b/packages/connect-web/.npmignore
@@ -1,6 +1,0 @@
-/src
-/*.json
-/dist/*/**/*.spec.js
-/dist/*/**/*.spec.d.ts
-/browserstack
-/conformance

--- a/packages/connect-web/biome.json
+++ b/packages/connect-web/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["browserstack/gen"]
+    "ignore": ["browserstack/gen", "package.json"]
   }
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-web"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",
+    "build": "tshy",
     "conformance:safari:promise": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser safari",
     "conformance:safari:callback": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser safari --useCallbackClient",
     "conformance:chrome:promise": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser chrome",
@@ -31,11 +28,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "devDependencies": {
@@ -47,10 +43,32 @@
     "@wdio/local-runner": "^9.19.2",
     "@wdio/browserstack-service": "^9.19.2",
     "jasmine": "^5.13.0",
+    "tshy": "^4.1.3",
     "webdriverio": "^9.7.2"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "@connectrpc/connect": "2.1.2"
-  }
+  },
+  "files": [
+    "dist/**",
+    "!dist/**/*.spec.js",
+    "!dist/**/*.spec.d.ts"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -29,6 +29,7 @@
   "type": "module",
   "sideEffects": false,
   "tshy": {
+    "selfLink": false,
     "exports": {
       ".": "./src/index.ts"
     }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -30,8 +30,7 @@
   "sideEffects": false,
   "tshy": {
     "exports": {
-      ".": "./src/index.ts",
-      "./package.json": "./package.json"
+      ".": "./src/index.ts"
     }
   },
   "devDependencies": {
@@ -65,8 +64,7 @@
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",

--- a/packages/connect-web/tsconfig.build.json
+++ b/packages/connect-web/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "include": ["src/**/*.ts"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "types": ["jasmine"]
-  }
-}

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -2,6 +2,7 @@
   "include": ["src/**/*.ts", "conformance/**/*.ts", "browserstack/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": false,
     "types": ["jasmine"]
   }
 }

--- a/packages/connect/.npmignore
+++ b/packages/connect/.npmignore
@@ -1,6 +1,0 @@
-/src
-/*.json
-/dist/*/**/*.spec.js
-/dist/*/**/*.spec.d.ts
-/buf.gen.yaml
-/scripts/update-user-agent.mjs

--- a/packages/connect/biome.json
+++ b/packages/connect/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["src/protocol-grpc/gen"]
+    "ignore": ["src/protocol-grpc/gen", "package.json"]
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -11,10 +11,7 @@
   "scripts": {
     "generate": "buf generate",
     "postgenerate": "license-header src/protocol-grpc/gen",
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.json --outDir ./dist/esm",
+    "build": "tshy",
     "postbuild": "node scripts/update-user-agent.mjs",
     "test": "jasmine --config=jasmine.json",
     "format": "biome format --write",
@@ -24,35 +21,14 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./protocol": {
-      "import": "./dist/esm/protocol/index.js",
-      "require": "./dist/cjs/protocol/index.js"
-    },
-    "./protocol-connect": {
-      "import": "./dist/esm/protocol-connect/index.js",
-      "require": "./dist/cjs/protocol-connect/index.js"
-    },
-    "./protocol-grpc": {
-      "import": "./dist/esm/protocol-grpc/index.js",
-      "require": "./dist/cjs/protocol-grpc/index.js"
-    },
-    "./protocol-grpc-web": {
-      "import": "./dist/esm/protocol-grpc-web/index.js",
-      "require": "./dist/cjs/protocol-grpc-web/index.js"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "protocol": ["./dist/cjs/protocol/index.d.ts"],
-      "protocol-connect": ["./dist/cjs/protocol-connect/index.d.ts"],
-      "protocol-grpc": ["./dist/cjs/protocol-grpc/index.d.ts"],
-      "protocol-grpc-web": ["./dist/cjs/protocol-grpc-web/index.d.ts"]
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./protocol": "./src/protocol/index.ts",
+      "./protocol-connect": "./src/protocol-connect/index.ts",
+      "./protocol-grpc": "./src/protocol-grpc/index.ts",
+      "./protocol-grpc-web": "./src/protocol-grpc-web/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "peerDependencies": {
@@ -62,6 +38,84 @@
     "@bufbuild/buf": "^1.66.1",
     "@bufbuild/protoc-gen-es": "^2.10.0",
     "@types/jasmine": "^5.1.13",
-    "jasmine": "^5.13.0"
+    "jasmine": "^5.13.0",
+    "tshy": "^4.1.3"
+  },
+  "files": [
+    "dist/**",
+    "!dist/**/*.spec.js",
+    "!dist/**/*.spec.d.ts"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./protocol": {
+      "import": {
+        "types": "./dist/esm/protocol/index.d.ts",
+        "default": "./dist/esm/protocol/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/protocol/index.d.ts",
+        "default": "./dist/commonjs/protocol/index.js"
+      }
+    },
+    "./protocol-connect": {
+      "import": {
+        "types": "./dist/esm/protocol-connect/index.d.ts",
+        "default": "./dist/esm/protocol-connect/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/protocol-connect/index.d.ts",
+        "default": "./dist/commonjs/protocol-connect/index.js"
+      }
+    },
+    "./protocol-grpc": {
+      "import": {
+        "types": "./dist/esm/protocol-grpc/index.d.ts",
+        "default": "./dist/esm/protocol-grpc/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/protocol-grpc/index.d.ts",
+        "default": "./dist/commonjs/protocol-grpc/index.js"
+      }
+    },
+    "./protocol-grpc-web": {
+      "import": {
+        "types": "./dist/esm/protocol-grpc-web/index.d.ts",
+        "default": "./dist/esm/protocol-grpc-web/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/protocol-grpc-web/index.d.ts",
+        "default": "./dist/commonjs/protocol-grpc-web/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "typesVersions": {
+    "*": {
+      "protocol": [
+        "./dist/commonjs/protocol/index.d.ts"
+      ],
+      "protocol-connect": [
+        "./dist/commonjs/protocol-connect/index.d.ts"
+      ],
+      "protocol-grpc": [
+        "./dist/commonjs/protocol-grpc/index.d.ts"
+      ],
+      "protocol-grpc-web": [
+        "./dist/commonjs/protocol-grpc-web/index.d.ts"
+      ]
+    }
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -22,6 +22,7 @@
   "type": "module",
   "sideEffects": false,
   "tshy": {
+    "selfLink": false,
     "exports": {
       ".": "./src/index.ts",
       "./protocol": "./src/protocol/index.ts",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -27,8 +27,7 @@
       "./protocol": "./src/protocol/index.ts",
       "./protocol-connect": "./src/protocol-connect/index.ts",
       "./protocol-grpc": "./src/protocol-grpc/index.ts",
-      "./protocol-grpc-web": "./src/protocol-grpc-web/index.ts",
-      "./package.json": "./package.json"
+      "./protocol-grpc-web": "./src/protocol-grpc-web/index.ts"
     }
   },
   "peerDependencies": {
@@ -96,8 +95,7 @@
         "types": "./dist/commonjs/protocol-grpc-web/index.d.ts",
         "default": "./dist/commonjs/protocol-grpc-web/index.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",

--- a/packages/connect/scripts/update-user-agent.mjs
+++ b/packages/connect/scripts/update-user-agent.mjs
@@ -19,9 +19,9 @@ const paths = [
   "dist/esm/protocol-connect/request-header.js",
   "dist/esm/protocol-grpc/request-header.js",
   "dist/esm/protocol-grpc-web/request-header.js",
-  "dist/cjs/protocol-connect/request-header.js",
-  "dist/cjs/protocol-grpc/request-header.js",
-  "dist/cjs/protocol-grpc-web/request-header.js",
+  "dist/commonjs/protocol-connect/request-header.js",
+  "dist/commonjs/protocol-grpc/request-header.js",
+  "dist/commonjs/protocol-grpc-web/request-header.js",
 ];
 
 const { version } = JSON.parse(

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -1,15 +1,7 @@
 {
-  "files": [
-    "src/index.ts",
-    "src/protocol/index.ts",
-    "src/protocol-connect/index.ts",
-    "src/protocol-grpc/index.ts",
-    "src/protocol-grpc-web/index.ts"
-  ],
-  "include": ["src/**/*.spec.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "verbatimModuleSyntax": false,
     "types": ["jasmine"]
   }
 }


### PR DESCRIPTION
tshy eases a lot of the pain of building CJS + ESM modules. This PR migrates all dual-build packages to build with tshy.
