### PR TITLE
Add requestGate handler option

### DIFF
--- a/packages/connect/src/protocol-connect/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.spec.ts
@@ -36,13 +36,16 @@ import {
   sinkAll,
   transformSplitEnvelope,
 } from "../protocol/index.js";
-import { Code, ConnectError } from "../index.js";
+import { Code, ConnectError, createContextKey } from "../index.js";
 import { errorFromJsonBytes } from "./error-json.js";
 import { endStreamFromJson } from "./end-stream.js";
 import { createTransport } from "./transport.js";
 import { requestHeader } from "./request-header.js";
 import { readAll } from "../protocol/async-iterable-helper.spec.js";
-import { contentTypeStreamProto } from "./content-type.js";
+import {
+  contentTypeStreamProto,
+  contentTypeUnaryProto,
+} from "./content-type.js";
 import { createServiceDesc } from "../descriptor-helper.spec.js";
 import {
   ApiSchema,
@@ -687,6 +690,99 @@ describe("createHandlerFactory()", () => {
           return true;
         },
       );
+    });
+  });
+
+  describe("requestGate", () => {
+    const denyAll = () => {
+      throw new ConnectError("no credentials", Code.Unauthenticated);
+    };
+    // A request body that records whether the handler read from it.
+    function trackedBody(state: { read: boolean }): AsyncIterable<Uint8Array> {
+      return {
+        [Symbol.asyncIterator]: () => ({
+          next: () => {
+            state.read = true;
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        }),
+      };
+    }
+
+    for (const method of [
+      testService.method.unary,
+      testService.method.serverStreaming,
+    ]) {
+      it(`should not read the request body of a ${method.methodKind} RPC`, async () => {
+        const { handler } = setupTestHandler(
+          method,
+          { requestGate: denyAll },
+          () => assert.fail("implementation should not be called"),
+        );
+        const state = { read: false };
+        const res = await handler({
+          httpVersion: "2.0",
+          method: "POST",
+          url: `https://example.com/${method.parent.typeName}/${method.name}`,
+          header: new Headers({
+            "Content-Type":
+              method.methodKind === "unary"
+                ? contentTypeUnaryProto
+                : contentTypeStreamProto,
+          }),
+          body: trackedBody(state),
+          signal: new AbortController().signal,
+        });
+        assert.notStrictEqual(res.status, 415); // wrong content-type for this RPC
+        assert.strictEqual(state.read, false);
+      });
+    }
+
+    it("should reject a streaming RPC with the error from the gate", async () => {
+      const { transport, method } = setupTestHandler(
+        testService.method.serverStreaming,
+        { requestGate: denyAll },
+        () => assert.fail("implementation should not be called"),
+      );
+      await assert.rejects(
+        async () => {
+          const r = await transport.stream(
+            method,
+            undefined,
+            undefined,
+            undefined,
+            createAsyncIterable([create(Int32ValueSchema)]),
+          );
+          await pipeTo(r.message, sinkAll());
+        },
+        (e) => {
+          assert.ok(e instanceof ConnectError);
+          assert.strictEqual(e.code, Code.Unauthenticated);
+          return true;
+        },
+      );
+    });
+
+    it("should pass context values from the gate to the implementation", async () => {
+      const kUser = createContextKey<string>("anonymous");
+      const { transport, method } = setupTestHandler(
+        testService.method.unary,
+        {
+          requestGate: (ctx) => {
+            assert.strictEqual(ctx.requestHeader.get("authorization"), "token");
+            ctx.values.set(kUser, "alice");
+          },
+        },
+        (_req, ctx) => ({ value: ctx.values.get(kUser) }),
+      );
+      const res = await transport.unary(
+        method,
+        undefined,
+        undefined,
+        { authorization: "token" },
+        create(Int32ValueSchema, { value: 1 }),
+      );
+      assert.strictEqual(res.message.value, "alice");
     });
   });
 });

--- a/packages/connect/src/protocol-connect/handler-factory.ts
+++ b/packages/connect/src/protocol-connect/handler-factory.ts
@@ -98,6 +98,7 @@ import { contentTypeMatcher } from "../protocol/content-type-matcher.js";
 import { createMethodUrl } from "../protocol/create-method-url.js";
 import type { EnvelopedMessage } from "../protocol/envelope.js";
 import {
+  applyRequestGate,
   invokeUnaryImplementation,
   transformInvokeImplementation,
 } from "../protocol/invoke-implementation.js";
