### PR TITLE
Enable gRPC in Cloudflare conformance tests

### DIFF
--- a/packages/connect-cloudflare/conformance/conformance-cloudflare-client.yaml
+++ b/packages/connect-cloudflare/conformance/conformance-cloudflare-client.yaml
@@ -5,7 +5,7 @@ features:
   protocols:
     - PROTOCOL_CONNECT
     # A Worker cannot send gRPC, but it can send gRPC-Web and opt in to
-    # Cloudflare converting it to gRPC. See conformance/transport.ts.
+    # Cloudflare converting it to gRPC.
     - PROTOCOL_GRPC
     - PROTOCOL_GRPC_WEB
   codecs:

--- a/packages/connect-cloudflare/conformance/conformance-cloudflare-client.yaml
+++ b/packages/connect-cloudflare/conformance/conformance-cloudflare-client.yaml
@@ -4,7 +4,9 @@ features:
     - HTTP_VERSION_2
   protocols:
     - PROTOCOL_CONNECT
-    # - PROTOCOL_GRPC Cloudflare turns gRPC-Web requests to gRPC, if the invoking request is gRPC. It doesn't directly support gRPC.
+    # A Worker cannot send gRPC, but it can send gRPC-Web and opt in to
+    # Cloudflare converting it to gRPC. See conformance/transport.ts.
+    - PROTOCOL_GRPC
     - PROTOCOL_GRPC_WEB
   codecs:
     - CODEC_PROTO

--- a/packages/connect-cloudflare/conformance/conformance-cloudflare-server.yaml
+++ b/packages/connect-cloudflare/conformance/conformance-cloudflare-server.yaml
@@ -4,7 +4,7 @@ features:
     - HTTP_VERSION_2
   protocols:
     - PROTOCOL_CONNECT
-    # - PROTOCOL_GRPC
+    - PROTOCOL_GRPC
     - PROTOCOL_GRPC_WEB
   codecs:
     - CODEC_PROTO
@@ -24,3 +24,7 @@ excludeCases:
     streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
   - protocol: PROTOCOL_GRPC_WEB
     streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
+  - protocol: PROTOCOL_GRPC
+    compression: COMPRESSION_GZIP
+  - protocol: PROTOCOL_GRPC
+    compression: COMPRESSION_DEFLATE

--- a/packages/connect-cloudflare/conformance/conformance-cloudflare-server.yaml
+++ b/packages/connect-cloudflare/conformance/conformance-cloudflare-server.yaml
@@ -24,6 +24,7 @@ excludeCases:
     streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
   - protocol: PROTOCOL_GRPC_WEB
     streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
+  # Cloudflare's inbound gRPC conversion does not support compressed messages.
   - protocol: PROTOCOL_GRPC
     compression: COMPRESSION_GZIP
   - protocol: PROTOCOL_GRPC

--- a/packages/connect-cloudflare/conformance/known-failing-client.txt
+++ b/packages/connect-cloudflare/conformance/known-failing-client.txt
@@ -1,2 +1,3 @@
 # On receiving 504, cloudflare is returning a static response back instead of the actual body.
 Errors/*/Protocol:PROTOCOL_CONNECT/*/*/TLS:true/unary/deadline-exceeded
+gRPC Unexpected Responses/HTTPVersion:2/TLS:true/trailers-only/ignore-header-if-body-present

--- a/packages/connect-cloudflare/conformance/transport.ts
+++ b/packages/connect-cloudflare/conformance/transport.ts
@@ -33,23 +33,17 @@ import type { RequestInitCfProperties } from "@cloudflare/workers-types";
 import { compressionDeflate, compressionGzip } from "./compression.js";
 
 /**
- * The "cf" property is absent from the DOM types this package compiles against.
+ * Cloudflare-specific fetch() init type.
  */
 type CloudflareRequestInit = RequestInit & {
   cf?: RequestInitCfProperties;
 };
 
