### PR TITLE
Reject unary calls when the http/2 stream closes with NO_ERROR before the response

### DIFF
--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -144,6 +144,42 @@ describe("universal node http client", () => {
     });
   });
 
+  describe("against a server that closes with NO_ERROR before the response", () => {
+    describe("over http/2", () => {
+      const server = useNodeServer(() =>
+        http2.createServer((request, response) => {
+          response.stream.close(http2.constants.NGHTTP2_NO_ERROR);
+        }),
+      );
+      it("should reject the response promise with Code.Unavailable", async () => {
+        const client = server.getClient();
+        await assert.rejects(
+          Promise.race([
+            client({
+              url: server.getUrl(),
+              method: "POST",
+              header: new Headers(),
+            }),
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () => reject(new Error("response promise never settled")),
+                500,
+              ),
+            ),
+          ]),
+          (e: unknown) => {
+            assert.ok(e instanceof ConnectError, String(e));
+            assert.strictEqual(
+              e.message,
+              "[unavailable] http/2 stream closed with error code NO_ERROR (0x0) before the response was received",
+            );
+            return true;
+          },
+        );
+      });
+    });
+  });
+
   describe("against a server that closes before the first response byte", () => {
     describe("over http/2", () => {
       const server = useNodeServer(() =>

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -309,10 +309,25 @@ function h2Request(
         sentinel.error(e);
       });
 
+      let responseReceived = false;
+      stream.once("response", () => {
+        responseReceived = true;
+      });
       stream.on("close", function h2StreamClose() {
         const err = connectErrorFromH2ResetCode(stream.rstCode);
         if (err) {
           sentinel.error(err);
+        } else if (!responseReceived) {
+          // A stream can be terminated with the NO_ERROR code before response
+          // headers are received - for example by a proxy during a graceful
+          // shutdown. Nothing else settles the sentinel in this case, and the
+          // request would stay pending forever.
+          sentinel.error(
+            new ConnectError(
+              "http/2 stream closed with error code NO_ERROR (0x0) before the response was received",
+              Code.Unavailable,
+            ),
+          );
         }
       });
       onStream(stream);


### PR DESCRIPTION
# Background

Fixes #1678.

The `close` handler in `h2Request()` only errors the sentinel when the stream's reset code maps to a ConnectError, and `connectErrorFromH2ResetCode()` intentionally maps `NO_ERROR` (0x0) to `undefined`, because that is also the code of ordinary stream completion.

But when a stream is reset with `NO_ERROR` *before response headers were received* - proxies like Linkerd or Envoy do this during graceful shutdowns - there is no ordinary completion: the response promise has not resolved, and nothing else errors the sentinel. The returned promise stays pending forever, which matches the forensics in #1678 (one orphaned `await`, session manager already moved on, no retained streams).

# Summary

Track whether the `response` event was seen, and reject with `Code.Unavailable` when the stream closes without it and without a mapped reset error. Streams that received a response are unaffected, so ordinary completions (which also close with code 0x0) don't change behavior.

Unavailable matches the existing `REFUSED_STREAM` mapping: the server provably did not process the request, so it is safe to retry.

The new test reproduces the hang with a server that resets the stream with `NGHTTP2_NO_ERROR` without responding; without the fix, the response promise never settles.

Related, but distinct from #1746: that one fixes a session-level hang in `Http2SessionManager.verify()`; this one fixes a call-level hang in the universal client.
