### PR TITLE
Release 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10398,7 +10398,7 @@
     },
     "packages/connect": {
       "name": "@connectrpc/connect",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/buf": "^1.72.0",
@@ -10414,22 +10414,22 @@
       "name": "@connectrpc/connect-cloudflare",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect": "2.2.0",
+        "@connectrpc/connect-node": "2.2.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260828.1",
-        "@connectrpc/connect-conformance": "^2.1.2",
+        "@connectrpc/connect-conformance": "^2.2.0",
         "tsx": "^4.20.6",
         "wrangler": "^4.127.1"
       }
     },
     "packages/connect-conformance": {
       "name": "@connectrpc/connect-conformance",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2",
+        "@connectrpc/connect": "2.2.0",
         "fflate": "^0.8.3",
         "tar-stream": "^3.2.1"
       },
@@ -10446,12 +10446,12 @@
     },
     "packages/connect-express": {
       "name": "@connectrpc/connect-express",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-conformance": "^2.1.2",
-        "@connectrpc/connect-node": "2.1.2",
+        "@connectrpc/connect": "2.2.0",
+        "@connectrpc/connect-conformance": "^2.2.0",
+        "@connectrpc/connect-node": "2.2.0",
         "@types/express": "^5.0.6",
         "express": "^5.2.1",
         "tsx": "^4.20.6"
@@ -10461,33 +10461,33 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2",
+        "@connectrpc/connect": "2.2.0",
+        "@connectrpc/connect-node": "2.2.0",
         "express": "^4.18.2 || ^5.0.1"
       }
     },
     "packages/connect-fastify": {
       "name": "@connectrpc/connect-fastify",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-conformance": "^2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect": "2.2.0",
+        "@connectrpc/connect-conformance": "^2.2.0",
+        "@connectrpc/connect-node": "2.2.0"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2",
+        "@connectrpc/connect": "2.2.0",
+        "@connectrpc/connect-node": "2.2.0",
         "fastify": "^4.22.1 || ^5.1.0"
       }
     },
     "packages/connect-migrate": {
       "name": "@connectrpc/connect-migrate",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "3.3.3",
@@ -10509,28 +10509,28 @@
     },
     "packages/connect-next": {
       "name": "@connectrpc/connect-next",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2"
+        "@connectrpc/connect": "2.2.0",
+        "@connectrpc/connect-node": "2.2.0"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2",
-        "@connectrpc/connect-node": "2.1.2",
+        "@connectrpc/connect": "2.2.0",
+        "@connectrpc/connect-node": "2.2.0",
         "next": "^15.0.2 || ^16.0.0"
       }
     },
     "packages/connect-node": {
       "name": "@connectrpc/connect-node",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.1.2",
+        "@connectrpc/connect-conformance": "^2.2.0",
         "@types/node": "^24.10.1",
         "tsx": "^4.20.6"
       },
@@ -10539,21 +10539,21 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2"
+        "@connectrpc/connect": "2.2.0"
       }
     },
     "packages/connect-web": {
       "name": "@connectrpc/connect-web",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@connectrpc/connect-conformance": "^2.1.2",
+        "@connectrpc/connect-conformance": "^2.2.0",
         "tsx": "^4.20.6",
         "webdriverio": "^9.31.4"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2"
+        "@connectrpc/connect": "2.2.0"
       }
     },
     "packages/connect-web-bench": {
@@ -10562,7 +10562,7 @@
         "@bufbuild/buf": "^1.72.0",
         "@bufbuild/protobuf": "^2.7.0",
         "@bufbuild/protoc-gen-es": "^2.10.0",
-        "@connectrpc/connect-web": "2.1.2",
+        "@connectrpc/connect-web": "2.2.0",
         "@types/brotli": "^1.3.5",
         "brotli": "^1.3.3",
         "esbuild": "^0.19.8",
@@ -10574,8 +10574,8 @@
       "name": "@connectrpc/example",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect-node": "^2.1.2",
-        "@connectrpc/connect-web": "^2.1.2",
+        "@connectrpc/connect-node": "^2.2.0",
+        "@connectrpc/connect-web": "^2.2.0",
         "tsx": "^4.20.6"
       },
       "devDependencies": {

--- a/packages/connect-cloudflare/package.json
+++ b/packages/connect-cloudflare/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect": "2.2.0",
+    "@connectrpc/connect-node": "2.2.0"
   },
   "devDependencies": {
     "wrangler": "^4.127.1",
     "@cloudflare/workers-types": "^5.20260828.1",
     "tsx": "^4.20.6",
-    "@connectrpc/connect-conformance": "^2.1.2"
+    "@connectrpc/connect-conformance": "^2.2.0"
   }
 }

