### PR TITLE
Drop support for Node.js 20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24.x, 22.x, 20.x]
+        node-version: [26.x, 24.x, 22.x]
     name: "test on Node.js ${{ matrix.node-version }}"
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/conformance-express.yaml
+++ b/.github/workflows/conformance-express.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24.x, 22.x, 20.x]
+        node-version: [26.x, 24.x, 22.x]
     name: "Node.js ${{ matrix.node-version }}"
     timeout-minutes: 10
     steps:

--- a/.github/workflows/conformance-fastify.yaml
+++ b/.github/workflows/conformance-fastify.yaml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Fastify v5 only supports Node.js v20+
-        node-version: [24.x, 22.x, 20.x]
+        node-version: [26.x, 24.x, 22.x]
     name: "Node.js ${{ matrix.node-version }}"
     timeout-minutes: 10
     steps:

--- a/.github/workflows/conformance-node.yaml
+++ b/.github/workflows/conformance-node.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24.x, 22.x, 20.x]
+        node-version: [26.x, 24.x, 22.x]
         side: [client, server]
     name: "Node.js ${{ matrix.node-version }} ${{ matrix.side }}"
     timeout-minutes: 10

--- a/.github/workflows/conformance-web.yaml
+++ b/.github/workflows/conformance-web.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [24.x, 22.x, 20.x]
+        node-version: [26.x, 24.x, 22.x]
         client: [promise, callback]
     name: "Node.js ${{ matrix.node-version }} ${{ matrix.client }}"
     timeout-minutes: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -10680,7 +10680,7 @@
         "tsx": "^4.20.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
@@ -10699,7 +10699,7 @@
         "@connectrpc/connect-node": "2.1.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
@@ -10727,7 +10727,7 @@
         "tsx": "^4.20.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "packages/connect-next": {
@@ -10739,7 +10739,7 @@
         "@connectrpc/connect-node": "2.1.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
@@ -10758,7 +10758,7 @@
         "tsx": "^4.20.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
@@ -10808,7 +10808,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "packages/example/node_modules/typescript": {

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -29,7 +29,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@connectrpc/connect-conformance": "^2.1.2",

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -28,7 +28,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@connectrpc/connect-conformance": "^2.1.2",

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -20,7 +20,7 @@
     "lint": "biome lint --error-on-warnings"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "fast-glob": "3.3.3",

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -27,7 +27,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -30,7 +30,7 @@
     }
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -12,7 +12,7 @@
     "lint": "biome lint --error-on-warnings"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",


### PR DESCRIPTION
Removes support for Node 20, as per our [compatibility policy](https://github.com/connectrpc/connect-es#compatibility). A bunch of our dependencies also no longer support Node 20, as it is EOL.

This PR also adds Node 26 to CI.