@@ -216,6 +217,11 @@ function createUnaryHandler<I extends DescMessage, O extends DescMessage>(
     let status = uResponseOk.status;
     let body: Uint8Array;
     try {
+      // We run the request gate before receiving the body, so that a request it
+      // rejects is never read, decompressed, or parsed.
+      if (opt.requestGate !== undefined) {
+        await opt.requestGate(context);
+      }
       if (opt.requireConnectProtocolHeader) {
         if (isGet) {
           requireProtocolVersionParam(queryParams);
@@ -440,11 +446,15 @@ function createStreamHandler<I extends DescMessage, O extends DescMessage>(
         // raises an error, but we want to be lenient
       ),
     );
-    const it = transformInvokeImplementation<I, O>(
-      spec,
-      context,
-      opt.interceptors,
-    )(inputIt)[Symbol.asyncIterator]();
+    // We run the request gate before receiving the body, so that a request it
+    // rejects is never read, decompressed, or parsed.
+    const it = await applyRequestGate(context, opt.requestGate, () =>
+      transformInvokeImplementation<I, O>(
+        spec,
+        context,
+        opt.interceptors,
+      )(inputIt),
+    );
     const outputIt = pipe(
       // We wrap the iterator in an async iterator to ensure that the
       // abort signal is aborted when the iterator is done.

--- a/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.spec.ts
@@ -27,6 +27,7 @@ import {
   pipeTo,
   sinkAll,
 } from "../protocol/index.js";
+import { createContextKey } from "../index.js";
 import { createHandlerFactory } from "./handler-factory.js";
 import { createTransport } from "./transport.js";
 import { requestHeader } from "./request-header.js";
@@ -299,6 +300,94 @@ describe("createHandlerFactory()", () => {
       assert.notStrictEqual(handlerContextSignal, undefined);
       assert.strictEqual(handlerContextSignal?.aborted, true);
       assert.strictEqual(handlerContextSignal?.reason, "test-reason");
+    });
+  });
+
+  describe("requestGate", () => {
+    const denyAll = () => {
+      throw new ConnectError("no credentials", Code.Unauthenticated);
+    };
+    // A request body that records whether the handler read from it.
+    function trackedBody(state: { read: boolean }): AsyncIterable<Uint8Array> {
+      return {
+        [Symbol.asyncIterator]: () => ({
+          next: () => {
+            state.read = true;
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        }),
+      };
+    }
+
+    for (const method of [
+      testService.method.unary,
+      testService.method.serverStreaming,
+    ]) {
+      it(`should not read the request body of a ${method.methodKind} RPC`, async () => {
+        const { handler } = setupTestHandler(
+          method,
+          { requestGate: denyAll },
+          () => assert.fail("implementation should not be called"),
+        );
+        const state = { read: false };
+        const res = await handler({
+          httpVersion: "2.0",
+          method: "POST",
+          url: `https://example.com/${method.parent.typeName}/${method.name}`,
+          header: new Headers({ "Content-Type": contentTypeProto }),
+          body: trackedBody(state),
+          signal: new AbortController().signal,
+        });
+        assert.notStrictEqual(res.status, 415); // wrong content-type for this RPC
+        assert.strictEqual(state.read, false);
+      });
+    }
+
+    it("should reject a streaming RPC with the error from the gate", async () => {
+      const { transport, method } = setupTestHandler(
+        testService.method.serverStreaming,
+        { requestGate: denyAll },
+        () => assert.fail("implementation should not be called"),
+      );
+      await assert.rejects(
+        async () => {
+          const r = await transport.stream(
+            method,
+            undefined,
+            undefined,
+            undefined,
+            createAsyncIterable([create(Int32ValueSchema)]),
+          );
+          await pipeTo(r.message, sinkAll());
+        },
+        (e) => {
+          assert.ok(e instanceof ConnectError);
+          assert.strictEqual(e.code, Code.Unauthenticated);
+          return true;
+        },
+      );
+    });
+
+    it("should pass context values from the gate to the implementation", async () => {
+      const kUser = createContextKey<string>("anonymous");
+      const { transport, method } = setupTestHandler(
+        testService.method.unary,
+        {
+          requestGate: (ctx) => {
+            assert.strictEqual(ctx.requestHeader.get("authorization"), "token");
+            ctx.values.set(kUser, "alice");
+          },
+        },
+        (_req, ctx) => ({ value: ctx.values.get(kUser) }),
+      );
+      const res = await transport.unary(
+        method,
+        undefined,
+        undefined,
+        { authorization: "token" },
+        create(Int32ValueSchema, { value: 1 }),
+      );
+      assert.strictEqual(res.message.value, "alice");
     });
   });
 });

--- a/packages/connect/src/protocol-grpc-web/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc-web/handler-factory.ts
@@ -52,7 +52,10 @@ import { compressionNegotiate } from "../protocol/compression.js";
 import { contentTypeMatcher } from "../protocol/content-type-matcher.js";
 import { createMethodUrl } from "../protocol/create-method-url.js";
 import type { EnvelopedMessage } from "../protocol/envelope.js";
-import { transformInvokeImplementation } from "../protocol/invoke-implementation.js";
+import {
+  applyRequestGate,
+  transformInvokeImplementation,
+} from "../protocol/invoke-implementation.js";
 import type { ProtocolHandlerFactory } from "../protocol/protocol-handler-factory.js";
 import { createMethodSerializationLookup } from "../protocol/serialization.js";
 import type { Serialization } from "../protocol/serialization.js";
@@ -172,11 +175,15 @@ function createHandler<I extends DescMessage, O extends DescMessage>(
         // raises an error, but we want to be lenient
       ),
     );
