### PR TITLE
Migrate @connectrpc/connect-next to tshy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14002,7 +14002,8 @@
         "@bufbuild/protoc-gen-es": "^2.10.0",
         "@types/debug": "^4.1.13",
         "@types/node-forge": "^1.3.14",
-        "@types/tar-stream": "^3.1.4"
+        "@types/tar-stream": "^3.1.4",
+        "tshy": "^4.1.3"
       }
     },
     "packages/connect-express": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14075,7 +14075,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect-node": "2.1.2",
+        "tshy": "^4.1.3"
       },
       "engines": {
         "node": ">=20"

--- a/packages/connect-conformance/bin/connectconformance.cjs
+++ b/packages/connect-conformance/bin/connectconformance.cjs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const { run } = require("../dist/cjs/conformance.js");
+const { run } = require("../dist/commonjs/conformance.js");
 const { scripts } = require("../package.json");
 
 // Extract conformance runner version from the `generate` script

--- a/packages/connect-conformance/biome.json
+++ b/packages/connect-conformance/biome.json
@@ -2,6 +2,6 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["../../biome.base.json"],
   "files": {
-    "ignore": ["src/gen"]
+    "ignore": ["src/gen", "package.json"]
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -3,11 +3,10 @@
   "version": "2.1.2",
   "private": true,
   "type": "module",
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "bin": {
@@ -16,11 +15,8 @@
   "scripts": {
     "generate": "buf generate buf.build/connectrpc/conformance:v1.0.4",
     "postgenerate": "license-header src/gen",
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
+    "build": "tshy",
     "postbuild": "connectconformance --version",
-    "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.json --outDir ./dist/esm",
     "format": "biome format --write",
     "license-header": "license-header",
     "lint": "biome lint --error-on-warnings",
@@ -37,6 +33,23 @@
     "@bufbuild/protoc-gen-es": "^2.10.0",
     "@types/debug": "^4.1.13",
     "@types/node-forge": "^1.3.14",
-    "@types/tar-stream": "^3.1.4"
-  }
+    "@types/tar-stream": "^3.1.4",
+    "tshy": "^4.1.3"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-conformance/tsconfig.json
+++ b/packages/connect-conformance/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "include": ["src/**/*.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "verbatimModuleSyntax": false,
     "resolveJsonModule": true
   }
 }

--- a/packages/connect-next/.npmignore
+++ b/packages/connect-next/.npmignore
@@ -1,4 +1,0 @@
-/src
-/*.json
-/dist/**/*.spec.js
-/dist/**/*.spec.d.ts

--- a/packages/connect-next/biome.json
+++ b/packages/connect-next/biome.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "extends": ["../../biome.base.json"]
+  "extends": ["../../biome.base.json"],
+  "files": {
+    "ignore": ["package.json"]
+  }
 }

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -8,10 +8,7 @@
     "directory": "packages/connect-next"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/*",
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.json --module commonjs --verbatimModuleSyntax false --moduleResolution node10 --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.json --outDir ./dist/esm",
+    "build": "tshy",
     "format": "biome format --write",
     "license-header": "license-header",
     "lint": "biome lint --error-on-warnings",
@@ -19,11 +16,10 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+  "tshy": {
+    "exports": {
+      ".": "./src/index.ts",
+      "./package.json": "./package.json"
     }
   },
   "engines": {
@@ -37,6 +33,26 @@
   },
   "devDependencies": {
     "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
-  }
+    "@connectrpc/connect-node": "2.1.2",
+    "tshy": "^4.1.3"
+  },
+  "files": [
+    "dist/**"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/packages/connect-next/tsconfig.json
+++ b/packages/connect-next/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "files": ["src/index.ts"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "verbatimModuleSyntax": false,
     // We see a row of errors from Next.js typings here, most likely simply
     // because of dependencies we do not install. For simplicity, we are
     // ignoring them, because we do not want to check Next.js typings.


### PR DESCRIPTION
atshy eases a lot of the pain of building CJS + ESM modules. This PR migrates the connect-next package to build with tshy.