### PR TITLE
connect-node: reject gRPC responses truncated by RST_STREAM(NO_ERROR) with Code.Unavailable

### DIFF
--- a/packages/connect-node/src/node-universal-client.spec.ts
+++ b/packages/connect-node/src/node-universal-client.spec.ts
@@ -16,7 +16,8 @@ import { describe, it } from "node:test";
 import * as assert from "node:assert";
 import * as http2 from "node:http2";
 import * as http from "node:http";
-import { ConnectError } from "@connectrpc/connect";
+import type * as net from "node:net";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { createAsyncIterable } from "@connectrpc/connect/protocol";
 import { createNodeHttpClient } from "./node-universal-client.js";
 import { useNodeServer } from "./use-node-server-helper.spec.js";
@@ -62,6 +63,25 @@ describe("node http/2 client closing with RST_STREAM with code CANCEL", () => {
     assert.strictEqual(serverReceivedRstCode, http2.constants.NGHTTP2_CANCEL);
   });
 });
+
+/**
+ * Returns a serialized RST_STREAM frame with error code NO_ERROR (0x0) for
+ * the given stream, see https://www.rfc-editor.org/rfc/rfc9113#name-rst_stream
+ *
+ * Writing this frame directly to the socket simulates a peer - typically a
+ * proxy - that resets a stream without the END_STREAM flag having been sent.
+ * The server APIs of the http2 module cannot produce this sequence: they
+ * gracefully end the stream first.
+ */
+function rstStreamNoError(streamId: number): Buffer {
+  const frame = Buffer.alloc(13);
+  frame.writeUIntBE(4, 0, 3); // payload length
+  frame.writeUInt8(0x03, 3); // frame type RST_STREAM
+  frame.writeUInt8(0, 4); // flags
+  frame.writeUInt32BE(streamId, 5); // stream id
+  frame.writeUInt32BE(0, 9); // error code NO_ERROR
+  return frame;
+}
 
 describe("universal node http client", () => {
   describe("against an unresolvable host", () => {
@@ -140,6 +160,264 @@ describe("universal node http client", () => {
           },
         );
         assert.ok(serverReceivedRequest);
+      });
+    });
+  });
+
+  describe("against a server that closes with NO_ERROR before the response", () => {
+    describe("over http/2", () => {
+      const server = useNodeServer(() =>
+        http2.createServer((request, response) => {
+          response.stream.close(http2.constants.NGHTTP2_NO_ERROR);
+        }),
+      );
+      it("should reject a request with te: trailers with Code.Unavailable", async () => {
+        const client = server.getClient();
+        await assert.rejects(
+          Promise.race([
+            client({
+              url: server.getUrl(),
+              method: "POST",
+              header: new Headers({ te: "trailers" }),
+            }),
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () => reject(new Error("response promise never settled")),
+                500,
+              ),
+            ),
+          ]),
+          (e: unknown) => {
+            assert.ok(e instanceof ConnectError, String(e));
+            assert.strictEqual(
+              e.message,
+              "[unavailable] http/2 stream closed with error code NO_ERROR (0x0) before trailers were received",
+            );
+            return true;
+          },
+        );
+      });
+    });
+  });
+
+  describe("against a server that resets the stream with NO_ERROR mid response body", () => {
+    describe("over http/2", () => {
+      let rawSocket: net.Socket | undefined;
+      const server = useNodeServer(() => {
+        const s = http2.createServer();
+        s.on("connection", (socket: net.Socket) => {
+          rawSocket = socket;
+        });
+        s.on("stream", (stream) => {
+          stream.respond({
+            ":status": 200,
+            "content-type": "application/grpc",
+          });
+          // Write a chunk of the response body, but never the END_STREAM
+          // flag. Then send a raw RST_STREAM frame with code NO_ERROR, like
+          // a proxy that loses the connection to the backend during a
+          // graceful shutdown. The frame is written directly to the socket,
+          // because closing the stream via the http2 module would gracefully
+          // send the END_STREAM flag first.
+          const id = stream.id ?? 0;
+          stream.write(new Uint8Array(64), () => {
+            setImmediate(() => rawSocket?.write(rstStreamNoError(id)));
+          });
+        });
+        return s;
+      });
+      it("should reject a request with te: trailers with Code.Unavailable", async () => {
+        const client = server.getClient();
+        const res = await client({
+          url: server.getUrl(),
+          method: "POST",
+          header: new Headers({ te: "trailers" }),
+        });
+        let bytesReceived = 0;
+        await assert.rejects(
+          async () => {
+            for await (const chunk of res.body) {
+              bytesReceived += chunk.byteLength;
+            }
+          },
+          (e: unknown) => {
+            assert.ok(e instanceof ConnectError, String(e));
+            assert.strictEqual(e.code, Code.Unavailable);
+            assert.strictEqual(
+              e.message,
+              "[unavailable] http/2 stream closed with error code NO_ERROR (0x0) before trailers were received",
+            );
+            return true;
+          },
+        );
+        assert.strictEqual(bytesReceived, 64);
+      });
+    });
+  });
+
+  describe("against a server that resets the stream with NO_ERROR after the response body, instead of sending trailers", () => {
+    describe("over http/2", () => {
+      const server = useNodeServer(() =>
+        http2.createServer().on("stream", (stream) => {
+          stream.respond(
+            {
+              ":status": 200,
+              "content-type": "application/grpc",
+            },
+            { waitForTrailers: true },
+          );
+          // Closing with NO_ERROR while trailers are still outstanding sends
+          // the response body, and then an RST_STREAM frame with code
+          // NO_ERROR without the END_STREAM flag - the same wire sequence as
+          // a proxy resetting the stream before the trailers arrive.
+          stream.write(new Uint8Array(64), () =>
+            stream.close(http2.constants.NGHTTP2_NO_ERROR),
+          );
+        }),
+      );
+      it("should reject a request with te: trailers with Code.Unavailable", async () => {
+        const client = server.getClient();
+        const res = await client({
+          url: server.getUrl(),
+          method: "POST",
+          header: new Headers({ te: "trailers" }),
+        });
+        let bytesReceived = 0;
+        await assert.rejects(
+          async () => {
+            for await (const chunk of res.body) {
+              bytesReceived += chunk.byteLength;
+            }
+          },
+          (e: unknown) => {
+            assert.ok(e instanceof ConnectError, String(e));
+            assert.strictEqual(e.code, Code.Unavailable);
+            assert.strictEqual(
+              e.message,
+              "[unavailable] http/2 stream closed with error code NO_ERROR (0x0) before trailers were received",
+            );
+            return true;
+          },
+        );
+        assert.strictEqual(bytesReceived, 64);
+      });
+    });
+  });
+
+  describe("against a server that resets the stream with NO_ERROR after the complete response, including trailers", () => {
+    describe("over http/2", () => {
+      let rawSocket: net.Socket | undefined;
+      const server = useNodeServer(() => {
+        const s = http2.createServer();
+        s.on("connection", (socket: net.Socket) => {
+          rawSocket = socket;
+        });
+        s.on("stream", (stream) => {
+          const id = stream.id ?? 0;
+          stream.respond(
+            {
+              ":status": 200,
+              "content-type": "application/grpc",
+            },
+            { waitForTrailers: true },
+          );
+          stream.on("wantTrailers", () =>
+            stream.sendTrailers({ "grpc-status": "0" }),
+          );
+          // A proxy may legally reset the stream with NO_ERROR after the
+          // complete response - the client must still succeed.
+          stream.on("close", () => {
+            setImmediate(() => rawSocket?.write(rstStreamNoError(id)));
+          });
+          stream.end(new Uint8Array(64));
+        });
+        return s;
+      });
+      it("should read the response body and trailers successfully", async () => {
+        const client = server.getClient();
+        const res = await client({
+          url: server.getUrl(),
+          method: "POST",
+          header: new Headers({ te: "trailers" }),
+        });
+        let bytesReceived = 0;
+        for await (const chunk of res.body) {
+          bytesReceived += chunk.byteLength;
+        }
+        assert.strictEqual(bytesReceived, 64);
+        assert.strictEqual(res.trailer.get("grpc-status"), "0");
+      });
+    });
+  });
+
+  describe("against a server that responds with trailers-only", () => {
+    describe("over http/2", () => {
+      let rawSocket: net.Socket | undefined;
+      const server = useNodeServer(() => {
+        const s = http2.createServer();
+        s.on("connection", (socket: net.Socket) => {
+          rawSocket = socket;
+        });
+        s.on("stream", (stream) => {
+          const id = stream.id ?? 0;
+          // A trailers-only gRPC response: the initial HEADERS frame carries
+          // the status and the END_STREAM flag, no trailers follow.
+          stream.respond(
+            {
+              ":status": 200,
+              "content-type": "application/grpc",
+              "grpc-status": "12",
+            },
+            { endStream: true },
+          );
+          // Even a reset with NO_ERROR after the response must not affect
+          // the client.
+          stream.on("close", () => {
+            setImmediate(() => rawSocket?.write(rstStreamNoError(id)));
+          });
+        });
+        return s;
+      });
+      it("should read the response successfully for a request with te: trailers", async () => {
+        const client = server.getClient();
+        const res = await client({
+          url: server.getUrl(),
+          method: "POST",
+          header: new Headers({ te: "trailers" }),
+        });
+        let bytesReceived = 0;
+        for await (const chunk of res.body) {
+          bytesReceived += chunk.byteLength;
+        }
+        assert.strictEqual(bytesReceived, 0);
+        assert.strictEqual(res.header.get("grpc-status"), "12");
+      });
+    });
+  });
+
+  describe("against a server that ends the response body without trailers", () => {
+    describe("over http/2", () => {
+      const server = useNodeServer(() =>
+        http2.createServer().on("stream", (stream) => {
+          // A response that ends with the END_STREAM flag on the final DATA
+          // frame, without trailers - normal for protocols that do not use
+          // trailers, such as the Connect protocol.
+          stream.respond({ ":status": 200 });
+          stream.end(new Uint8Array(64));
+        }),
+      );
+      it("should read the response body successfully for a request without te: trailers", async () => {
+        const client = server.getClient();
+        const res = await client({
+          url: server.getUrl(),
+          method: "POST",
+          header: new Headers(),
+        });
+        let bytesReceived = 0;
+        for await (const chunk of res.body) {
+          bytesReceived += chunk.byteLength;
+        }
+        assert.strictEqual(bytesReceived, 64);
       });
     });
   });