-    const it = transformInvokeImplementation<I, O>(
-      spec,
-      context,
-      opt.interceptors,
-    )(inputIt)[Symbol.asyncIterator]();
+    // We run the request gate before receiving the body, so that a request it
+    // rejects is never read, decompressed, or parsed.
+    const it = await applyRequestGate(context, opt.requestGate, () =>
+      transformInvokeImplementation<I, O>(
+        spec,
+        context,
+        opt.interceptors,
+      )(inputIt),
+    );
     const outputIt = pipe(
       // We wrap the iterator in an async iterator to ensure that the
       // abort signal is aborted when the iterator is done.

--- a/packages/connect/src/protocol-grpc/handler-factory.spec.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.spec.ts
@@ -28,7 +28,7 @@ import {
 import { createHandlerFactory } from "./handler-factory.js";
 import { createTransport } from "./transport.js";
 import { requestHeader } from "./request-header.js";
-import { Code, ConnectError } from "../index.js";
+import { Code, ConnectError, createContextKey } from "../index.js";
 import { contentTypeProto } from "./content-type.js";
 import { createServiceDesc } from "../descriptor-helper.spec.js";
 import { Int32ValueSchema, StringValueSchema } from "@bufbuild/protobuf/wkt";
@@ -298,6 +298,94 @@ describe("createHandlerFactory()", () => {
       assert.notStrictEqual(handlerContextSignal, undefined);
       assert.strictEqual(handlerContextSignal?.aborted, true);
       assert.strictEqual(handlerContextSignal?.reason, "test-reason");
+    });
+  });
+
+  describe("requestGate", () => {
+    const denyAll = () => {
+      throw new ConnectError("no credentials", Code.Unauthenticated);
+    };
+    // A request body that records whether the handler read from it.
+    function trackedBody(state: { read: boolean }): AsyncIterable<Uint8Array> {
+      return {
+        [Symbol.asyncIterator]: () => ({
+          next: () => {
+            state.read = true;
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        }),
+      };
+    }
+
+    for (const method of [
+      testService.method.unary,
+      testService.method.serverStreaming,
+    ]) {
+      it(`should not read the request body of a ${method.methodKind} RPC`, async () => {
+        const { handler } = setupTestHandler(
+          method,
+          { requestGate: denyAll },
+          () => assert.fail("implementation should not be called"),
+        );
+        const state = { read: false };
+        const res = await handler({
+          httpVersion: "2.0",
+          method: "POST",
+          url: `https://example.com/${method.parent.typeName}/${method.name}`,
+          header: new Headers({ "Content-Type": contentTypeProto }),
+          body: trackedBody(state),
+          signal: new AbortController().signal,
+        });
+        assert.notStrictEqual(res.status, 415); // wrong content-type for this RPC
+        assert.strictEqual(state.read, false);
+      });
+    }
+
+    it("should reject a streaming RPC with the error from the gate", async () => {
+      const { transport, method } = setupTestHandler(
+        testService.method.serverStreaming,
+        { requestGate: denyAll },
+        () => assert.fail("implementation should not be called"),
+      );
+      await assert.rejects(
+        async () => {
+          const r = await transport.stream(
+            method,
+            undefined,
+            undefined,
+            undefined,
+            createAsyncIterable([create(Int32ValueSchema)]),
+          );
+          await pipeTo(r.message, sinkAll());
+        },
+        (e) => {
+          assert.ok(e instanceof ConnectError);
+          assert.strictEqual(e.code, Code.Unauthenticated);
+          return true;
+        },
+      );
+    });
+
+    it("should pass context values from the gate to the implementation", async () => {
+      const kUser = createContextKey<string>("anonymous");
+      const { transport, method } = setupTestHandler(
+        testService.method.unary,
+        {
+          requestGate: (ctx) => {
+            assert.strictEqual(ctx.requestHeader.get("authorization"), "token");
+            ctx.values.set(kUser, "alice");
+          },
+        },
+        (_req, ctx) => ({ value: ctx.values.get(kUser) }),
+      );
+      const res = await transport.unary(
+        method,
+        undefined,
+        undefined,
+        { authorization: "token" },
+        create(Int32ValueSchema, { value: 1 }),
+      );
+      assert.strictEqual(res.message.value, "alice");
     });
   });
 });