--- a/packages/connect-conformance/package.json
+++ b/packages/connect-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-conformance",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.2",
+    "@connectrpc/connect": "2.2.0",
     "fflate": "^0.8.3",
     "tar-stream": "^3.2.1"
   },

--- a/packages/connect-express/package.json
+++ b/packages/connect-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-express",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,9 +32,9 @@
     "node": ">=22"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.1.2",
-    "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2",
+    "@connectrpc/connect-conformance": "^2.2.0",
+    "@connectrpc/connect": "2.2.0",
+    "@connectrpc/connect-node": "2.2.0",
     "@types/express": "^5.0.6",
     "express": "^5.2.1",
     "tsx": "^4.20.6"
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "express": "^4.18.2 || ^5.0.1",
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect": "2.2.0",
+    "@connectrpc/connect-node": "2.2.0"
   }
 }

--- a/packages/connect-fastify/package.json
+++ b/packages/connect-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-fastify",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,14 +31,14 @@
     "node": ">=22"
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.1.2",
-    "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect-conformance": "^2.2.0",
+    "@connectrpc/connect": "2.2.0",
+    "@connectrpc/connect-node": "2.2.0"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "fastify": "^4.22.1 || ^5.1.0",
-    "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect": "2.2.0",
+    "@connectrpc/connect-node": "2.2.0"
   }
 }

--- a/packages/connect-migrate/package.json
+++ b/packages/connect-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-migrate",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "This tool updates your Connect project to use the new @connectrpc packages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/connect-next/package.json
+++ b/packages/connect-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-next",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
     "next": "^15.0.2 || ^16.0.0",
-    "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect": "2.2.0",
+    "@connectrpc/connect-node": "2.2.0"
   },
   "devDependencies": {
-    "@connectrpc/connect": "2.1.2",
-    "@connectrpc/connect-node": "2.1.2"
+    "@connectrpc/connect": "2.2.0",
+    "@connectrpc/connect-node": "2.2.0"
   }
 }

--- a/packages/connect-node/package.json
+++ b/packages/connect-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-node",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -34,11 +34,11 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.2"
+    "@connectrpc/connect": "2.2.0"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
-    "@connectrpc/connect-conformance": "^2.1.2",
+    "@connectrpc/connect-conformance": "^2.2.0",
     "tsx": "^4.20.6"
   }
 }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -15,10 +15,10 @@ usually do. We repeat this for an increasing number of RPCs.
 
 | code generator | RPCs | bundle size |  minified | compressed |
 | -------------- | ---: | ----------: | --------: | ---------: |
-| Connect-ES     |    1 |   285,310 b | 180,641 b |   36,527 b |
-| Connect-ES     |    4 |   289,562 b | 183,743 b |   37,343 b |
-| Connect-ES     |    8 |   294,425 b | 188,174 b |   38,310 b |
-| Connect-ES     |   16 |   303,553 b | 195,801 b |   39,822 b |
+| Connect-ES     |    1 |   285,310 b | 180,641 b |   36,562 b |
+| Connect-ES     |    4 |   289,562 b | 183,743 b |   37,363 b |
+| Connect-ES     |    8 |   294,425 b | 188,174 b |   38,255 b |
+| Connect-ES     |   16 |   303,553 b | 195,801 b |   39,800 b |
 | gRPC-Web       |    1 | 1,070,505 b | 707,341 b |   70,184 b |
 | gRPC-Web       |    4 | 1,121,879 b | 738,633 b |   72,562 b |
 | gRPC-Web       |    8 | 1,197,272 b | 786,157 b |   75,059 b |

--- a/packages/connect-web-bench/chart.svg
+++ b/packages/connect-web-bench/chart.svg
@@ -42,13 +42,13 @@
 <text x="-10" y="294" text-anchor="end">0 KiB</text>
 </g>
 <g transform="translate(110, 20)">
-  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.55439453125 140,184.24345703125 280,181.5048828125 420,177.2228515625">
+  <polyline fill="none" stroke="#ffa600" stroke-width="2" points="0,186.4552734375 140,184.18681640625 280,181.66064453125 420,177.28515625">
     <title>Connect-ES</title>
   </polyline>
