### PR TITLE
Fix flaky ECONNRESET test

### DIFF
--- a/packages/connect-node/src/node-universal-handler.spec.ts
+++ b/packages/connect-node/src/node-universal-handler.spec.ts
@@ -196,21 +196,20 @@ describe("universalRequestFromNodeResponse()", () => {
       s.headersTimeout = 0;
       return s;
     });
+    // Destroys the connection once the server has read the request headers.
     async function request() {
-      return new Promise<void>((resolve) => {
-        const request = http.request(server.getUrl(), {
-          method: "POST",
-        });
-        request.on("error", () => {
-          // we need this event lister so that Node.js does not raise the error
-          // we trigger by calling destroy()
-        });
-        request.flushHeaders();
-        setTimeout(() => {
-          request.destroy();
-          resolve();
-        }, 20);
+      const req = http.request(server.getUrl(), {
+        method: "POST",
       });
+      req.on("error", () => {
+        // we need this event lister so that Node.js does not raise the error
+        // we trigger by calling destroy()
+      });
+      req.flushHeaders();
+      while (serverRequest === undefined) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      req.destroy();
     }
     it("should abort request signal with ConnectError and Code.Aborted", async () => {
       await request();


### PR DESCRIPTION
The helper flushed the request headers, waited 20ms, then destroyed the
connection. That wait assumed the server had read the headers and run
its handler within the window. Under CI load it had not, so
serverRequest was still undefined and the guard assertion failed.

Fixes the failure in https://github.com/connectrpc/connect-es/actions/runs/32992292045