-/**
- * A Worker cannot speak gRPC, because fetch does not expose HTTP trailers.
- * Opt in to Cloudflare converting a gRPC-Web request to gRPC instead.
- */
-const grpcConversion: CloudflareRequestInit = {
-  cf: { grpcWeb: "convert" },
-};
-
-function createWorkerHttpClient(cfInit?: CloudflareRequestInit) {
+function createWorkerHttpClient(cf?: RequestInitCfProperties) {
   return createFetchClient(async (input, init) => {
-    const res = await fetch(input, cfInit ?? init);
+    const cfInit: CloudflareRequestInit | undefined =
+      cf === undefined ? init : { ...init, cf };
+    const res = await fetch(input, cfInit);
     // Cloudflare decompresses the response, but retains the original content-encoding and
     // content-length headers.
     //
@@ -143,7 +137,7 @@ export function createTransport(req: ClientCompatRequest) {
       // Send gRPC-Web and let Cloudflare convert it to gRPC.
       return createGrpcWebTransport({
         ...sharedOptions,
-        httpClient: createWorkerHttpClient(grpcConversion),
+        httpClient: createWorkerHttpClient({ grpcWeb: "convert" }),
       });
     case Protocol.GRPC_WEB:
       return createGrpcWebTransport(sharedOptions);

--- a/packages/connect-cloudflare/conformance/transport.ts
+++ b/packages/connect-cloudflare/conformance/transport.ts
@@ -26,11 +26,47 @@ import {
 } from "@connectrpc/connect-conformance";
 import type { ClientCompatRequest } from "@connectrpc/connect-conformance";
 import { createTransport as createConnectTransport } from "@connectrpc/connect/protocol-connect";
-import { createTransport as createGrpcTransport } from "@connectrpc/connect/protocol-grpc";
 import { createTransport as createGrpcWebTransport } from "@connectrpc/connect/protocol-grpc-web";
 import { createFetchClient } from "@connectrpc/connect/protocol";
 import type { Compression } from "@connectrpc/connect/protocol";
+import type { RequestInitCfProperties } from "@cloudflare/workers-types";
 import { compressionDeflate, compressionGzip } from "./compression.js";
+
+/**
+ * The "cf" property is absent from the DOM types this package compiles against.
+ */
+type CloudflareRequestInit = RequestInit & {
+  cf?: RequestInitCfProperties;
+};
+
+/**
+ * A Worker cannot speak gRPC, because fetch does not expose HTTP trailers.
+ * Opt in to Cloudflare converting a gRPC-Web request to gRPC instead.
+ */
+const grpcConversion: CloudflareRequestInit = {
+  cf: { grpcWeb: "convert" },
+};
+
+function createWorkerHttpClient(cfInit?: CloudflareRequestInit) {
+  return createFetchClient(async (input, init) => {
+    const res = await fetch(input, cfInit ?? init);
+    // Cloudflare decompresses the response, but retains the original content-encoding and
+    // content-length headers.
+    //
+    // https://github.com/WinterTC55/fetch/issues/23
+    if (res.headers.has("content-encoding")) {
+      const headers = new Headers(res.headers);
+      headers.delete("content-encoding");
+      headers.delete("content-length");
+      return new Response(res.body, {
+        headers,
+        status: res.status,
+        statusText: res.statusText,
+      });
+    }
+    return res;
+  });
+}
 
 /**
  * Configure a transport for a client running as a Cloudflare Worker under test.
@@ -78,24 +114,7 @@ export function createTransport(req: ClientCompatRequest) {
 
   const sharedOptions = {
     baseUrl,
-    httpClient: createFetchClient(async (input, init) => {
-      const res = await fetch(input, init);
-      // Cloudflare decompresses the response, but retains the original content-encoding and
-      // content-length headers.
-      //
-      // https://github.com/WinterTC55/fetch/issues/23
-      if (res.headers.has("content-encoding")) {
-        const headers = new Headers(res.headers);
-        headers.delete("content-encoding");
-        headers.delete("content-length");
-        return new Response(res.body, {
-          headers,
-          status: res.status,
-          statusText: res.statusText,
-        });
-      }
-      return res;
-    }),
+    httpClient: createWorkerHttpClient(),
     useBinaryFormat: req.codec === Codec.PROTO,
     interceptors: [],
     acceptCompression: sendCompression !== null ? [sendCompression] : [],
@@ -121,7 +140,11 @@ export function createTransport(req: ClientCompatRequest) {
         useHttpGet: req.useGetHttpMethod,
       });
     case Protocol.GRPC:
-      return createGrpcTransport(sharedOptions);
+      // Send gRPC-Web and let Cloudflare convert it to gRPC.
+      return createGrpcWebTransport({
+        ...sharedOptions,
+        httpClient: createWorkerHttpClient(grpcConversion),
+      });
     case Protocol.GRPC_WEB:
       return createGrpcWebTransport(sharedOptions);
     default:

--- a/packages/connect-cloudflare/conformance/wrangler-client.toml
+++ b/packages/connect-cloudflare/conformance/wrangler-client.toml
@@ -1,3 +1,3 @@
 name = "conformance-client"
 main = "client-worker.ts"
-compatibility_date = "2023-10-02"             # Enables stream APIs
+compatibility_date = "2026-08-25"

--- a/packages/connect-cloudflare/conformance/wrangler-server.toml
+++ b/packages/connect-cloudflare/conformance/wrangler-server.toml
@@ -1,3 +1,3 @@
 name = "conformance-server"
 main = "server-worker.ts"
-compatibility_date = "2023-10-02"             # Enables stream APIs
+compatibility_date = "2026-08-25"


### PR DESCRIPTION
Cloudflare Workers can't send gRPC directly so the client sends gRPC-Web and opts into Cloudflare's conversion via `cf: { grpcWeb: "convert" }` request property or the `auto_grpc_convert` compatibility flag

If not already, you may need to enable gRPC on the zone serving `CLOUDFLARE_WORKERS_SERVER_HOST`