--- a/packages/connect-node/src/node-universal-client.ts
+++ b/packages/connect-node/src/node-universal-client.ts
@@ -309,10 +309,50 @@ function h2Request(
         sentinel.error(e);
       });
 
+      // A gRPC response over HTTP/2 is always terminated by trailers (a
+      // HEADERS frame with the END_STREAM flag), or is a "trailers-only"
+      // response, where the initial HEADERS frame carries the status and the
+      // END_STREAM flag.
+      // gRPC requests declare this contract with the request header
+      // "TE: trailers".
+      // If an intermediary (e.g. a proxy during a graceful shutdown) resets
+      // the stream with the NO_ERROR code before the response has completed,
+      // Node.js versions without the fix from
+      // https://github.com/nodejs/node/pull/63249 surface the reset as a
+      // clean, error-free end of the response body, with rstCode 0. The
+      // protocol layer then fails parsing the truncated body with misleading
+      // errors such as "protocol error: incomplete envelope", or "protocol
+      // error: missing status".
+      // To surface the reset instead, we track whether the response was
+      // properly terminated, and raise Code.Unavailable from the "close"
+      // event if it was not.
+      const expectTrailers = requestExpectsTrailers(headers);
+      let responseIsTrailersOnly = false;
+      let trailersReceived = false;
+      stream.once("response", (responseHeaders) => {
+        // In a "trailers-only" gRPC response, the initial HEADERS frame
+        // carries the status, and no trailers frame follows. We must not
+        // flag such a response as incomplete.
+        responseIsTrailersOnly = responseHeaders["grpc-status"] !== undefined;
+      });
+      stream.once("trailers", () => {
+        trailersReceived = true;
+      });
       stream.on("close", function h2StreamClose() {
         const err = connectErrorFromH2ResetCode(stream.rstCode);
         if (err) {
           sentinel.error(err);
+        } else if (
+          expectTrailers &&
+          !trailersReceived &&
+          !responseIsTrailersOnly
+        ) {
+          sentinel.error(
+            new ConnectError(
+              "http/2 stream closed with error code NO_ERROR (0x0) before trailers were received",
+              Code.Unavailable,
+            ),
+          );
         }
       });
       onStream(stream);
