### PR TITLE
Add connectTimeoutMs option to bound connection establishment

### DIFF
--- a/packages/connect-node/src/http2-session-manager.spec.ts
+++ b/packages/connect-node/src/http2-session-manager.spec.ts
@@ -16,6 +16,7 @@ import { describe, it } from "node:test";
 import * as assert from "node:assert";
 import { useNodeServer } from "./use-node-server-helper.spec.js";
 import * as http2 from "node:http2";
+import * as net from "node:net";
 import { Http2SessionManager } from "./http2-session-manager.js";
 import { ConnectError } from "@connectrpc/connect";
 import { Worker } from "node:worker_threads";
@@ -266,6 +267,76 @@ describe("Http2SessionManager", () => {
       // clean up
       await new Promise<void>((resolve) =>
         req2.close(http2.constants.NGHTTP2_NO_ERROR, resolve),
+      );
+      sm.abort();
+      assert.strictEqual(sm.state(), "closed");
+    });
+  });
+
+  describe("with connectTimeoutMs", () => {
+    it("should reject requests if the connection cannot be established in time", async (t) => {
+      // a server that accepts connections, but never completes the TLS
+      // handshake - without connectTimeoutMs, the connection attempt (and
+      // every request waiting on it) stays pending indefinitely
+      const silentSockets: net.Socket[] = [];
+      const silentServer = net.createServer((socket) =>
+        silentSockets.push(socket),
+      );
+      await new Promise<void>((resolve) =>
+        silentServer.listen(0, "localhost", resolve),
+      );
+      t.after(() => {
+        for (const socket of silentSockets) {
+          socket.destroy();
+        }
+        silentServer.close();
+      });
+
+      const sm = new Http2SessionManager(
+        `https://localhost:${(silentServer.address() as net.AddressInfo).port}`,
+        {
+          connectTimeoutMs: 50, // intentionally short for tests
+        },
+      );
+      t.after(() => sm.abort());
+
+      await assert.rejects(
+        Promise.race([
+          sm.request("POST", "/", {}, {}),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("connection attempt is not bounded")),
+              1000,
+            ),
+          ),
+        ]),
+        /\[unavailable] connection establishment timed out/,
+      );
+      assert.strictEqual(sm.state(), "error");
+
+      // the manager must not be stuck: the next request dials again, and is
+      // bounded by the same timeout
+      await assert.rejects(
+        Promise.race([
+          sm.request("POST", "/", {}, {}),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("connection attempt is not bounded")),
+              1000,
+            ),
+          ),
+        ]),
+        /\[unavailable] connection establishment timed out/,
+      );
+    });
+    it("should not affect connections that are established in time", async () => {
+      const sm = new Http2SessionManager(server.getUrl(), {
+        connectTimeoutMs: 1000,
+      });
+      const req = await sm.request("POST", "/", {}, {});
+      assert.strictEqual(sm.state(), "open");
+      await new Promise<void>((resolve) =>
+        req.close(http2.constants.NGHTTP2_NO_ERROR, resolve),
       );
       sm.abort();
       assert.strictEqual(sm.state(), "closed");

--- a/packages/connect-node/src/http2-session-manager.ts
+++ b/packages/connect-node/src/http2-session-manager.ts
@@ -69,6 +69,23 @@ export interface Http2SessionOptions {
    * This option is equivalent to GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS of gRPC core.
    */
   idleConnectionTimeoutMs?: number;
+
+  /**
+   * Timeout for establishing a connection, including the TLS handshake. If
+   * the connection is not ready within this time, it is destroyed, and
+   * pending requests reject with Code.Unavailable.
+   *
+   * By default, no timeout is applied. The operating system's TCP timeouts
+   * bound a connection attempt that receives no answer at all, but nothing
+   * bounds an attempt that dies after the TCP handshake - for example when
+   * the network path is lost while the TLS handshake is in flight. Such an
+   * attempt stays pending indefinitely, and every request waiting on it
+   * fails.
+   *
+   * This option is similar to the connection deadline that gRPC core derives
+   * from GRPC_ARG_MIN_RECONNECT_BACKOFF_MS.
+   */
+  connectTimeoutMs?: number;
 }
 
 /**
@@ -170,6 +187,8 @@ export class Http2SessionManager {
       pingIdleConnection: pingOptions?.pingIdleConnection ?? false,
       idleConnectionTimeoutMs:
         pingOptions?.idleConnectionTimeoutMs ?? 1000 * 60 * 15,
+      connectTimeoutMs:
+        pingOptions?.connectTimeoutMs ?? Number.POSITIVE_INFINITY,
     };
   }
 
@@ -269,12 +288,24 @@ export class Http2SessionManager {
         this.s.conn.closed ||
         this.s.conn.destroyed
       ) {
-        this.setState(connect(this.authority, this.http2SessionOptions));
+        this.setState(
+          connect(
+            this.authority,
+            this.http2SessionOptions,
+            this.options.connectTimeoutMs,
+          ),
+        );
       } else if (this.s.requiresVerify()) {
         await this.verify(this.s);
       }
     } else if (this.s.t == "closed" || this.s.t == "error") {
-      this.setState(connect(this.authority, this.http2SessionOptions));
+      this.setState(
+        connect(
+          this.authority,
+          this.http2SessionOptions,
+          this.options.connectTimeoutMs,
+        ),
+      );
     }
     while (this.s.t !== "ready") {
       if (this.s.t === "error") {
@@ -338,7 +369,13 @@ export class Http2SessionManager {
             return;
           }
           // verify() has destroyed the old connection
-          this.setState(connect(this.authority, this.http2SessionOptions));
+          this.setState(
+            connect(
+              this.authority,
+              this.http2SessionOptions,
+              this.options.connectTimeoutMs,
+            ),
+          );
         },
         (reason) => {
           this.setState(closedOrError(reason));
@@ -425,6 +462,7 @@ function connect(
     | http2.ClientSessionOptions
     | http2.SecureClientSessionOptions
     | undefined,
+  connectTimeoutMs: number,
 ): StateConnecting {
   let resolve: ((value: http2.ClientHttp2Session) => void) | undefined;
   let reject: ((reason: unknown) => void) | undefined;
@@ -433,6 +471,17 @@ function connect(
     reject = rej;
   });
   const newConn = http2.connect(authority, http2SessionOptions);
+  const connectTimeoutId = safeSetTimeout(() => {
+    if (!newConn.destroyed) {
+      newConn.destroy(undefined, http2.constants.NGHTTP2_CANCEL);
+    }
+    // Same as abort() below: destroy() should terminate the session, but we
+    // still receive a "connect" event. We must not resolve a broken
+    // connection, so we reject it manually here.
+    reject?.(
+      new ConnectError("connection establishment timed out", Code.Unavailable),
+    );
+  }, connectTimeoutMs);
   newConn.on("connect", onConnect);
   newConn.on("error", onError);
 
@@ -447,6 +496,7 @@ function connect(
   }
 
   function cleanup() {
+    clearTimeout(connectTimeoutId);
     newConn.off("connect", onConnect);
     newConn.off("error", onError);
   }

--- a/packages/connect-node/src/node-transport-options.ts
+++ b/packages/connect-node/src/node-transport-options.ts
@@ -89,6 +89,7 @@ export function validateNodeTransportOptions(
           pingIdleConnection: options.pingIdleConnection,
           pingTimeoutMs: options.pingTimeoutMs,
           idleConnectionTimeoutMs: options.idleConnectionTimeoutMs,
+          connectTimeoutMs: options.connectTimeoutMs,
         },
         options.nodeOptions,
       );


### PR DESCRIPTION
# Background

Connection establishment in `Http2SessionManager` has no timeout. The operating system's TCP timeouts bound an attempt that receives no answer at all, but nothing bounds an attempt that dies *after* the TCP handshake - for example when the network path is lost while the TLS handshake is in flight. At that point there is nothing left for TCP to retransmit, TLS clients in Node.js have no handshake timeout, and `http2.connect()` adds none, so the attempt stays pending indefinitely. The manager pins in the "connecting" state, and every request queued on it fails on its own deadline (or hangs, if it has none).

This is easy to demonstrate: dial a TCP server that accepts connections but never completes the TLS handshake. The manager reports "connecting" forever.

We've been chasing this family of hangs in production (see #1746 and #1747 for the session-level and call-level variants); this is the last phase of a connection's life without a bounded clock. gRPC core bounds connection establishment with a connect deadline; connect-node currently has no equivalent.

# Summary

Add an opt-in `connectTimeoutMs` option to `Http2SessionOptions`. When the connection is not ready within the given time, it is destroyed, and pending requests reject with `Code.Unavailable` - the same code that `ETIMEDOUT` and `ECONNREFUSED` map to, so retry behavior is consistent with other connection failures. The next request opens a fresh connection.

By default no timeout is applied, so behavior is unchanged for existing users. Since the transport options intersect `Http2SessionOptions`, the option is available on `createGrpcTransport()` et al with a one-line change in `validateNodeTransportOptions`.

The new test uses a TCP server that accepts and stays silent: with `connectTimeoutMs`, the first request rejects within the timeout, the manager transitions to "error" instead of pinning, and a subsequent request dials again with the same bound.
