### PR TITLE
Migrate @connectrpc/connect-web to tshy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14118,6 +14118,7 @@
         "@wdio/jasmine-framework": "^9.19.2",
         "@wdio/local-runner": "^9.19.2",
         "jasmine": "^5.13.0",
+        "tshy": "^4.1.3",
         "webdriverio": "^9.7.2"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14002,7 +14002,8 @@
         "@bufbuild/protoc-gen-es": "^2.10.0",
         "@types/debug": "^4.1.13",
         "@types/node-forge": "^1.3.14",
-        "@types/tar-stream": "^3.1.4"
+        "@types/tar-stream": "^3.1.4",
+        "tshy": "^4.1.3"
       }
     },
     "packages/connect-express": {
@@ -14035,7 +14036,8 @@
       "devDependencies": {
         "@connectrpc/connect": "2.1.2",
         "@connectrpc/connect-conformance": "^2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect-node": "2.1.2",
+        "tshy": "^4.1.3"
       },
       "engines": {
         "node": ">=20"
@@ -14074,7 +14076,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect-node": "2.1.2",
+        "tshy": "^4.1.3"
       },
       "engines": {
         "node": ">=20"

--- a/packages/connect-conformance/bin/connectconformance.cjs
+++ b/packages/connect-conformance/bin/connectconformance.cjs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const { run } = require("../dist/cjs/conformance.js");
+const { run } = require("../dist/commonjs/conformance.js");
 const { scripts } = require("../package.json");
 
 // Extract conformance runner version from the `generate` script

--- a/packages/connect-conformance/biome.json
+++ b/packages/connect-conformance/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["src/gen"]
+    "ignore": ["src/gen", "package.json"]
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -3,11 +3,10 @@
   "version": "2.1.2",
   "private": true,
   "type": "module",
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "bin": {
@@ -16,11 +15,8 @@
   "scripts": {
     "generate": "buf generate buf.build/connectrpc/conformance:v1.0.4",
     "postgenerate": "license-header src/gen",
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
+    "build": "tshy",
     "postbuild": "connectconformance --version",
-    "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.json --outDir ./dist/esm",
     "format": "biome format --write",
     "license-header": "license-header",
     "lint": "biome lint --error-on-warnings",
@@ -37,6 +33,23 @@
     "@bufbuild/protoc-gen-es": "^2.10.0",
     "@types/debug": "^4.1.13",
     "@types/node-forge": "^1.3.14",
-    "@types/tar-stream": "^3.1.4"
-  }
+    "@types/tar-stream": "^3.1.4",
+    "tshy": "^4.1.3"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-conformance/tsconfig.json
+++ b/packages/connect-conformance/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "include": ["src/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "verbatimModuleSyntax": false,
     "resolveJsonModule": true
   }
 }

--- a/packages/connect-fastify/.npmignore
+++ b/packages/connect-fastify/.npmignore
@@ -1,5 +1,0 @@
-/src
-/*.json
-/conformance
-/dist/**/*.spec.js
-/dist/**/*.spec.d.ts

--- a/packages/connect-fastify/biome.json
+++ b/packages/connect-fastify/biome.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "extends": ["../../biome.base.json"]
+  "extends": ["../../biome.base.json"],
+  "files": {
+    "ignore": ["package.json"]
+  }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-fastify"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",
+    "build": "tshy",
     "conformance": "tsc --noEmit && connectconformance --mode server --conf ./conformance/conformance-fastify.yaml -v -- tsx ./conformance/server.ts",
     "format": "biome format --write",
     "license-header": "license-header",
@@ -20,11 +17,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "engines": {
@@ -33,12 +29,32 @@
   "devDependencies": {
     "@connectrpc/connect-conformance": "^2.1.2",
     "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect-node": "2.1.2",
+    "tshy": "^4.1.3"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "fastify": "^4.22.1 || ^5.1.0",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-node": "2.1.2"
-  }
+  },
+  "files": [
+    "dist/**"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-fastify/tsconfig.build.json
+++ b/packages/connect-fastify/tsconfig.build.json
@@ -1,7 +1,0 @@
-{
-  "files": ["src/index.ts"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "./src"
-  }
-}

--- a/packages/connect-fastify/tsconfig.json
+++ b/packages/connect-fastify/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "files": ["src/index.ts", "conformance/server.ts"],
-  "extends": "../../tsconfig.base.json"
+  "include": ["src/**/*.ts", "conformance/**/*.ts"],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  }
 }

--- a/packages/connect-next/.npmignore
+++ b/packages/connect-next/.npmignore
@@ -1,4 +1,0 @@
-/src
-/*.json
-/dist/**/*.spec.js
-/dist/**/*.spec.d.ts

--- a/packages/connect-next/biome.json
+++ b/packages/connect-next/biome.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "extends": ["../../biome.base.json"]
+  "extends": ["../../biome.base.json"],
+  "files": {
+    "ignore": ["package.json"]
+  }
 }

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-next"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.json --outDir ./dist/esm",
+    "build": "tshy",
     "format": "biome format --write",
     "license-header": "license-header",
     "lint": "biome lint --error-on-warnings",
@@ -19,11 +16,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "engines": {
@@ -37,6 +33,26 @@
   },
   "devDependencies": {
     "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
-  }
+    "@connectrpc/connect-node": "2.1.2",
+    "tshy": "^4.1.3"
+  },
+  "files": [
+    "dist/**"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-next/tsconfig.json
+++ b/packages/connect-next/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "files": ["src/index.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "verbatimModuleSyntax": false,
     // We see a row of errors from Next.js typings here, most likely simply
     // because of dependencies we do not install. For simplicity, we are
     // ignoring them, because we do not want to check Next.js typings.

--- a/packages/connect-web/.npmignore
+++ b/packages/connect-web/.npmignore
@@ -1,6 +1,0 @@
-/src
-/*.json
-/dist/*/**/*.spec.js
-/dist/*/**/*.spec.d.ts
-/browserstack
-/conformance

--- a/packages/connect-web/biome.json
+++ b/packages/connect-web/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["browserstack/gen"]
+    "ignore": ["browserstack/gen", "package.json"]
   }
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-web"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --outDir ./dist/esm",
+    "build": "tshy",
     "conformance:safari:promise": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser safari",
     "conformance:safari:callback": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser safari --useCallbackClient",
     "conformance:chrome:promise": "connectconformance --mode client --conf conformance/conformance-web.yaml -- tsx conformance/client.ts --browser chrome",
@@ -31,11 +28,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "devDependencies": {
@@ -47,10 +43,32 @@
     "@wdio/local-runner": "^9.19.2",
     "@wdio/browserstack-service": "^9.19.2",
     "jasmine": "^5.13.0",
+    "tshy": "^4.1.3",
     "webdriverio": "^9.7.2"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "@connectrpc/connect": "2.1.2"
-  }
+  },
+  "files": [
+    "dist/**",
+    "!dist/**/*.spec.js",
+    "!dist/**/*.spec.d.ts"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-web/tsconfig.build.json
+++ b/packages/connect-web/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "include": ["src/**/*.ts"],
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "types": ["jasmine"]
-  }
-}

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -2,6 +2,7 @@
   "include": ["src/**/*.ts", "conformance/**/*.ts", "browserstack/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "verbatimModuleSyntax": false,
     "types": ["jasmine"]
   }
 }


### PR DESCRIPTION
tshy eases a lot of the pain of building CJS + ESM modules. This PR migrates the connect-web package to build with tshy.