-<circle cx="0" cy="186.55439453125" r="4" fill="#ffa600"><title>Connect-ES 35.67 KiB for 1 RPCs</title></circle>
-<circle cx="140" cy="184.24345703125" r="4" fill="#ffa600"><title>Connect-ES 36.47 KiB for 4 RPCs</title></circle>
-<circle cx="280" cy="181.5048828125" r="4" fill="#ffa600"><title>Connect-ES 37.41 KiB for 8 RPCs</title></circle>
-<circle cx="420" cy="177.2228515625" r="4" fill="#ffa600"><title>Connect-ES 38.89 KiB for 16 RPCs</title></circle>
+<circle cx="0" cy="186.4552734375" r="4" fill="#ffa600"><title>Connect-ES 35.71 KiB for 1 RPCs</title></circle>
+<circle cx="140" cy="184.18681640625" r="4" fill="#ffa600"><title>Connect-ES 36.49 KiB for 4 RPCs</title></circle>
+<circle cx="280" cy="181.66064453125" r="4" fill="#ffa600"><title>Connect-ES 37.36 KiB for 8 RPCs</title></circle>
+<circle cx="420" cy="177.28515625" r="4" fill="#ffa600"><title>Connect-ES 38.87 KiB for 16 RPCs</title></circle>
 </g>
 <g transform="translate(110, 20)">
   <polyline fill="none" stroke="#ff6361" stroke-width="2" points="0,91.23671875 140,84.50214843750001 280,77.43056640625 420,66.39697265625">

--- a/packages/connect-web-bench/package.json
+++ b/packages/connect-web-bench/package.json
@@ -13,7 +13,7 @@
     "@bufbuild/buf": "^1.72.0",
     "@bufbuild/protobuf": "^2.7.0",
     "@bufbuild/protoc-gen-es": "^2.10.0",
-    "@connectrpc/connect-web": "2.1.2",
+    "@connectrpc/connect-web": "2.2.0",
     "@types/brotli": "^1.3.5",
     "brotli": "^1.3.3",
     "esbuild": "^0.19.8",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect-web",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -36,12 +36,12 @@
     }
   },
   "devDependencies": {
-    "@connectrpc/connect-conformance": "^2.1.2",
+    "@connectrpc/connect-conformance": "^2.2.0",
     "tsx": "^4.20.6",
     "webdriverio": "^9.31.4"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect": "2.1.2"
+    "@connectrpc/connect": "2.2.0"
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectrpc/connect",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Type-safe APIs with Protobuf and TypeScript.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0",
-    "@connectrpc/connect-node": "^2.1.2",
-    "@connectrpc/connect-web": "^2.1.2",
+    "@connectrpc/connect-node": "^2.2.0",
+    "@connectrpc/connect-web": "^2.2.0",
     "tsx": "^4.20.6"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed

> [!IMPORTANT]
> 
> This release adds a security-related feature for servers: the [request gate](https://github.com/connectrpc/connect-es/pull/1781) is a function that runs after the request headers are available. Throwing a `ConnectError` in the gate rejects a request before messages are read, decompressed, or parsed. Use this option to reject unauthenticated requests instead of interceptors. See the [documentation for details](https://connectrpc.com/docs/node/interceptors/#authentication).
>
> We also recommend that you configure a message size limit for your server, see the [readMaxBytes option](https://connectrpc.com/docs/node/server-plugins/#common-options).


* Disallow propagation of protocol headers by @ajeetdsouza in https://github.com/connectrpc/connect-es/pull/1717
* Fix Http2SessionManager.verify() never settling when the connection closes during verification by @jackyzha0 in https://github.com/connectrpc/connect-es/pull/1746
* Drop support for Node.js 20 by @ajeetdsouza in https://github.com/connectrpc/connect-es/pull/1777
* Add requestGate handler option by @timostamm in https://github.com/connectrpc/connect-es/pull/1781
* Stop delivering stream messages after cancellation by @ajeetdsouza in https://github.com/connectrpc/connect-es/pull/1792
* Enable gRPC in Cloudflare conformance tests by @mar-cf in https://github.com/connectrpc/connect-es/pull/1774

## New Contributors
* @jackyzha0 made their first contribution in https://github.com/connectrpc/connect-es/pull/1746
* @mar-cf made their first contribution in https://github.com/connectrpc/connect-es/pull/1774

**Full Changelog**: https://github.com/connectrpc/connect-es/compare/v2.1.2...v2.2.0