@@ -321,6 +361,21 @@ function h2Request(
       sentinel.error(reason);
     },
   );
+}
+
+/**
+ * Returns true if the request declares with the "TE: trailers" header that
+ * the response must be terminated by HTTP trailers, as gRPC requests do.
+ */
+function requestExpectsTrailers(headers: http2.OutgoingHttpHeaders): boolean {
+  const te = headers.te;
+  if (typeof te != "string") {
+    return false;
+  }
+  return te
+    .toLowerCase()
+    .split(",")
+    .some((v) => v.trim() == "trailers");
 }
 
 function h2ResponseTrailer(response: http2.ClientHttp2Stream): Headers {

--- a/packages/connect-node/src/transport.spec.ts
+++ b/packages/connect-node/src/transport.spec.ts
@@ -14,11 +14,12 @@
 
 import { beforeEach, describe, it } from "node:test";
 import * as assert from "node:assert";
-import { create } from "@bufbuild/protobuf";
+import { create, toBinary } from "@bufbuild/protobuf";
 import { useNodeServer } from "./use-node-server-helper.spec.js";
 import * as http2 from "node:http2";
+import type * as net from "node:net";
 import { connectNodeAdapter } from "./connect-node-adapter.js";
-import { createClient } from "@connectrpc/connect";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
 import type { Transport } from "@connectrpc/connect";
 import { createTransport as createGrpcTransport } from "@connectrpc/connect/protocol-grpc";
 import { createTransport as createGrpcWebTransport } from "@connectrpc/connect/protocol-grpc-web";
@@ -26,9 +27,10 @@ import { validateNodeTransportOptions } from "./node-transport-options.js";
 import {
   ElizaService,
   IntroduceResponseSchema,
+  SayResponseSchema,
 } from "./testdata/gen/connectrpc/eliza/v1/eliza_pb.js";
 
-describe("Calls should fail with code internal on RST_STREAM no_error before trailers are received", () => {
+describe("Calls should fail on RST_STREAM no_error before trailers are received", () => {
   let firstMessage: ReturnType<typeof createCompleter<void>>;
   let rstStream: ReturnType<typeof createCompleter<void>>;
   beforeEach(() => {
@@ -93,6 +95,146 @@ describe("Calls should fail with code internal on RST_STREAM no_error before tra
     );
   });
 });
+
+describe("gRPC unary calls against a server that resets the stream with NO_ERROR before the response completed", () => {
+  // A serialized gRPC message envelope for the response of ElizaService.say
+  function sayResponseEnvelope(): Buffer {
+    const payload = toBinary(
+      SayResponseSchema,
+      create(SayResponseSchema, { sentence: "you said: hi" }),
+    );
+    const envelope = Buffer.alloc(5 + payload.byteLength);
+    envelope.writeUInt8(0, 0); // no compression
+    envelope.writeUInt32BE(payload.byteLength, 1);
+    envelope.set(payload, 5);
+    return envelope;
+  }
+
+  function assertResetError(e: unknown): boolean {
+    assert.ok(e instanceof ConnectError, String(e));
+    // Without the truncation guard in the http/2 client, the protocol layer
+    // fails parsing the truncated body with the misleading errors
+    // "[invalid_argument] protocol error: incomplete envelope", or
+    // "[internal] protocol error: missing status".
+    assert.doesNotMatch(e.message, /incomplete envelope|missing status/);
+    assert.strictEqual(e.code, Code.Unavailable);
+    assert.match(e.message, /before trailers were received/);
+    return true;
+  }
+
+  describe("mid message", () => {
+    let rawSocket: net.Socket | undefined;
+    const server = useNodeServer(() => {
+      const s = http2.createServer();
+      s.on("connection", (socket: net.Socket) => {
+        rawSocket = socket;
+      });
+      s.on("stream", (stream) => {
+        const id = stream.id ?? 0;
+        stream.respond({
+          ":status": 200,
+          "content-type": "application/grpc+proto",
+        });
+        // Cut the response off in the middle of the message envelope, then
+        // reset the stream with NO_ERROR via a raw RST_STREAM frame, like a
+        // proxy that loses the connection to the backend.
+        stream.write(sayResponseEnvelope().subarray(0, 3), () => {
+          setImmediate(() => rawSocket?.write(rstStreamNoError(id)));
+        });
+      });
+      return s;
+    });
+    it("should fail with Code.Unavailable, not with a protocol error", async () => {
+      const transport = createGrpcTransport({
+        ...validateNodeTransportOptions({
+          httpVersion: "2",
+          baseUrl: server.getUrl(),
+        }),
+        baseUrl: server.getUrl(),
+        httpClient: server.getClient(),
+      });
+      const client = createClient(ElizaService, transport);
+      await assert.rejects(client.say({ sentence: "hi" }), assertResetError);
+    });
+  });
+
+  describe("before trailers", () => {
+    const server = useNodeServer(() =>
+      http2.createServer().on("stream", (stream) => {
+        stream.respond(
+          {
+            ":status": 200,
+            "content-type": "application/grpc+proto",
+          },
+          { waitForTrailers: true },
+        );
+        // Send the complete message, but close with NO_ERROR while trailers
+        // are still outstanding. This sends an RST_STREAM frame with code
+        // NO_ERROR without the END_STREAM flag ever being sent.
+        stream.write(sayResponseEnvelope(), () =>
+          stream.close(http2.constants.NGHTTP2_NO_ERROR),
+        );
+      }),
+    );
+    it("should fail with Code.Unavailable, not with a protocol error", async () => {
+      const transport = createGrpcTransport({
+        ...validateNodeTransportOptions({
+          httpVersion: "2",
+          baseUrl: server.getUrl(),
+        }),
+        baseUrl: server.getUrl(),
+        httpClient: server.getClient(),
+      });
+      const client = createClient(ElizaService, transport);
+      await assert.rejects(client.say({ sentence: "hi" }), assertResetError);
+    });
+  });
+});
+
+describe("gRPC unary calls against a server that responds with an HTTP error and no trailers", () => {
+  const server = useNodeServer(() =>
+    http2.createServer().on("stream", (stream) => {
+      // A proxy or middlebox may answer with a plain HTTP error - a response
+      // body ended with the END_STREAM flag, no gRPC trailers. The HTTP
+      // status error must surface, not the missing-trailers guard in the
+      // http/2 client.
+      stream.respond({ ":status": 404, "content-type": "text/html" });
+      stream.end("<html>not found</html>");
+    }),
+  );
+  it("should fail with the HTTP status error, not with Code.Unavailable", async () => {
+    const transport = createGrpcTransport({
+      ...validateNodeTransportOptions({
+        httpVersion: "2",
+        baseUrl: server.getUrl(),
+      }),
+      baseUrl: server.getUrl(),
+      httpClient: server.getClient(),
+    });
+    const client = createClient(ElizaService, transport);
+    await assert.rejects(client.say({ sentence: "hi" }), (e: unknown) => {
+      assert.ok(e instanceof ConnectError, String(e));
+      assert.strictEqual(e.code, Code.Unimplemented);
+      assert.match(e.message, /HTTP 404/);
+      assert.doesNotMatch(e.message, /trailers/);
+      return true;
+    });
+  });
+});
+
+/**
+ * Returns a serialized RST_STREAM frame with error code NO_ERROR (0x0) for
+ * the given stream, see https://www.rfc-editor.org/rfc/rfc9113#name-rst_stream
+ */
+function rstStreamNoError(streamId: number): Buffer {
+  const frame = Buffer.alloc(13);
+  frame.writeUIntBE(4, 0, 3); // payload length
+  frame.writeUInt8(0x03, 3); // frame type RST_STREAM
+  frame.writeUInt8(0, 4); // flags
+  frame.writeUInt32BE(streamId, 5); // stream id
+  frame.writeUInt32BE(0, 9); // error code NO_ERROR
+  return frame;
+}
 
 function createCompleter<T>() {
   let resolve: (_: T | PromiseLike<T>) => void;


### PR DESCRIPTION
*Note from myself, because the issue/PR were crafted by Fable 5: If you do not accept such Issues/PRs, feel free to close both. However, our team ran into this issue five days ago and I investigate the issue yesterday with Fable 5 and a backend peer from our team who has control over Envoy.*

Fixes #1751.

When a peer (typically a proxy such as Envoy) resets a stream with `RST_STREAM code=0 (NO_ERROR)` before the response completed, Node's http2 client (pre nodejs/node#63249) surfaces the truncation as a clean, error-free end-of-stream with `rstCode 0`. The protocol layer then fails parsing the truncated body with misleading wire-format errors — `[invalid_argument] protocol error: incomplete envelope` (cut mid-message) or `[internal] protocol error: missing status` (cut before trailers) — blaming the server and reading as non-retryable, when the actual failure is a transport-level abort. See #1751 for the full evidence (Envoy edge logs, instrumented client traces, controls).

### What this PR does

In `h2Request()`'s close handler: when the request declared `TE: trailers` (as gRPC requests always do), and the stream closes with `rstCode 0` without a `'trailers'` event and without a trailers-only response (`grpc-status` in the initial HEADERS), reject with `Code.Unavailable`:

```
http/2 stream closed with error code NO_ERROR (0x0) before trailers were received
```

This mirrors grpc-js, which reports the same case as `Received RST_STREAM with code 0 (Call ended without gRPC status)` and ignores NO_ERROR resets only when the status already arrived.

### Design notes

- **Why the `TE: trailers` signal:** pre-#63249, no public Node API distinguishes this truncation generically — the `'trailers'` event is the only deterministic signal (`stream.closed`-at-`'end'` is a timing artifact, `endAfterHeaders` does not help). The TE header is how the request itself declares that trailers must terminate the response, so the guard is scoped precisely to protocols that need it. If you'd prefer an explicit option plumbed down from the transports instead of reading the request header, happy to rework.
- **Relationship to #1747:** that PR handles the complementary case — RST(NO_ERROR) *before* response headers (currently a hang). This PR deliberately does not overlap it: for `TE: trailers` requests the new guard also catches the pre-response close (reject instead of hang), while requests without `TE: trailers` keep today's behavior in that case, which remains #1747's scope. The two compose cleanly if both land.
- **Conservative by construction:** a NO_ERROR reset *after* a complete response (incl. trailers) still succeeds — per RFC 9113 §8.1, "Clients MUST NOT discard responses as a result of receiving such a RST_STREAM" — and a genuinely complete-but-trailerless HTTP response (e.g. a proxy's HTML error page) still surfaces its HTTP status error, not the new guard. Both are pinned by tests.
- **Not covered:** gRPC-web (trailers travel in the body, so the http/2 layer cannot know they are missing); on post-#63249 Node the new branch becomes harmless dead code, since the reset then surfaces as an explicit stream error first.

### Testing

- Package tests: 113/113. 5 new failure-mode tests fail without the fix (mid-message cut, cut before trailers, pre-response close — at the universal-client level and through `createTransport` from `protocol-grpc` with real error-message assertions); 4 new non-regression tests (post-trailers reset succeeds, trailers-only response succeeds, trailerless non-TE response succeeds, HTTP error response without trailers keeps its HTTP status error).
- Conformance: 6258/6258 client and 4718/4718 server.
- The fix was additionally verified against a live Envoy-fronted environment exhibiting the bug: the misleading protocol errors became the new `Unavailable` on the identical failing streams (details in #1751).
