### PR TITLE
Stop delivering stream messages after cancellation

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   285,189 b | 180,619 b |   36,513 b |
-| Connect-ES     |    4 |   289,441 b | 183,721 b |   37,280 b |
-| Connect-ES     |    8 |   294,304 b | 188,152 b |   38,292 b |
-| Connect-ES     |   16 |   303,432 b | 195,779 b |   39,788 b |
+| Connect-ES     |    1 |   285,310 b | 180,641 b |   36,527 b |
+| Connect-ES     |    4 |   289,562 b | 183,743 b |   37,343 b |
+| Connect-ES     |    8 |   294,425 b | 188,174 b |   38,310 b |
+| Connect-ES     |   16 |   303,553 b | 195,801 b |   39,822 b |
 | gRPC-Web       |    1 | 1,070,505 b | 707,341 b |   70,184 b |
 | gRPC-Web       |    4 | 1,121,879 b | 738,633 b |   72,562 b |
 | gRPC-Web       |    8 | 1,197,272 b | 786,157 b |   75,059 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.59404296875 140,184.421875 280,181.555859375 420,177.319140625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.55439453125 140,184.24345703125 280,181.5048828125 420,177.2228515625">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="186.59404296875" r="4" fill="#ffa600"><title>Connect-ES 35.66 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="184.421875" r="4" fill="#ffa600"><title>Connect-ES 36.41 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="181.555859375" r="4" fill="#ffa600"><title>Connect-ES 37.39 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="177.319140625" r="4" fill="#ffa600"><title>Connect-ES 38.86 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="186.55439453125" r="4" fill="#ffa600"><title>Connect-ES 35.67 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="184.24345703125" r="4" fill="#ffa600"><title>Connect-ES 36.47 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="181.5048828125" r="4" fill="#ffa600"><title>Connect-ES 37.41 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="177.2228515625" r="4" fill="#ffa600"><title>Connect-ES 38.89 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,91.23671875 140,84.50214843750001 280,77.43056640625 420,66.39697265625">

--- a/packages/connect/src/protocol/run-call.spec.ts
+++ b/packages/connect/src/protocol/run-call.spec.ts
@@ -242,6 +242,35 @@ describe("runStreamingCall()", () => {
     const it = req.message[Symbol.asyncIterator]();
     assert.deepStrictEqual(await it.next(), { done: true, value: undefined });
   });
+  it("should not pull messages after the user aborts", async () => {
+    const userAbort = new AbortController();
+    let didPullAfterAbort = false;
+    const res = await runStreamingCall<
+      typeof Int32ValueSchema,
+      typeof StringValueSchema
+    >({
+      signal: userAbort.signal,
+      req: makeReq(),
+      next: (req) =>
+        Promise.resolve({
+          ...makeRes(req),
+          message: (async function* () {
+            yield create(StringValueSchema, { value: "1" });
+            didPullAfterAbort = true;
+            yield create(StringValueSchema, { value: "2" });
+          })(),
+        }),
+    });
+    const it = res.message[Symbol.asyncIterator]();
+
+    await it.next();
+    userAbort.abort();
+
+    await assert.rejects(it.next(), {
+      message: "[canceled] This operation was aborted",
+    });
+    assert.ok(!didPullAfterAbort);
+  });
   it("should raise Code.DeadlineExceeded on timeout", async () => {
     const req = makeReq();
     const resPromise = runStreamingCall<

--- a/packages/connect/src/protocol/run-call.ts
+++ b/packages/connect/src/protocol/run-call.ts
@@ -137,6 +137,9 @@ export function runStreamingCall<
           const it = res.message[Symbol.asyncIterator]();
           return {
             next() {
+              if (!doneCalled && signal.aborted) {
+                return abort(getAbortSignalReason(signal));
+              }
               return it.next().then((r) => {
                 if (r.done == true) {
                   doneCalled = true;


### PR DESCRIPTION
Clients read bytes from the server in _chunks_. If the chunk happens to contain more than one envelope, the envelope reader queues them all up. This means that if a client reads a single message and aborts, the remaining queued messages from that chunk would keep getting delivered.

This change makes `runStreamingCall` check the abort signal before delivering each message. This fixes the client behavior for bidi / server-side streaming, in both `connect-web` and `connect-node`. Servers are unaffected.

Fixes the conformance flake found in: https://github.com/connectrpc/connect-es/actions/runs/33062690944/job/98485105428?pr=1780