--- a/packages/connect/src/protocol-grpc/handler-factory.ts
+++ b/packages/connect/src/protocol-grpc/handler-factory.ts
@@ -47,7 +47,10 @@ import {
 import { compressionNegotiate } from "../protocol/compression.js";
 import { contentTypeMatcher } from "../protocol/content-type-matcher.js";
 import { createMethodUrl } from "../protocol/create-method-url.js";
-import { transformInvokeImplementation } from "../protocol/invoke-implementation.js";
+import {
+  applyRequestGate,
+  transformInvokeImplementation,
+} from "../protocol/invoke-implementation.js";
 import type { ProtocolHandlerFactory } from "../protocol/protocol-handler-factory.js";
 import { createMethodSerializationLookup } from "../protocol/serialization.js";
 import { validateUniversalHandlerOptions } from "../protocol/universal-handler.js";
@@ -158,11 +161,15 @@ function createHandler<I extends DescMessage, O extends DescMessage>(
       transformDecompressEnvelope(compression.request, opt.readMaxBytes),
       transformParseEnvelope(serialization.getI(type.binary)),
     );
-    const it = transformInvokeImplementation<I, O>(
-      spec,
-      context,
-      opt.interceptors,
-    )(inputIt)[Symbol.asyncIterator]();
+    // We run the request gate before receiving the body, so that a request it
+    // rejects is never read, decompressed, or parsed.
+    const it = await applyRequestGate(context, opt.requestGate, () =>
+      transformInvokeImplementation<I, O>(
+        spec,
+        context,
+        opt.interceptors,
+      )(inputIt),
+    );
     const outputIt = pipe(
       // We wrap the iterator in an async iterator to ensure that the
       // abort signal is aborted when the iterator is done.

--- a/packages/connect/src/protocol/invoke-implementation.ts
+++ b/packages/connect/src/protocol/invoke-implementation.ts
@@ -31,6 +31,32 @@ import type {
 import { applyInterceptors } from "../interceptor.js";
 
 /**
+ * Invoke the implementation for a streaming RPC, unless a request gate rejects
+ * the call first.
+ *
+ * The gate runs before the request body is received. If it throws, the returned
+ * iterator rejects with its error, so the caller's response pipeline serializes
+ * it without reading the body; otherwise the implementation's iterator is
+ * returned.
+ *
+ * @private Internal code, does not follow semantic versioning.
+ */
+export async function applyRequestGate<T>(
+  context: HandlerContext,
+  requestGate: ((context: HandlerContext) => void | Promise<void>) | undefined,
+  invoke: () => AsyncIterable<T>,
+): Promise<AsyncIterator<T>> {
+  if (requestGate !== undefined) {
+    try {
+      await requestGate(context);
+    } catch (reason) {
+      return { next: () => Promise.reject(reason) };
+    }
+  }
+  return invoke()[Symbol.asyncIterator]();
+}
+
+/**
  * Invoke a user-provided implementation of a unary RPC. Returns a normalized
  * output message.
  *

--- a/packages/connect/src/protocol/universal-handler.spec.ts
+++ b/packages/connect/src/protocol/universal-handler.spec.ts
@@ -41,6 +41,7 @@ describe("validateUniversalHandlerOptions()", () => {
       shutdownSignal: undefined,
       requireConnectProtocolHeader: false,
       interceptors: [],
+      requestGate: undefined,
     });
   });
   it("should accept inputs", () => {
@@ -66,6 +67,9 @@ describe("validateUniversalHandlerOptions()", () => {
       shutdownSignal: new AbortController().signal,
       requireConnectProtocolHeader: true,
       interceptors: [],
+      requestGate: () => {
+        // no-op
+      },
     };
     const o = validateUniversalHandlerOptions(i);
     assert.deepStrictEqual(o, i);

--- a/packages/connect/src/protocol/universal-handler.ts
+++ b/packages/connect/src/protocol/universal-handler.ts
@@ -20,7 +20,11 @@ import type {
   JsonReadOptions,
   JsonWriteOptions,
 } from "@bufbuild/protobuf";
-import type { MethodImplSpec, ServiceImplSpec } from "../implementation.js";
+import type {
+  HandlerContext,
+  MethodImplSpec,
+  ServiceImplSpec,
+} from "../implementation.js";
 import {
   uResponseMethodNotAllowed,
   uResponseUnsupportedMediaType,
@@ -122,6 +126,19 @@ export interface UniversalHandlerOptions {
    * this router. See the Interceptor type for details.
    */
   interceptors: Interceptor[];
+
+  /**
+   * An optional gate that runs after request headers are available, but before
+   * any request message is received, decompressed, or parsed.
+   *
+   * This is the right place to reject unauthenticated requests cheaply. Throw
+   * a ConnectError to end any RPC without reading the body.
+   *
+   * The gate receives the HandlerContext for the call. It may set context
+   * values for interceptors and the implementation to consume, and set
+   * response headers or trailers.
+   */
+  requestGate?: (context: HandlerContext) => void | Promise<void>;
 }
 
 /**
@@ -193,6 +210,7 @@ export function validateUniversalHandlerOptions(
     shutdownSignal: opt.shutdownSignal,
     requireConnectProtocolHeader,
     interceptors: opt.interceptors ?? [],
+    requestGate: opt.requestGate,
   };
 }
 


### PR DESCRIPTION
This PR adds a new handler option:

```ts
  /**
   * An optional gate that runs after request headers are available, but before
   * any request message is received, decompressed, or parsed.
   *
   * This is the right place to reject unauthenticated requests cheaply. Throw
   * a ConnectError to end any RPC without reading the body.
   *
   * The gate receives the HandlerContext for the call. It may set context
   * values for interceptors and the implementation to consume, and set
   * response headers or trailers.
   */
  requestGate?: (context: HandlerContext) => void | Promise<void>;
```

To authenticate requests on a server, prefer this option over interceptors. For unary RPCs, interceptors run after the request message is received, decompressed, and parsed. The request gate turns away requests without spending anything on them.

```ts
import * as http from "http";
import routes from "./connect";
import { connectNodeAdapter } from "@connectrpc/connect-node";
import { Code, ConnectError } from "@connectrpc/connect";
import type { HandlerContext } from "@connectrpc/connect";
// This can come from an auth library like passport.js
import { authenticate } from "./authenticate";

function authGate(context: HandlerContext) {
  if (authenticate(context.requestHeader.get("Authorization")) === undefined) {
    throw new ConnectError("User not authenticated", Code.Unauthenticated);
  }
}

http
  .createServer(
    connectNodeAdapter({
      routes,
      requestGate: authGate,
    }),
  )
  .listen(8080);
```