### PR TITLE
Fix gRPC-web trailers-only error propagation

### DIFF
--- a/packages/connect/src/protocol-grpc-web/transport.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.spec.ts
@@ -149,4 +149,37 @@ describe("gRPC-web transport", () => {
       assert.ok(httpRequestAborted);
     });
   });
+  it("uses a gRPC status response header for a trailers-only unary response", async () => {
+    const transport = createTransport({
+      httpClient(): Promise<UniversalClientResponse> {
+        return Promise.resolve({
+          status: 200,
+          header: new Headers({
+            "Content-Type": "application/grpc-web+proto",
+            "grpc-status": Code.InvalidArgument.toString(),
+          }),
+          body: createAsyncIterable([
+            encodeEnvelope(trailerFlag, new Uint8Array()),
+          ]),
+          trailer: new Headers(),
+        });
+      },
+      ...defaultOptions,
+    });
+
+    await assert.rejects(
+      transport.unary(
+        TestService.method.unary,
+        undefined,
+        undefined,
+        undefined,
+        {},
+      ),
+      (e) => {
+        assert.ok(e instanceof ConnectError);
+        assert.strictEqual(e.code, Code.InvalidArgument);
+        return true;
+      },
+    );
+  });
 });

--- a/packages/connect/src/protocol-grpc-web/transport.ts
+++ b/packages/connect/src/protocol-grpc-web/transport.ts
@@ -173,6 +173,10 @@ export function createTransport(opt: CommonTransportOptions): Transport {
           }
           validateTrailer(trailer, uRes.header);
           if (message === undefined) {
+            // Trailers only response
+            if (headerError) {
+              throw headerError;
+            }
             throw new ConnectError(
               "protocol error: missing output message for unary method",
               trailer.has(headerGrpcStatus) ? Code.Unimplemented : Code.Unknown,


### PR DESCRIPTION
# Background

A gRPC-web unary trailers-only response can carry its gRPC error in the response headers and an empty trailer frame in the body. The empty frame is parsed as an empty `Headers` object, so the existing undefined-trailer check does not propagate the response-header error. The transport then reports `Unknown` for the missing message instead of the server's status.

# Summary

- propagate `headerError` when a gRPC-web unary response has no output message
- add a regression test for an empty trailer frame with response-header `grpc-status: 3`

# Testing

- `node --import tsx --test packages/connect/src/protocol-grpc-web/transport.spec.ts`
- `npm test --workspace @connectrpc/connect`
- `npx turbo run build lint license-header attw --filter=@connectrpc/connect`

Fixes #1764
