### PR TITLE
Fix Http2SessionManager.verify() never settling when the connection closes during verification

### DIFF
--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -274,21 +274,21 @@ describe("Http2SessionManager", () => {
     it("should open a new connection if the existing one closes gracefully during verification", async (t) => {
       // proxy the server, so that the answer to a verification PING can be dropped
       let dropServerToClient = false;
-      const proxy = net.createServer((clientSide) => {
-        const serverSide = net.connect(
+      const proxy = net.createServer((clientSocket) => {
+        const serverSocket = net.connect(
           Number(new URL(server.getUrl()).port),
           "localhost",
         );
-        clientSide.pipe(serverSide);
-        serverSide.on("data", (chunk) => {
+        clientSocket.pipe(serverSocket);
+        serverSocket.on("data", (chunk) => {
           if (!dropServerToClient) {
-            clientSide.write(chunk);
+            clientSocket.write(chunk);
           }
         });
-        clientSide.on("error", () => {});
-        serverSide.on("error", () => {});
-        clientSide.on("close", () => serverSide.destroy());
-        serverSide.on("close", () => clientSide.destroy());
+        clientSocket.on("error", () => {});
+        serverSocket.on("error", () => {});
+        clientSocket.on("close", () => serverSocket.destroy());
+        serverSocket.on("close", () => clientSocket.destroy());
       });
       await new Promise<void>((resolve) =>
         proxy.listen(0, "localhost", resolve),
@@ -305,12 +305,14 @@ describe("Http2SessionManager", () => {
       );
       t.after(() => sm.abort());
 
-      // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
+      // issue a request and close it to start the idle timeout
       const req1 = await sm.request("POST", "/", {}, {});
       const req1Session = req1.session;
       await new Promise<void>((resolve) =>
         req1.close(http2.constants.NGHTTP2_NO_ERROR, resolve),
       );
+
+      // stop the server and wait for more than pingIntervalMs to trigger a verification
       dropServerToClient = true;
       await new Promise<void>((resolve) => setTimeout(resolve, 20));
 
@@ -318,11 +320,12 @@ describe("Http2SessionManager", () => {
       const req2Promise = sm.request("POST", "/", {}, {});
       req2Promise.catch(() => {}); // tolerate a late rejection after a failed test
       assert.strictEqual(sm.state(), "verifying");
-
-      // the PING answer is dropped for good - restore the network, then wait
-      // for the idle timeout to close the connection while the PING is still
-      // in flight ("close" without "error", PING cancelled without a result)
       await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+      // the PING answer should be dropped for good now - restore the network,
+      // then wait for the idle timeout to close the connection while the PING
+      // is still in flight ("close" without "error", PING cancelled without a
+      // result)
       dropServerToClient = false;
       await new Promise<void>((resolve) => setTimeout(resolve, 40));
 

--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -16,6 +16,7 @@ import { describe, it } from "node:test";
 import * as assert from "node:assert";
 import { useNodeServer } from "./use-node-server-helper.spec.js";
 import * as http2 from "node:http2";
+import * as net from "node:net";
 import { Http2SessionManager } from "./http2-session-manager.js";
 import { ConnectError } from "@connectrpc/connect";
 import { Worker } from "node:worker_threads";
@@ -269,6 +270,76 @@ describe("Http2SessionManager", () => {
       );
       sm.abort();
       assert.strictEqual(sm.state(), "closed");
+    });
+    it("should open a new connection if the existing one closes gracefully during verification", async (t) => {
+      // proxy the server, so that the answer to a verification PING can be dropped
+      let dropServerToClient = false;
+      const proxy = net.createServer((clientSide) => {
+        const serverSide = net.connect(
+          Number(new URL(server.getUrl()).port),
+          "localhost",
+        );
+        clientSide.pipe(serverSide);
+        serverSide.on("data", (chunk) => {
+          if (!dropServerToClient) {
+            clientSide.write(chunk);
+          }
+        });
+        clientSide.on("error", () => {});
+        serverSide.on("error", () => {});
+        clientSide.on("close", () => serverSide.destroy());
+        serverSide.on("close", () => clientSide.destroy());
+      });
+      await new Promise<void>((resolve) =>
+        proxy.listen(0, "localhost", resolve),
+      );
+      t.after(() => proxy.close());
+
+      const sm = new Http2SessionManager(
+        `http://localhost:${(proxy.address() as net.AddressInfo).port}`,
+        {
+          pingIntervalMs: 10, // intentionally short to trigger verification in tests
+          pingTimeoutMs: 250, // intentionally long, so that the idle timeout below fires first
+          idleConnectionTimeoutMs: 50, // intentionally short, so that the connection closes during verification
+        },
+      );
+      t.after(() => sm.abort());
+
+      // issue a request and close it, then wait for more than pingIntervalMs to trigger a verification
+      const req1 = await sm.request("POST", "/", {}, {});
+      const req1Session = req1.session;
+      await new Promise<void>((resolve) =>
+        req1.close(http2.constants.NGHTTP2_NO_ERROR, resolve),
+      );
+      dropServerToClient = true;
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+      // this request sends a verification PING whose answer is dropped
+      const req2Promise = sm.request("POST", "/", {}, {});
+      req2Promise.catch(() => {}); // tolerate a late rejection after a failed test
+      assert.strictEqual(sm.state(), "verifying");
+
+      // the PING answer is dropped for good - restore the network, then wait
+      // for the idle timeout to close the connection while the PING is still
+      // in flight ("close" without "error", PING cancelled without a result)
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      dropServerToClient = false;
+      await new Promise<void>((resolve) => setTimeout(resolve, 40));
+
+      // the verification must settle, and the request proceeds on a new connection
+      const req2 = await Promise.race([
+        req2Promise,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("verification never settled")),
+            500,
+          ),
+        ),
+      ]);
+      assert.notStrictEqual(req1Session, req2.session);
+      await new Promise<void>((resolve) =>
+        req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve),
+      );
     });
   });
 

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -613,15 +613,22 @@ function ready(
     verify() {
       conn.ref();
       return new Promise<boolean>((resolve) => {
-        const onError = () => {
+        // The connection can close gracefully while the PING is in flight,
+        // for example when the idle timeout elapses during verification. That
+        // emits "close" without "error", and cancels the PING without a
+        // result. This promise is memoized in Http2SessionManager.verifying -
+        // if it never settles, all future verifications hang.
+        const onFailure = () => {
           resolve(false);
         };
         commonPing(() => {
           if (streamCount == 0) conn.unref();
-          conn.off("error", onError);
+          conn.off("error", onFailure);
+          conn.off("close", onFailure);
           resolve(true);
         });
-        conn.once("error", onError);
+        conn.once("error", onFailure);
+        conn.once("close", onFailure);
       });
     },
     abort(reason) {


### PR DESCRIPTION
# Background

`verify()` settles its promise in two ways: the PING callback succeeds, or the connection emits `error`. There is a third case: the connection closes gracefully while the PING is in flight. This happens in practice when the idle timeout elapses during a verification - the idle timer keeps running while a verify is pending, and `onIdleTimeout` calls `conn.close()`.

A graceful close emits `close` without `error`. The PING callback receives `ERR_HTTP2_PING_CANCEL` and returns without resolving (deferring to the `error` listener that never fires), and the PING timeout timer that would have destroyed the connection is cleared by the ready state's `cleanup()` on close. So none of the settle paths run, and the promise stays pending forever.

Because the manager memoizes the promise in `this.verifying` and only clears it once it settles, a single occurrence poisons the manager permanently: every future request that hits `requiresVerify()` awaits the pinned promise until its own deadline. New connections still get dialed once the state reaches `closed`, but each one only serves the request that dialed it - after the next quiet period, requests funnel back into the stuck verification. `abort()` doesn't recover either, it never touches `verifying`.

We hit this in production: a process's transport stopped serving requests for ~50 minutes (every RPC timed out on its deadline, sockets healthy at the kernel level, no PING frames on the wire) until the process was restarted. Possibly the same root cause as the zombie state described in #1561.

# Summary

Resolve `verify()` on `close` as well, and detach the listeners on every settle path.

The new test reproduces the hang with a small TCP proxy that drops the answer to the verification PING while the idle timeout closes the connection gracefully. Without the fix, the request never settles; with it, the verification fails and the request proceeds on a new connection.
